### PR TITLE
fix: preserve default index repo when custom index_repos configured

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -416,6 +416,21 @@ private:
         }
         if (globalIndexRepos_.empty()) {
             globalIndexRepos_ = default_global_index_repos_(mirror_);
+        } else {
+            // Ensure the default index repo is always present when user
+            // defines custom index_repos (e.g. adding "ros2").  Without
+            // this, user-defined repos replace the default and packages
+            // in the primary index (like "python") become unfindable.
+            auto defaults = default_global_index_repos_(mirror_);
+            for (auto& def : defaults) {
+                bool found = false;
+                for (auto& repo : globalIndexRepos_) {
+                    if (repo.name == def.name) { found = true; break; }
+                }
+                if (!found) {
+                    globalIndexRepos_.insert(globalIndexRepos_.begin(), std::move(def));
+                }
+            }
         }
 
         paths_.dataDir  = paths_.homeDir / "data";


### PR DESCRIPTION
## Summary

- When users add custom `index_repos` in `.xlings.json` (e.g. adding a `ros2` repo), `load_index_repos_from_json_()` clears and replaces `globalIndexRepos_` entirely, dropping the default `xim` index repo
- This causes all packages in the primary index (like `python`, `gcc`, `cmake`, etc.) to become unfindable via `xlings search` or `xlings install`
- After loading user-defined repos, the fix checks whether the default repo is present and prepends it if missing

## Reproduction

```bash
# .xlings.json has: "index_repos": [{"name": "ros2", "url": "..."}]
xlings search python    # → "no packages found"
xlings install python   # → "package not found"
```

## Test plan

- [x] `XLINGS_HOME=/home/speak/.xlings ./build/.../xlings search python` → finds `xim:python`
- [x] `XLINGS_HOME=/home/speak/.xlings ./build/.../xlings search ros` → finds both `xim:*` and `ros2:*` packages
- [x] Clean environment (no custom index_repos) still works as before


🤖 Generated with [Claude Code](https://claude.com/claude-code)