### PR TITLE
fix: suppress git clone progress to avoid TUI conflict

### DIFF
--- a/src/core/xim/downloader.cppm
+++ b/src/core/xim/downloader.cppm
@@ -66,7 +66,7 @@ DownloadResult git_clone_one(const DownloadTask& task) {
 
     log::debug("cloning {} from {}", task.name, url);
     auto cmd = std::format(
-        "git clone --depth 1 --recursive \"{}\" \"{}\"",
+        "git clone --depth 1 --recursive --quiet \"{}\" \"{}\"",
         url, destDir.string());
     auto rc = platform::exec(cmd);
     if (rc != 0) {
@@ -111,7 +111,7 @@ DownloadResult download_one(const DownloadTask& task,
             if (repoName.empty()) repoName = task.name;
             auto destDir = task.destDir / repoName;
             result.localFile = destDir;
-            auto cmd = std::format("git clone --depth 1 --recursive \"{}\" \"{}\"",
+            auto cmd = std::format("git clone --depth 1 --recursive --quiet \"{}\" \"{}\"",
                                    task.url, destDir.string());
             auto h = platform::spawn_command(cmd);
             if (h.pid <= 0) { result.error = "failed to spawn git"; return result; }

--- a/src/core/xim/repo.cppm
+++ b/src/core/xim/repo.cppm
@@ -166,7 +166,7 @@ bool sync_repo(const std::filesystem::path& localDir,
 
     if (!fs::exists(localDir / ".git")) {
         log::debug("cloning index repo: {}", url);
-        auto cmd = std::format("git clone --depth 1 \"{}\" \"{}\"",
+        auto cmd = std::format("git clone --depth 1 --quiet \"{}\" \"{}\"",
                                url, localDir.string());
         auto [rc, output] = platform::run_command_capture(cmd);
         if (rc != 0) {


### PR DESCRIPTION
## Summary

- Add `--quiet` flag to all `git clone` commands (repo.cppm + downloader.cppm)
- Git's progress output (Cloning, Receiving objects, Resolving deltas, submodule updates) overlaps with xlings TUI progress bar, making the display unreadable
- xlings already has its own progress indicator, so git's output is redundant

## Test plan

- [x] `xlings install ros2:openpi -y` — TUI progress bar displays cleanly without git noise


🤖 Generated with [Claude Code](https://claude.com/claude-code)