### PR TITLE
Fix command execution syntax for xlings_exec

### DIFF
--- a/core/common.lua
+++ b/core/common.lua
@@ -151,7 +151,7 @@ function xlings_download(url, dest)
                 end
                 -- -#, --progress-bar
                 -- -L, --location):
-                xlings_exec(tool.program .. " -L -# -o " .. dest .. " " .. url)
+                xlings_exec("\"" .. tool.program .. "\"" .. " -L -# -o " .. dest .. " " .. url)
                 --os.vrunv(tool.program, {"-#", "-o", dest, url})
             else
                 -- { insecure = true }


### PR DESCRIPTION
The path of `curl` might be like: `C:\Program Files\xmake\winenv\bin\curl.exe`. We need to wrap the path with `"`.