### PR TITLE
fix(ci): release.yml reads VERSION from src/core/config.cppm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,8 +184,12 @@ jobs:
           if [[ -n "${{ inputs.version }}" ]]; then
             echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           else
-            VER=$(sed -n 's/.*VERSION = "\([^"]*\)".*/\1/p' core/config.cppm | head -1)
-            [[ -z "$VER" ]] && VER="0.2.0"
+            VER=$(sed -n 's/.*VERSION = "\([^"]*\)".*/\1/p' src/core/config.cppm | head -1)
+            if [[ -z "$VER" ]]; then
+              echo "Failed to read VERSION from src/core/config.cppm." >&2
+              echo "Either fix the source path or pass an explicit version via workflow_dispatch input." >&2
+              exit 1
+            fi
             echo "version=$VER" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
The `Determine version` step in `release.yml` was reading the pre-restructure path `core/config.cppm`. After the C++23 module restructure that moved sources under `src/`, the sed read produces an empty string and the silent fallback `[[ -z "$VER" ]] && VER="0.2.0"` kicked in. Result: the v0.4.3 release run tagged as **v0.2.0** and softprops appended the 0.4.3 archives onto the existing 2026-02-24 v0.2.0 release.

Two-line fix:

- `core/config.cppm` → `src/core/config.cppm`
- silent default → **hard failure** (so the next time someone moves the file, the release run fails loudly instead of silently poisoning an old tag)

Verified locally:

```
$ sed -n 's/.*VERSION = "\([^"]*\)".*/\1/p' src/core/config.cppm
0.4.3
```

After this merges I'll:
1. Delete the stray `xlings-0.4.3-{linux,macosx,windows}.{tar.gz,zip}` assets that were appended onto v0.2.0.
2. Re-trigger `Release` workflow on main; it will now correctly read `0.4.3` and create v0.4.3.

## Test plan

- [x] sed locally returns `0.4.3` from `src/core/config.cppm`
- [ ] CI green
- [ ] Re-triggered release run produces v0.4.3 (not v0.2.0)