### PR TITLE
feat: default installed check via xvm version query

### DIFF
--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -901,6 +901,16 @@ public:
                     payloadInstalled = true;
                 }
             }
+            // Default: check xvm version database when no installed hook
+            else if (!payloadInstalled) {
+                auto db = Config::versions();
+                auto resolved = xvm::match_version(db, node.name, node.version);
+                if (!resolved.empty()) {
+                    log::debug("{} already installed in xvm (version {})",
+                              node.name, resolved);
+                    payloadInstalled = true;
+                }
+            }
 
             // Run install hook
             if (!payloadInstalled && executor.has_hook(mcpplibs::xpkg::HookType::Install)) {


### PR DESCRIPTION
## Summary
- When a package has no `installed` hook, fall back to querying the xvm version database (`match_version`) to detect already-installed packages
- Prevents redundant re-installs for packages tracked by xvm but lacking a custom installed hook
- Uses `match_version` (not `has_version`) to handle namespace-prefixed versions (e.g. `local:0.26.0`)

## Test plan
- [ ] `xmake build` compiles cleanly
- [ ] `xmake test` — existing tests pass
- [ ] Manual: install a package, then re-run `xlings install <pkg>` — should skip with "already installed in xvm" debug log instead of re-installing

🤖 Generated with [Claude Code](https://claude.com/claude-code)