### PR TITLE
fix(quick_install): use /dev/tty with fallback for CI

### DIFF
--- a/tools/other/quick_install.sh
+++ b/tools/other/quick_install.sh
@@ -138,5 +138,5 @@ fi
 log_info "Running installer..."
 cd "$EXTRACT_DIR"
 chmod +x bin/xlings
-# Do not use </dev/tty - fails in CI (No such device). Install uses defaults when stdin is not a TTY.
-./bin/xlings self install
+# Use /dev/tty for interactive prompts when piped (curl|bash); fallback when CI has no /dev/tty
+( ./bin/xlings self install < /dev/tty ) || ./bin/xlings self install


### PR DESCRIPTION
Use ( ./bin/xlings self install < /dev/tty ) || ./bin/xlings self install
- Interactive (curl|bash): /dev/tty works, user can input
- CI (no /dev/tty): redirect fails, fallback uses defaults