### PR TITLE
fix: install scripts bypass user prompt when XLINGS_HOME is pre-set

### DIFF
--- a/tools/install-from-release.ps1
+++ b/tools/install-from-release.ps1
@@ -29,26 +29,30 @@ function Detect-ExistingXlingsHome {
     return $null
 }
 
-if ($env:XLINGS_HOME) {
-    $XLINGS_HOME = $env:XLINGS_HOME
-} else {
+$OLD_XLINGS_HOME = $null
+if ($env:XLINGS_HOME -and $env:XLINGS_HOME -ne $DEFAULT_XLINGS_HOME) {
+    $OLD_XLINGS_HOME = $env:XLINGS_HOME
+}
+
+if (-not $OLD_XLINGS_HOME) {
     $OLD_XLINGS_HOME = Detect-ExistingXlingsHome
-    if ($OLD_XLINGS_HOME -and $OLD_XLINGS_HOME -ne $DEFAULT_XLINGS_HOME) {
-        Write-Host "[xlings]: Detected existing xlings at: $OLD_XLINGS_HOME" -ForegroundColor Yellow
-        Write-Host "[xlings]: Default install directory is: $DEFAULT_XLINGS_HOME" -ForegroundColor Yellow
-        Write-Host ""
-        Write-Host "  [1] Overwrite existing installation at $OLD_XLINGS_HOME" -ForegroundColor Cyan
-        Write-Host "  [2] Install to default location $DEFAULT_XLINGS_HOME (keep old)" -ForegroundColor Cyan
-        Write-Host ""
-        $choice = Read-Host "Choose [1/2] (default: 1)"
-        if ($choice -eq "2") {
-            $XLINGS_HOME = $DEFAULT_XLINGS_HOME
-        } else {
-            $XLINGS_HOME = $OLD_XLINGS_HOME
-        }
-    } else {
+}
+
+if ($OLD_XLINGS_HOME -and $OLD_XLINGS_HOME -ne $DEFAULT_XLINGS_HOME) {
+    Write-Host "[xlings]: Detected existing xlings at: $OLD_XLINGS_HOME" -ForegroundColor Yellow
+    Write-Host "[xlings]: Default install directory is: $DEFAULT_XLINGS_HOME" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "  [1] Overwrite existing installation at $OLD_XLINGS_HOME" -ForegroundColor Cyan
+    Write-Host "  [2] Install to default location $DEFAULT_XLINGS_HOME (keep old)" -ForegroundColor Cyan
+    Write-Host ""
+    $choice = Read-Host "Choose [1/2] (default: 1)"
+    if ($choice -eq "2") {
         $XLINGS_HOME = $DEFAULT_XLINGS_HOME
+    } else {
+        $XLINGS_HOME = $OLD_XLINGS_HOME
     }
+} else {
+    $XLINGS_HOME = $DEFAULT_XLINGS_HOME
 }
 
 Write-Host "[xlings]: Installing xlings to $XLINGS_HOME" -ForegroundColor Green

--- a/tools/install-from-release.sh
+++ b/tools/install-from-release.sh
@@ -64,29 +64,33 @@ detect_existing_xlings_home() {
     fi
 }
 
-if [[ -n "${XLINGS_HOME:-}" ]]; then
-    : # respect explicit XLINGS_HOME from environment
-else
+OLD_XLINGS_HOME=""
+if [[ -n "${XLINGS_HOME:-}" ]] && [[ "${XLINGS_HOME}" != "$DEFAULT_XLINGS_HOME" ]]; then
+    OLD_XLINGS_HOME="$XLINGS_HOME"
+fi
+
+if [[ -z "$OLD_XLINGS_HOME" ]]; then
     OLD_XLINGS_HOME=$(detect_existing_xlings_home || true)
-    if [[ -n "$OLD_XLINGS_HOME" ]] && [[ "$OLD_XLINGS_HOME" != "$DEFAULT_XLINGS_HOME" ]]; then
-        log_warn "Detected existing xlings at: ${CYAN}${OLD_XLINGS_HOME}${RESET}"
-        log_warn "Default install directory is: ${CYAN}${DEFAULT_XLINGS_HOME}${RESET}"
-        echo ""
-        echo -e "  [1] Overwrite existing installation at ${CYAN}${OLD_XLINGS_HOME}${RESET}"
-        echo -e "  [2] Install to default location ${CYAN}${DEFAULT_XLINGS_HOME}${RESET} (keep old)"
-        echo ""
-        read -rp "Choose [1/2] (default: 1): " choice
-        case "$choice" in
-            2)
-                XLINGS_HOME="$DEFAULT_XLINGS_HOME"
-                ;;
-            *)
-                XLINGS_HOME="$OLD_XLINGS_HOME"
-                ;;
-        esac
-    else
-        XLINGS_HOME="$DEFAULT_XLINGS_HOME"
-    fi
+fi
+
+if [[ -n "$OLD_XLINGS_HOME" ]] && [[ "$OLD_XLINGS_HOME" != "$DEFAULT_XLINGS_HOME" ]]; then
+    log_warn "Detected existing xlings at: ${CYAN}${OLD_XLINGS_HOME}${RESET}"
+    log_warn "Default install directory is: ${CYAN}${DEFAULT_XLINGS_HOME}${RESET}"
+    echo ""
+    echo -e "  [1] Overwrite existing installation at ${CYAN}${OLD_XLINGS_HOME}${RESET}"
+    echo -e "  [2] Install to default location ${CYAN}${DEFAULT_XLINGS_HOME}${RESET} (keep old)"
+    echo ""
+    read -rp "Choose [1/2] (default: 1): " choice
+    case "$choice" in
+        2)
+            XLINGS_HOME="$DEFAULT_XLINGS_HOME"
+            ;;
+        *)
+            XLINGS_HOME="$OLD_XLINGS_HOME"
+            ;;
+    esac
+else
+    XLINGS_HOME="$DEFAULT_XLINGS_HOME"
 fi
 
 log_info "Installing xlings to ${CYAN}${XLINGS_HOME}${RESET}"

--- a/tools/other/quick_install.sh
+++ b/tools/other/quick_install.sh
@@ -127,7 +127,7 @@ fi
 log_info "Extracting..."
 tar -xzf "${WORK_DIR}/${TARBALL}" -C "$WORK_DIR"
 
-EXTRACT_DIR=$(find "$WORK_DIR" -maxdepth 1 -type d -name "xlings-*" | head -1)
+EXTRACT_DIR=$(find "$WORK_DIR" -mindepth 1 -maxdepth 1 -type d -name "xlings-*" | head -1)
 if [[ -z "$EXTRACT_DIR" ]] || [[ ! -f "$EXTRACT_DIR/install.sh" ]]; then
     log_error "Extracted package is invalid (missing install.sh)."
     exit 1


### PR DESCRIPTION
Two bugs fixed:

1. quick_install.sh: `find` without `-mindepth 1` matches the temp directory itself (named xlings-install.XXX) against the `xlings-*` pattern, causing EXTRACT_DIR to point to the wrong directory and report "missing install.sh".

2. install-from-release.sh/.ps1: when XLINGS_HOME is already set in the environment (e.g. from a previous installation), the installer silently uses it without prompting the user. Now it detects non-default XLINGS_HOME and still asks whether to overwrite or install to the default location.