### PR TITLE
feat(downloader): auto-detect HTTP_PROXY / HTTPS_PROXY env at download time

### DIFF
--- a/docs/plans/2026-04-25-auto-proxy-detect.md
+++ b/docs/plans/2026-04-25-auto-proxy-detect.md
@@ -1,0 +1,161 @@
+# 方案：xlings 下载器自动检测 + 应用系统代理
+
+**目标：** 用户在配过 `clash`/`v2ray`/`mihomo` 等代理（或在企业网设了 HTTP 代理）的环境下，`xlings install`/`update` 等下载命令应该自动走代理，而不是穷尽重试 + 失败。**程序自己读，用户零配置**。
+
+## 一、当前现状
+
+### 1.1 下载链路（已确认）
+- `src/core/xim/downloader.cppm:82-194` `download_one()` → 调 `tinyhttps::download_file`
+- `src/libs/tinyhttps.cppm:36-45` `make_client()` 构造 `mcpplibs::tinyhttps::HttpClient`，目前只设 `connectTimeoutMs / readTimeoutMs / verifySsl / keepAlive / maxRedirects`
+- 整仓 grep `proxy/PROXY/HTTP_PROXY` —— **零结果**：没读 env、没配置项、没 fallback
+
+### 1.2 上游能力（**重要发现**）
+mcpplibs::tinyhttps 0.2.0 **已经有完整的 HTTP CONNECT 隧道支持**：
+
+```cpp
+// mcpplibs/tinyhttps/src/http.cppm:35
+struct HttpClientConfig {
+    std::optional<std::string> proxy;   // ← 设这个就走代理
+    // ...
+};
+
+// http.cppm:278-280, 558-560, 807-809：HttpClient 内部已经
+//   if (config_.proxy.has_value()) {
+//       auto pc = parse_proxy_url(config_.proxy.value());
+//       auto tunnel = proxy_connect(pc.host, pc.port, ...);
+//       // 用 tunnel socket 继续 TLS / 普通 HTTP 通信
+//   }
+```
+
+**结论：本方案只需要在 xlings 这一侧把 `proxy` 字段填上**，无需改 mcpplibs，无需升级版本。CONNECT 隧道、HTTPS over proxy、错误处理上游都做好了。
+
+### 1.3 平台原生代理来源
+| 平台 | 来源（命令行/GUI 用户最常见的两条） |
+|---|---|
+| Linux | `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` env，**就这一个**，GUI 也是写到 systemd-environment 里最终走 env |
+| macOS | env 同上；GUI 在 System Settings → Network → Proxies 设的会写进 SystemConfiguration，命令行可以用 `scutil --proxy` 拿到，C 层可以用 `SCDynamicStoreCopyProxies()` / `CFNetworkCopySystemProxySettings()` |
+| Windows | env 同上（Git Bash / PowerShell 用户）；GUI 在「Internet 选项 → 连接 → 局域网设置」写进注册表 `HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ProxyEnable + ProxyServer`；WinHTTP 也提供 `WinHttpGetProxyForUrlEx` |
+
+### 1.4 不做 WPAD/PAC
+libcurl 都没原生支持 PAC（[Daniel Stenberg 解释](https://daniel.haxx.se/blog/2022/08/12/the-dream-of-auto-detecting-proxies/)：要嵌一个 JS 引擎跑 `FindProxyForURL(url, host)`），生态里只有 `libproxy` 这种重量级方案。**xlings 不做 PAC**，不值得。
+
+## 二、设计
+
+### 2.1 三层职责（与现有架构对齐）
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ src/platform/{linux,macos,windows}.cppm                  │
+│   detect_system_proxy(target_url) -> ProxyConfig         │  ← 新增
+│   读 env + 平台原生 store，按 NO_PROXY 过滤               │
+└──────────────────┬───────────────────────────────────────┘
+                   │ 一次调用，结果可缓存
+                   ▼
+┌──────────────────────────────────────────────────────────┐
+│ src/libs/tinyhttps.cppm                                  │
+│   make_client() 在 HttpClientConfig.proxy 上填好          │  ← 新增 ~3 行
+└──────────────────┬───────────────────────────────────────┘
+                   │
+                   ▼
+┌──────────────────────────────────────────────────────────┐
+│ mcpplibs::tinyhttps  (已支持 HTTP CONNECT 隧道)           │  ← 不动
+└──────────────────────────────────────────────────────────┘
+```
+
+### 2.2 `ProxyConfig` 数据结构（新建 `src/platform/proxy.cppm` 或并入 `platform.cppm`）
+
+```cpp
+struct ProxyConfig {
+    std::string http_proxy;     // empty = direct
+    std::string https_proxy;    // empty = direct
+    std::vector<std::string> no_proxy;  // host suffix list (libcurl 兼容)
+    std::string source;         // "env" / "scutil" / "winhttp" / "registry" / "none" — 给 --verbose 看
+};
+
+// 给 URL 解析合适的代理；"none" / 命中 NO_PROXY 时返回空。
+std::string resolve_proxy_for(const ProxyConfig& cfg, std::string_view url);
+```
+
+### 2.3 平台实现优先级
+
+每个平台都按以下顺序探测，**第一个命中就用**（兼容 libcurl/curl/git 的常规感知）：
+
+1. **`HTTPS_PROXY` / `HTTP_PROXY` env**（大小写都试，libcurl 兼容）
+2. **`ALL_PROXY` env**
+3. 平台原生 store：
+   - macOS: `SCDynamicStoreCopyProxies()` —— 读 `kSCPropNetProxiesHTTPProxy/Port`、`HTTPSProxy/Port`、`ExceptionsList`
+   - Windows: `WinHttpGetIEProxyConfigForCurrentUser()` 拿 IE/系统代理（这个比直接读注册表更稳）
+   - Linux: 没有"平台原生 store"，停在 env 即可
+
+4. 都没有 → `source = "none"`，下载走 direct
+
+### 2.4 NO_PROXY 处理
+libcurl 兼容语法："comma-separated host suffix"，例如 `localhost,127.0.0.1,.example.com,*.internal`。`resolve_proxy_for(cfg, url)` 在选中代理前先检查 url 的 host：
+- 完全匹配
+- 后缀匹配（`.example.com` 命中 `foo.example.com` / `example.com`）
+- `*` 通配（可选）
+
+### 2.5 在 tinyhttps.cppm 里的注入点（极小改动）
+
+```cpp
+// src/libs/tinyhttps.cppm:36
+auto make_client(int connectTimeoutSec, int readTimeoutSec, std::string_view url)
+    -> mcpplibs::tinyhttps::HttpClient {
+    mcpplibs::tinyhttps::HttpClientConfig cfg;
+    cfg.connectTimeoutMs = connectTimeoutSec * 1000;
+    cfg.readTimeoutMs    = readTimeoutSec * 1000;
+
+    static const auto proxy_cfg = platform::detect_system_proxy();    // ← cache
+    auto proxy = platform::resolve_proxy_for(proxy_cfg, url);
+    if (!proxy.empty()) cfg.proxy = proxy;                            // ← 关键 1 行
+
+    return mcpplibs::tinyhttps::HttpClient(std::move(cfg));
+}
+```
+
+调用点 `download_once / probe_latency / fetch_to_file / query_content_length` 把 `url` 传过来即可。
+
+### 2.6 用户可见的覆盖通道
+
+| 优先级 | 来源 | 备注 |
+|---|---|---|
+| 1（最高）| `XLINGS_PROXY=...` env | 用户显式覆盖 |
+| 2 | `XLINGS_NO_PROXY=1` | 强制不走代理（哪怕系统配了） |
+| 3 | `.xlings.json` 里 `proxy: "..."` 字段（可选 Phase 2） | 工程级覆盖 |
+| 4 | 自动检测（HTTPS_PROXY / scutil / WinHTTP） | 默认 |
+
+把 `xlings config` 的输出加一行显示当前生效代理 + source，让用户能 debug。
+
+## 三、实现拆解
+
+| Phase | 文件 | 改动 | 估算 LOC |
+|---|---|---|---|
+| 1 | `src/platform.cppm` (`platform/proxy.cppm`) | 加 `ProxyConfig` + `resolve_proxy_for` + `detect_system_proxy` 接口 | ~40 |
+| 1 | `src/platform/linux.cppm` | env-only 实现 | ~30 |
+| 1 | `src/libs/tinyhttps.cppm` | make_client 注入 + 各调用点透传 url | ~15 |
+| 1 | `src/cli.cppm` `xlings config` panel | 显示当前 proxy + source | ~8 |
+| 1 | `tests/unit/test_main.cpp` `Proxy.*` | env 解析 / NO_PROXY 匹配 / XLINGS_PROXY override | ~80 |
+| 2 | `src/platform/macos.cppm` | SCDynamicStoreCopyProxies | ~50 |
+| 2 | `src/platform/windows.cppm` | WinHttpGetIEProxyConfigForCurrentUser | ~50 |
+| 2 | `tests/e2e/proxy_smoke_test.sh` | mock proxy（用 `nc -l` 或 mitmproxy）+ 跑 `xlings install` 看连过来 | ~100 |
+| 3（可选）| `docs/quick-install.md` 加代理章节 | 文档 | ~30 |
+
+**Phase 1 ≈ 170 LOC，能让 90% 用户（设了 env 的）开箱即用。** Phase 2 ≈ 100 LOC，覆盖 macOS GUI / Windows GUI 两条剩下的路径。
+
+## 四、风险与边界
+
+1. **HTTPS_PROXY 不带 scheme 的写法** —— `127.0.0.1:7890` vs `http://127.0.0.1:7890`，libcurl 容忍，我们的 `parse_proxy_url` 也容忍（已经处理了）。
+2. **认证代理** `http://user:pass@host:port` —— mcpplibs::tinyhttps 当前的 `proxy_connect` **不支持 Basic Auth**（看代码无 user/pass 解析），如果用户用带认证的代理，会失败。**Phase 2 内增加**或推一个上游 PR。
+3. **HTTPS proxy（TLS-to-proxy）** —— 现在 mcpplibs 只做 plain HTTP CONNECT；如果用户设 `https://proxy.example:443`（通过 TLS 连代理本身），现版不支持。Phase 2 / 上游推。
+4. **代理脏快照** —— `detect_system_proxy()` 缓存为 static，进程内不刷。如果用户跑 xlings 时改代理设置不会被感知（一次 install 命令周期内不刷可接受）。
+5. **noproxy 包冲突** —— xim:noproxy（"Run commands bypassing system proxy"）是给 *外部* 命令清 env 用的，和 xlings 内部下载不冲突。但如果用户在 noproxy shell 里 `xlings install`，env 里没 HTTP_PROXY，xlings 会走 direct，**这是预期行为**。
+
+## 五、需要你确认的设计抉择
+
+1. **Phase 1 范围** —— 我建议只做 env（HTTPS_PROXY/HTTP_PROXY/ALL_PROXY/NO_PROXY + XLINGS_PROXY 覆盖），不动 macOS scutil 和 Windows registry。Phase 2 再补。这样能用最小代码立刻给 80%+ 用户解决，同意吗？
+2. **缓存策略** —— `detect_system_proxy()` 进程内 cached（static once），还是每次下载都重读 env？我倾向 cached。
+3. **认证代理 / TLS-to-proxy** —— 不在 Phase 1。同意还是要一起？（要的话需要先推上游 mcpplibs）
+4. **`xlings config` 是否显示 proxy 状态？** —— 我建议显示，方便用户 debug "为什么没走代理"。
+5. **CLI 子命令 `xlings proxy`** —— 显示当前生效 proxy + 来源 + 测试连通性。是要还是过度设计？
+
+要我开始按 Phase 1 写代码吗？

--- a/src/libs/tinyhttps.cppm
+++ b/src/libs/tinyhttps.cppm
@@ -2,6 +2,7 @@ export module xlings.libs.tinyhttps;
 
 import std;
 import mcpplibs.tinyhttps;
+import xlings.core.log;
 
 export namespace xlings::tinyhttps {
 
@@ -29,11 +30,85 @@ double probe_latency(const std::string& url, int timeoutMs = 2000);
 bool fetch_to_file(const std::string& url, const std::filesystem::path& dest);
 std::int64_t query_content_length(const std::string& url, int connectTimeoutSec = 10);
 
+// Returns the proxy URL that would be used for `url` (libcurl-style env
+// resolution: HTTPS_PROXY / HTTP_PROXY / ALL_PROXY with NO_PROXY exemption,
+// case-insensitive variants accepted). Empty result means direct connection.
+// Exposed for testability and for callers that want to display "what proxy
+// am I about to use" — the actual download path calls this internally.
+std::string resolve_proxy(std::string_view url);
+
 // ── Implementations ──────────────────────────────────────────────────
 
 namespace detail_ {
 
-auto make_client(int connectTimeoutSec, int readTimeoutSec = 60)
+// Pull host out of an http(s) URL: "https://example.com:443/foo" → "example.com".
+// Used by NO_PROXY suffix matching.
+std::string url_host_(std::string_view url) {
+    auto s = std::string{url};
+    if (auto p = s.find("://"); p != std::string::npos) s = s.substr(p + 3);
+    if (auto p = s.find('/'); p != std::string::npos) s = s.substr(0, p);
+    if (auto p = s.rfind(':'); p != std::string::npos) {
+        // Don't lop off a colon that's actually IPv6 part — but proxy-via-env
+        // for IPv6 is enough of an edge case to ignore here.
+        s = s.substr(0, p);
+    }
+    return s;
+}
+
+// libcurl/curl/Go-net compatible NO_PROXY matcher.
+// `np` is comma-separated entries; an entry matches `host` if:
+//   - exact equal
+//   - leading dot suffix match (`.example.com` matches `foo.example.com` and `example.com`)
+//   - bare suffix (`example.com` matches `foo.example.com` and `example.com`)
+//   - `*` matches everything (rarely used; libcurl rejects it but Go honours it)
+bool host_in_no_proxy_(std::string_view host, std::string_view np) {
+    std::size_t i = 0;
+    while (i < np.size()) {
+        auto end = np.find(',', i);
+        auto entry = np.substr(i, end == std::string_view::npos ? std::string_view::npos : end - i);
+        i = (end == std::string_view::npos) ? np.size() : end + 1;
+        // trim spaces
+        while (!entry.empty() && (entry.front() == ' ' || entry.front() == '\t')) entry.remove_prefix(1);
+        while (!entry.empty() && (entry.back()  == ' ' || entry.back()  == '\t')) entry.remove_suffix(1);
+        if (entry.empty()) continue;
+        if (entry == "*") return true;
+        if (entry.front() == '.') entry.remove_prefix(1);
+        if (host == entry) return true;
+        if (host.size() > entry.size()
+            && host[host.size() - entry.size() - 1] == '.'
+            && host.substr(host.size() - entry.size()) == entry) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Resolve which proxy to use for `url` from env, libcurl-style. Returns empty
+// string when direct connection should be used. Matches libcurl/Go/git
+// behaviour: HTTPS_PROXY for https:// URLs, HTTP_PROXY for http://, ALL_PROXY
+// as fallback, NO_PROXY exemptions, lowercase variants accepted.
+std::string env_proxy_for_(std::string_view url) {
+    auto get = [](const char* name) -> const char* {
+        const char* v = std::getenv(name);
+        return (v && *v) ? v : nullptr;
+    };
+
+    // NO_PROXY exemption first.
+    if (auto np = get("NO_PROXY") ?: get("no_proxy")) {
+        if (host_in_no_proxy_(url_host_(url), np)) return {};
+    }
+
+    bool isHttps = url.starts_with("https://");
+    if (isHttps) {
+        if (auto p = get("HTTPS_PROXY") ?: get("https_proxy")) return p;
+    } else {
+        if (auto p = get("HTTP_PROXY") ?: get("http_proxy")) return p;
+    }
+    if (auto p = get("ALL_PROXY") ?: get("all_proxy")) return p;
+    return {};
+}
+
+auto make_client(int connectTimeoutSec, int readTimeoutSec, std::string_view url)
     -> mcpplibs::tinyhttps::HttpClient {
     mcpplibs::tinyhttps::HttpClientConfig cfg;
     cfg.connectTimeoutMs = connectTimeoutSec * 1000;
@@ -41,6 +116,10 @@ auto make_client(int connectTimeoutSec, int readTimeoutSec = 60)
     cfg.verifySsl = true;
     cfg.keepAlive = false;
     cfg.maxRedirects = 10;
+    if (auto proxy = env_proxy_for_(url); !proxy.empty()) {
+        log::debug("tinyhttps: using proxy {} for {}", proxy, url);
+        cfg.proxy = std::move(proxy);
+    }
     return mcpplibs::tinyhttps::HttpClient(std::move(cfg));
 }
 
@@ -53,7 +132,7 @@ DownloadFileResult download_once(
     std::function<void(double, double)> onProgress,
     std::function<bool()> isCancelled = nullptr
 ) {
-    auto client = make_client(connectSec, maxSec);
+    auto client = make_client(connectSec, maxSec, url);
 
     mcpplibs::tinyhttps::DownloadProgressFn progress;
     if (onProgress) {
@@ -73,6 +152,10 @@ DownloadFileResult download_once(
 }
 
 } // namespace detail_
+
+std::string resolve_proxy(std::string_view url) {
+    return detail_::env_proxy_for_(url);
+}
 
 void global_init() {
     mcpplibs::tinyhttps::Socket::platform_init();
@@ -148,7 +231,7 @@ bool fetch_to_file(const std::string& url, const std::filesystem::path& dest) {
 
 std::int64_t query_content_length(const std::string& url, int connectTimeoutSec) {
     global_init();
-    auto client = detail_::make_client(connectTimeoutSec);
+    auto client = detail_::make_client(connectTimeoutSec, /*readTimeoutSec=*/60, url);
 
     mcpplibs::tinyhttps::HttpRequest req;
     req.method = mcpplibs::tinyhttps::Method::HEAD;

--- a/src/libs/tinyhttps.cppm
+++ b/src/libs/tinyhttps.cppm
@@ -88,23 +88,26 @@ bool host_in_no_proxy_(std::string_view host, std::string_view np) {
 // behaviour: HTTPS_PROXY for https:// URLs, HTTP_PROXY for http://, ALL_PROXY
 // as fallback, NO_PROXY exemptions, lowercase variants accepted.
 std::string env_proxy_for_(std::string_view url) {
-    auto get = [](const char* name) -> const char* {
-        const char* v = std::getenv(name);
-        return (v && *v) ? v : nullptr;
+    // Two-name lookup: try uppercase first, then lowercase. Avoids the
+    // GNU `?:` binary-conditional extension (MSVC rejects it).
+    auto get_either = [](const char* a, const char* b) -> const char* {
+        if (auto v = std::getenv(a); v && *v) return v;
+        if (auto v = std::getenv(b); v && *v) return v;
+        return nullptr;
     };
 
     // NO_PROXY exemption first.
-    if (auto np = get("NO_PROXY") ?: get("no_proxy")) {
+    if (auto np = get_either("NO_PROXY", "no_proxy")) {
         if (host_in_no_proxy_(url_host_(url), np)) return {};
     }
 
     bool isHttps = url.starts_with("https://");
     if (isHttps) {
-        if (auto p = get("HTTPS_PROXY") ?: get("https_proxy")) return p;
+        if (auto p = get_either("HTTPS_PROXY", "https_proxy")) return p;
     } else {
-        if (auto p = get("HTTP_PROXY") ?: get("http_proxy")) return p;
+        if (auto p = get_either("HTTP_PROXY", "http_proxy")) return p;
     }
-    if (auto p = get("ALL_PROXY") ?: get("all_proxy")) return p;
+    if (auto p = get_either("ALL_PROXY", "all_proxy")) return p;
     return {};
 }
 

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -25,6 +25,7 @@ import xlings.core.xself;
 import xlings.core.profile;
 import xlings.runtime;
 import xlings.capabilities;
+import xlings.libs.tinyhttps;
 import mcpplibs.xpkg;
 import mcpplibs.cmdline;
 
@@ -2777,6 +2778,143 @@ TEST(ThemeIcons, AllAreThreeByteBmpUtf8) {
         EXPECT_TRUE((b2 & 0xC0) == 0x80)
             << "icon::" << slot.name << " byte 2 not a continuation";
     }
+}
+
+// ═══════════════════════════════════════════════════════════════
+//  Proxy: env-driven proxy resolution for the downloader
+// ═══════════════════════════════════════════════════════════════
+//
+// xlings::tinyhttps::resolve_proxy(url) reads HTTPS_PROXY / HTTP_PROXY /
+// ALL_PROXY (case-insensitive variants) and respects NO_PROXY. These
+// tests lock the libcurl-compatible behaviour: scheme-aware selection,
+// NO_PROXY suffix exemption, lowercase fallback.
+
+namespace {
+struct EnvScope {
+    std::string name;
+    bool had_prev{false};
+    std::string prev_value;
+
+    EnvScope(std::string_view n, const char* val) : name(n) {
+        if (auto v = std::getenv(name.c_str())) {
+            had_prev = true;
+            prev_value = v;
+        }
+        set_(val);
+    }
+    ~EnvScope() {
+        if (had_prev) set_(prev_value.c_str());
+        else clear_();
+    }
+    void set_(const char* val) {
+        if (!val) { clear_(); return; }
+#ifdef _WIN32
+        _putenv_s(name.c_str(), val);
+#else
+        ::setenv(name.c_str(), val, 1);
+#endif
+    }
+    void clear_() {
+#ifdef _WIN32
+        _putenv_s(name.c_str(), "");
+#else
+        ::unsetenv(name.c_str());
+#endif
+    }
+};
+
+// Wipe every proxy-related env var so each test starts from a clean slate.
+// Vector elements are unique_ptrs so a reallocation on push_back doesn't
+// move-then-destroy intermediate EnvScopes (which would prematurely
+// restore env vars before the test body runs).
+struct ProxyEnvSandbox {
+    std::vector<std::unique_ptr<EnvScope>> guards;
+    ProxyEnvSandbox() {
+        for (auto* n : {"HTTPS_PROXY", "https_proxy",
+                        "HTTP_PROXY",  "http_proxy",
+                        "ALL_PROXY",   "all_proxy",
+                        "NO_PROXY",    "no_proxy"}) {
+            guards.push_back(std::make_unique<EnvScope>(n, nullptr));
+        }
+    }
+};
+} // namespace
+
+TEST(Proxy, NoEnvMeansDirect) {
+    ProxyEnvSandbox sandbox;
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("https://example.com/foo"), "");
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("http://example.com/foo"),  "");
+}
+
+TEST(Proxy, HttpsProxyUsedForHttpsScheme) {
+    ProxyEnvSandbox sandbox;
+    EnvScope https("HTTPS_PROXY", "http://127.0.0.1:7890");
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("https://example.com/x"),
+              "http://127.0.0.1:7890");
+}
+
+TEST(Proxy, HttpProxyUsedForHttpScheme) {
+    ProxyEnvSandbox sandbox;
+    EnvScope http("HTTP_PROXY", "http://127.0.0.1:7890");
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("http://example.com/x"),
+              "http://127.0.0.1:7890");
+}
+
+TEST(Proxy, LowercaseEnvAlsoAccepted) {
+    ProxyEnvSandbox sandbox;
+    EnvScope https("https_proxy", "http://10.0.0.1:8080");
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("https://example.com/x"),
+              "http://10.0.0.1:8080");
+}
+
+TEST(Proxy, AllProxyFallback) {
+    ProxyEnvSandbox sandbox;
+    EnvScope all("ALL_PROXY", "socks5://127.0.0.1:1080");
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("https://example.com/x"),
+              "socks5://127.0.0.1:1080");
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("http://example.com/x"),
+              "socks5://127.0.0.1:1080");
+}
+
+TEST(Proxy, HttpsProxyTakesPrecedenceOverHttpProxy) {
+    ProxyEnvSandbox sandbox;
+    EnvScope https("HTTPS_PROXY", "http://https-proxy:1");
+    EnvScope http("HTTP_PROXY",   "http://http-proxy:2");
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("https://example.com/x"),
+              "http://https-proxy:1");
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("http://example.com/x"),
+              "http://http-proxy:2");
+}
+
+TEST(Proxy, NoProxyExactHostExempt) {
+    ProxyEnvSandbox sandbox;
+    EnvScope https("HTTPS_PROXY", "http://127.0.0.1:7890");
+    EnvScope np("NO_PROXY", "localhost,internal.example");
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("https://localhost:9000/x"), "");
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("https://internal.example/x"), "");
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("https://other.example.com/x"),
+              "http://127.0.0.1:7890");
+}
+
+TEST(Proxy, NoProxySuffixMatchExempt) {
+    ProxyEnvSandbox sandbox;
+    EnvScope https("HTTPS_PROXY", "http://127.0.0.1:7890");
+    EnvScope np("NO_PROXY", ".internal.example,corp.local");
+    // dot-prefixed suffix: matches both bare and prefixed
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("https://api.internal.example/x"), "");
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("https://internal.example/x"), "");
+    // bare suffix without dot: still suffix-matches subdomains
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("https://node1.corp.local/x"), "");
+    // unrelated host still goes through proxy
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("https://github.com/x"),
+              "http://127.0.0.1:7890");
+}
+
+TEST(Proxy, NoProxyWildcardExemptsAll) {
+    ProxyEnvSandbox sandbox;
+    EnvScope https("HTTPS_PROXY", "http://127.0.0.1:7890");
+    EnvScope np("NO_PROXY", "*");
+    EXPECT_EQ(xlings::tinyhttps::resolve_proxy("https://anything.example/x"), "");
 }
 
 TEST(ThemeIcons, InfoPanelEmitsIconBytesToStdout) {


### PR DESCRIPTION
xlings's downloader now respects the standard libcurl-compatible proxy environment variables, so a user who already sets `HTTPS_PROXY` for their shell (clash / v2ray / mihomo / corporate egress) gets `xlings install` and `xlings update` routed through that proxy automatically — **no config file, no flag, no wrapper script**.

Design behind the change: [`docs/plans/2026-04-25-auto-proxy-detect.md`](./docs/plans/2026-04-25-auto-proxy-detect.md).

## Summary

- Resolves a per-URL proxy from env, libcurl precedence:
  - `HTTPS_PROXY` / `https_proxy` for `https://`
  - `HTTP_PROXY` / `http_proxy`  for `http://`
  - `ALL_PROXY` / `all_proxy` as fallback
- Honours `NO_PROXY` / `no_proxy` with the standard matchers: exact host, dotted-suffix (`.example.com`), bare-suffix, and the `*` wildcard.
- Logs `tinyhttps: using proxy <url> for <target>` at **debug** level (visible with `xlings -v ...`) so users can confirm which proxy is in effect when something looks off.

## Why the change is so small

`mcpplibs::tinyhttps 0.2.0` (already a dep) ships **complete HTTP CONNECT tunneling**: `parse_proxy_url` + `proxy_connect`, wired into `HttpClient` via `HttpClientConfig.proxy` for both plain HTTP and TLS-over-tunnel. This PR is purely the xlings-side plumbing to populate that field.

No mcpplibs bump required. The downloader, `download_file`, `fetch_to_file` public APIs are unchanged.

## Files

| File | Change |
|---|---|
| `src/libs/tinyhttps.cppm` | + `detail_::env_proxy_for_` (env + NO_PROXY resolver), `make_client` takes URL and fills `cfg.proxy`, new public `resolve_proxy` for tests/diagnostics |
| `tests/unit/test_main.cpp` | 9 new `TEST(Proxy, …)` cases covering the resolution matrix |
| `docs/plans/2026-04-25-auto-proxy-detect.md` | Design doc with rationale, alternatives, and what we deliberately punted |

## Deliberately scoped out (smallest viable change)

- macOS `SCDynamicStoreCopyProxies` and Windows `WinHttpGetIEProxyConfigForCurrentUser` — Phase 2. The env path covers the bulk of users (clash/v2ray/mihomo/corporate VPN typically expose env).
- `XLINGS_PROXY` override or `.xlings.json` proxy field — env is the single source of truth.
- PAC / WPAD — libcurl itself doesn't ship that.
- Basic-auth proxies and HTTPS-to-proxy — mcpplibs::tinyhttps 0.2.0 doesn't support those today; would need upstream changes.

## Tests

- **Unit**: 9 new `Proxy.*` cases lock the resolution matrix:
  - `NoEnvMeansDirect`
  - `HttpsProxyUsedForHttpsScheme`
  - `HttpProxyUsedForHttpScheme`
  - `LowercaseEnvAlsoAccepted`
  - `AllProxyFallback`
  - `HttpsProxyTakesPrecedenceOverHttpProxy`
  - `NoProxyExactHostExempt`
  - `NoProxySuffixMatchExempt`
  - `NoProxyWildcardExemptsAll`
- All env mutation runs under a `ProxyEnvSandbox` that nuke-then-restore every proxy var, so the test suite is hermetic regardless of the host shell's env.
- Total local: **164 / 164 tests pass**, 32 suites. `tests/e2e/remove_multi_version_test.sh` and `tests/e2e/tui_utf8_test.sh` still green.

## Test plan

- [x] `xmake build` clean
- [x] `xmake run xlings_tests` 164/164
- [x] e2e regressions still green
- [ ] CI (linux / macOS / windows)
- [ ] Manual: `HTTPS_PROXY=http://127.0.0.1:7890 xlings -v install <pkg>` shows `tinyhttps: using proxy http://127.0.0.1:7890 for <url>` and the request actually traverses the proxy.