### PR TITLE
Update pacman.lua

### DIFF
--- a/core/xim/pm/wrapper/pacman.lua
+++ b/core/xim/pm/wrapper/pacman.lua
@@ -1,0 +1,45 @@
+-- 检查包是否已安装（通过 `pacman -Q`）
+function installed(name)
+    return os.iorunv("pacman", {"-Q", name}) ~= nil
+end
+
+-- 获取包的依赖信息（通过 `pactree -d 1`）
+function deps(name)
+    local output = os.iorunv("pactree", {"-d", "1", name})
+    if output then
+        return output:trim()
+    else
+        return nil, string.format("Failed to get dependencies for package '%s'", name)
+    end
+end
+
+-- 安装包（通过 `pacman -S`）
+function install(name)
+    local ok = os.execv("sudo", {"pacman", "-S", name})
+    return ok == 0
+end
+
+-- 卸载包（通过 `pacman -R`）
+function uninstall(name)
+    local ok = os.execv("sudo", {"pacman", "-R", name})
+    return ok == 0
+end
+
+-- 获取包信息（通过 `pacman -Qi`）
+function info(name)
+    local output = os.iorunv("pacman", {"-Qi", name})
+    if output then
+        return output:trim()
+    else
+        return nil, string.format("Failed to get information for package '%s'", name)
+    end
+end
+
+function main()
+    print(installed("linux")) -- true
+    print(deps("code"))
+    -- print(install("code"))
+    print(info("code"))
+    print(info("awa")) -- error: 错误：软件包 'awa' 未找到
+end
+


### PR DESCRIPTION
The output of this file in the current version:
```
dengh@Lenovo ~/Projects/xlings/xlings-xim/core (xim) 
❯ xmake l ./xim/pm/wrapper/pacman.lua
true
code
├─electron32
├─libsecret
├─libx11
├─libxkbfile
└─ripgrep
名字           : code
版本           : 1.95.1-1
描述           : The Open Source build of Visual Studio Code (vscode) editor
架构           : x86_64
URL            : https://github.com/microsoft/vscode
软件许可       : MIT
组             : 无
提供           : vscode
依赖于         : electron32  libsecret  libx11  libxkbfile  ripgrep
可选依赖       : bash-completion: Bash completions
                 zsh-completions: ZSH completitons
                 x11-ssh-askpass: SSH authentication [已安装]
依赖它         : 无
被可选依赖     : 无
与它冲突       : 无
取代           : 无
安装后大小     : 83.21 MiB
打包者         : Massimiliano Torromeo <mtorromeo@archlinux.org>
编译日期       : 2024年11月02日 星期六 01时17分40秒
安装日期       : 2024年12月13日 星期五 21时17分20秒
安装原因       : 单独指定安装
安装脚本       : 否
验证者         : 数字签名
error: 错误：软件包 'awa' 未找到

```

Possible issue:
Function 'deps' does not print optional dependencies
The print information format of the function 'info' is not consistent in each package manager