### PR TITLE
fix: awesome namespace search and improve search output format

### DIFF
--- a/core/xim/CmdProcessor.lua
+++ b/core/xim/CmdProcessor.lua
@@ -473,8 +473,22 @@ end
 
 function CmdProcessor:search(opt)
     opt = opt or {}
-    local names = index_manager:search(self.target, opt)
-    print(names)
+    local names_table = index_manager:search(self.target, opt)
+    for name, alias in pairs(names_table) do
+        local alias_str = table.concat(alias, ", ")
+        if alias_str ~= "" then
+            cprint(
+                "${dim bright}->${clear} ${dim yellow}%s${clear} ${dim}(%s)",
+                name,
+                alias_str
+            )
+        else
+            cprint(
+                "${dim bright}->${clear} ${dim yellow}%s${clear}",
+                name
+            )
+        end
+    end
 end
 
 function CmdProcessor:remove()


### PR DESCRIPTION
- IndexManager: treat 'awesome' and 'awesome:xxx' as user-specified namespace so 'xlings search awesome' returns awesome namespace packages
- IndexManager: same fix for match_package_version (install awesome/awesome:xxx)
- CmdProcessor: format search output like list (-> dim_yellow pkgname (aliases))

Made-with: Cursor