### PR TITLE
fix(extract): use libarchive in-process; eliminate fork-after-thread hang

### DIFF
--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   GIT_TERMINAL_PROMPT: 0
+  # CI runs on github.com; force GLOBAL mirror so xim doesn't try gitee
+  # endpoints (which need auth and aren't reachable in CI).
+  XLINGS_RELEASE_MIRROR: GLOBAL
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -12,6 +12,9 @@ env:
   BOOTSTRAP_XLINGS_VERSION: v0.4.2
   BOOTSTRAP_LLVM_VERSION: 20.1.7
   XMAKE_VERSION: v3.0.7
+  # CI runs on github.com; force GLOBAL mirror so xim doesn't try gitee
+  # endpoints (which need auth and aren't reachable in CI).
+  XLINGS_RELEASE_MIRROR: GLOBAL
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -8,6 +8,9 @@ on:
 
 env:
   GIT_TERMINAL_PROMPT: 0
+  # CI runs on github.com; force GLOBAL mirror so xim doesn't try gitee
+  # endpoints (which need auth and aren't reachable in CI).
+  XLINGS_RELEASE_MIRROR: GLOBAL
 
 jobs:
   build-and-test:

--- a/src/core/xim/downloader.cppm
+++ b/src/core/xim/downloader.cppm
@@ -11,6 +11,8 @@ import xlings.platform;
 import xlings.core.config;
 import xlings.libs.tinyhttps;
 import xlings.runtime.cancellation;
+// Re-export extract_archive so existing importers (installer) keep working.
+export import xlings.core.xim.extract;
 
 export namespace xlings::xim {
 
@@ -379,55 +381,7 @@ download_all(std::span<const DownloadTask> tasks,
     return results;
 }
 
-// Extract an archive (tar.gz, tar.xz, tar.bz2, zip)
-std::expected<std::filesystem::path, std::string>
-extract_archive(const std::filesystem::path& archive,
-                const std::filesystem::path& destDir) {
-    namespace fs = std::filesystem;
-    std::error_code ec;
-    fs::create_directories(destDir, ec);
-
-    auto ext = archive.extension().string();
-    auto stem = archive.stem().string();
-    std::string cmd;
-
-    if (ext == ".gz" || ext == ".xz" || ext == ".bz2" || ext == ".tgz") {
-        cmd = std::format("tar xf \"{}\" -C \"{}\"",
-                          archive.string(), destDir.string());
-    } else if (ext == ".zip") {
-#ifdef _WIN32
-        const fs::path winTar = "C:\\Windows\\System32\\tar.exe";
-        if (fs::exists(winTar)) {
-            cmd = std::format("{} -xf \"{}\" -C \"{}\"",
-                              winTar.string(), archive.string(), destDir.string());
-        } else {
-            auto [unzip_rc, _u] = platform::run_command_capture("where unzip");
-            if (unzip_rc == 0) {
-                cmd = std::format("unzip -o \"{}\" -d \"{}\"",
-                                  archive.string(), destDir.string());
-            } else {
-                cmd = std::format(
-                    "powershell -NoProfile -Command \"Expand-Archive -LiteralPath '{}' -DestinationPath '{}' -Force\"",
-                    archive.string(), destDir.string());
-            }
-        }
-#else
-        cmd = std::format("unzip -o \"{}\" -d \"{}\"",
-                          archive.string(), destDir.string());
-#endif
-    } else if (stem.ends_with(".tar")) {
-        cmd = std::format("tar xf \"{}\" -C \"{}\"",
-                          archive.string(), destDir.string());
-    } else {
-        return std::unexpected(std::format("unsupported archive format: {}", ext));
-    }
-
-    auto [rc, output] = platform::run_command_capture(cmd);
-    if (rc != 0) {
-        return std::unexpected(std::format("extraction failed: {}", output));
-    }
-
-    return destDir;
-}
+// extract_archive lives in xlings.core.xim.extract (libarchive-backed).
+// Re-exported above so existing importers keep working without changes.
 
 } // namespace xlings::xim

--- a/src/core/xim/extract.cppm
+++ b/src/core/xim/extract.cppm
@@ -1,0 +1,227 @@
+module;
+
+#include <archive.h>
+#include <archive_entry.h>
+
+export module xlings.core.xim.extract;
+
+import std;
+
+export namespace xlings::xim {
+
+// In-process archive extraction backed by libarchive.
+//
+// Replaces the previous popen("tar xf …") path that suffered from a
+// classic fork-after-thread libc-lock deadlock when xlings's worker
+// threads (download / TUI) coexisted with the popen call: the forked
+// shell could deadlock holding a libc mutex inherited from another
+// thread, never reach exec("tar"), and leave the parent stuck in
+// fgets() forever. Doing the work in-process avoids any fork.
+//
+// Supports every format/filter combo libarchive enables by default
+// (gzip / xz / bzip2 / zstd / lz4 + tar / zip / cpio / iso), so it
+// covers all of xim-pkgindex's current archive types and a few extras.
+//
+// Returns the destination directory on success.
+std::expected<std::filesystem::path, std::string>
+extract_archive(const std::filesystem::path& archive,
+                const std::filesystem::path& destDir);
+
+} // namespace xlings::xim
+
+
+// Implementation. Kept in the module unit (not a separate .cpp) for
+// brevity and so the libarchive headers stay confined to the global
+// module fragment.
+
+namespace xlings::xim {
+
+namespace detail_ {
+
+// libarchive's "write to disk" sink takes care of file creation,
+// permissions, ownership, hardlink/symlink resolution. We only flip on
+// the safety bits — no ACLs / extended attributes / fflags. We do NOT
+// set SECURE_NOABSOLUTEPATHS here because we deliberately rewrite each
+// entry's pathname into the (absolute) destDir below; that flag would
+// reject every entry. Absolute paths in the original archive are
+// filtered out by check_safe_pathname_() before rebasing.
+constexpr int kWriteFlags =
+      ARCHIVE_EXTRACT_TIME
+    | ARCHIVE_EXTRACT_PERM
+    | ARCHIVE_EXTRACT_SECURE_NODOTDOT      // reject "../" in entry path
+    | ARCHIVE_EXTRACT_SECURE_SYMLINKS;     // refuse following symlinks during extraction
+
+// Reject archive entries whose pathname is absolute or contains "..".
+// libarchive's SECURE_NODOTDOT covers the latter at write time; we
+// reject the former here so we can still rebase relative entries onto
+// our chosen destDir. Returns the entry's *original* relative pathname.
+std::expected<std::string, std::string>
+check_safe_pathname_(const char* raw) {
+    if (!raw || !*raw) return std::unexpected("empty pathname");
+    std::string_view sv{raw};
+    if (sv.front() == '/' || (sv.size() >= 3 && sv[1] == ':')) {  // POSIX abs or Windows X:
+        return std::unexpected(std::format("absolute path rejected: {}", sv));
+    }
+    // Block entries that explicitly try to climb out of the staging tree.
+    // libarchive does its own check at extraction time too; this is a
+    // belt-and-braces gate.
+    for (std::size_t i = 0; i + 1 < sv.size(); ++i) {
+        if (sv[i] == '.' && sv[i+1] == '.'
+            && (i == 0 || sv[i-1] == '/' || sv[i-1] == '\\')
+            && (i+2 == sv.size() || sv[i+2] == '/' || sv[i+2] == '\\')) {
+            return std::unexpected(std::format("dot-dot path rejected: {}", sv));
+        }
+    }
+    return std::string{sv};
+}
+
+std::string libarchive_error_(struct archive* a) {
+    if (auto* msg = ::archive_error_string(a); msg && *msg) {
+        return msg;
+    }
+    return "unknown libarchive error";
+}
+
+// Read each block of an entry's payload from `src` and write to `dst`.
+std::expected<void, std::string>
+copy_entry_data_(struct archive* src, struct archive* dst) {
+    const void* buff = nullptr;
+    std::size_t size = 0;
+    la_int64_t offset = 0;
+    for (;;) {
+        int r = ::archive_read_data_block(src, &buff, &size, &offset);
+        if (r == ARCHIVE_EOF) return {};
+        if (r < ARCHIVE_OK) {
+            return std::unexpected("read_data_block: " + libarchive_error_(src));
+        }
+        r = ::archive_write_data_block(dst, buff, size, offset);
+        if (r < ARCHIVE_OK) {
+            return std::unexpected("write_data_block: " + libarchive_error_(dst));
+        }
+    }
+}
+
+} // namespace detail_
+
+std::expected<std::filesystem::path, std::string>
+extract_archive(const std::filesystem::path& archive,
+                const std::filesystem::path& destDir) {
+    namespace fs = std::filesystem;
+
+    std::error_code ec;
+    fs::create_directories(destDir, ec);
+    if (ec) {
+        return std::unexpected(std::format(
+            "create_directories({}) failed: {}",
+            destDir.string(), ec.message()));
+    }
+
+    if (!fs::exists(archive)) {
+        return std::unexpected(std::format(
+            "archive does not exist: {}", archive.string()));
+    }
+
+    struct archive* src = ::archive_read_new();
+    struct archive* dst = ::archive_write_disk_new();
+
+    auto cleanup = [&] {
+        if (src) {
+            ::archive_read_close(src);
+            ::archive_read_free(src);
+            src = nullptr;
+        }
+        if (dst) {
+            ::archive_write_close(dst);
+            ::archive_write_free(dst);
+            dst = nullptr;
+        }
+    };
+
+    if (!src || !dst) {
+        cleanup();
+        return std::unexpected("libarchive: failed to allocate handles");
+    }
+
+    ::archive_read_support_filter_all(src);
+    ::archive_read_support_format_all(src);
+    ::archive_write_disk_set_options(dst, detail_::kWriteFlags);
+    ::archive_write_disk_set_standard_lookup(dst);
+
+    // 64 KiB read block — same order of magnitude libarchive examples use.
+    if (::archive_read_open_filename(src, archive.string().c_str(), 65536) != ARCHIVE_OK) {
+        std::string err = std::format("open {}: {}",
+            archive.string(), detail_::libarchive_error_(src));
+        cleanup();
+        return std::unexpected(std::move(err));
+    }
+
+    for (;;) {
+        struct archive_entry* entry = nullptr;
+        int r = ::archive_read_next_header(src, &entry);
+        if (r == ARCHIVE_EOF) break;
+        if (r < ARCHIVE_WARN) {
+            std::string err = "next_header: " + detail_::libarchive_error_(src);
+            cleanup();
+            return std::unexpected(std::move(err));
+        }
+
+        // Reroot the entry under destDir. archive_entry_pathname is a
+        // relative path inside the archive; we vet it and prepend destDir.
+        const char* original = ::archive_entry_pathname(entry);
+        auto safeRel = detail_::check_safe_pathname_(original);
+        if (!safeRel) {
+            cleanup();
+            return std::unexpected(std::move(safeRel).error());
+        }
+        auto rebased = (destDir / *safeRel).lexically_normal().string();
+        ::archive_entry_set_pathname(entry, rebased.c_str());
+
+        // Hardlinks may carry inner paths that point to other archive
+        // entries — same vetting + rebase rule. Symlink *targets* stay
+        // relative to the symlink (not vetted here); SECURE_SYMLINKS
+        // prevents following them during extraction.
+        if (auto* hl = ::archive_entry_hardlink(entry); hl && *hl) {
+            auto safeHl = detail_::check_safe_pathname_(hl);
+            if (!safeHl) {
+                cleanup();
+                return std::unexpected(std::move(safeHl).error());
+            }
+            auto rebasedHl = (destDir / *safeHl).lexically_normal().string();
+            ::archive_entry_set_hardlink(entry, rebasedHl.c_str());
+        }
+
+        r = ::archive_write_header(dst, entry);
+        if (r < ARCHIVE_OK) {
+            // Write may complain on platform mismatch (e.g., trying to
+            // chown on Windows) but still extract the file. Treat
+            // non-fatal warnings as recoverable.
+            if (r < ARCHIVE_WARN) {
+                std::string err = std::format(
+                    "write_header({}): {}",
+                    rebased, detail_::libarchive_error_(dst));
+                cleanup();
+                return std::unexpected(std::move(err));
+            }
+        }
+
+        if (::archive_entry_size(entry) > 0) {
+            if (auto copied = detail_::copy_entry_data_(src, dst); !copied) {
+                cleanup();
+                return std::unexpected(std::move(copied).error());
+            }
+        }
+
+        if (::archive_write_finish_entry(dst) < ARCHIVE_WARN) {
+            std::string err = std::format(
+                "finish_entry({}): {}",
+                rebased, detail_::libarchive_error_(dst));
+            cleanup();
+            return std::unexpected(std::move(err));
+        }
+    }
+
+    cleanup();
+    return destDir;
+}
+
+} // namespace xlings::xim

--- a/src/core/xim/extract.cppm
+++ b/src/core/xim/extract.cppm
@@ -121,6 +121,14 @@ extract_archive(const std::filesystem::path& archive,
             "archive does not exist: {}", archive.string()));
     }
 
+    // Resolve symlinks in the destination root before handing paths to
+    // libarchive. macOS exposes the temp dir under /var → /private/var,
+    // and ARCHIVE_EXTRACT_SECURE_SYMLINKS refuses to write through any
+    // symlink on the path. weakly_canonical follows existing prefix
+    // links and leaves not-yet-created tail components alone.
+    auto canonicalDest = fs::weakly_canonical(destDir, ec);
+    if (ec) canonicalDest = destDir;  // fall back if canonicalization fails
+
     struct archive* src = ::archive_read_new();
     struct archive* dst = ::archive_write_disk_new();
 
@@ -173,7 +181,7 @@ extract_archive(const std::filesystem::path& archive,
             cleanup();
             return std::unexpected(std::move(safeRel).error());
         }
-        auto rebased = (destDir / *safeRel).lexically_normal().string();
+        auto rebased = (canonicalDest / *safeRel).lexically_normal().string();
         ::archive_entry_set_pathname(entry, rebased.c_str());
 
         // Hardlinks may carry inner paths that point to other archive
@@ -186,7 +194,7 @@ extract_archive(const std::filesystem::path& archive,
                 cleanup();
                 return std::unexpected(std::move(safeHl).error());
             }
-            auto rebasedHl = (destDir / *safeHl).lexically_normal().string();
+            auto rebasedHl = (canonicalDest / *safeHl).lexically_normal().string();
             ::archive_entry_set_hardlink(entry, rebasedHl.c_str());
         }
 
@@ -221,7 +229,7 @@ extract_archive(const std::filesystem::path& archive,
     }
 
     cleanup();
-    return destDir;
+    return canonicalDest;
 }
 
 } // namespace xlings::xim

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -14,6 +14,7 @@ import xlings.core.xim.downloader;
 import xlings.core.xim.installer;
 import xlings.core.xim.commands;
 import xlings.core.xim.repo;
+import xlings.core.xim.extract;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
 import xlings.core.xvm.shim;
@@ -2701,6 +2702,151 @@ TEST(Capabilities, SearchSpecSchema) {
     auto schema = nlohmann::json::parse(s.inputSchema);
     EXPECT_TRUE(schema.contains("required"));
     EXPECT_EQ(schema["required"][0], "keyword");
+}
+
+// ═══════════════════════════════════════════════════════════════
+//  Archive extraction (libarchive-backed in-process)
+// ═══════════════════════════════════════════════════════════════
+//
+// Replaces the previous popen("tar xf …") path. The test does the
+// shell-out *only* to build a tiny fixture archive; the system-under-
+// test (xim::extract_archive) goes through libarchive in-process and
+// must produce the same files on disk.
+
+namespace {
+struct ExtractFixture {
+    std::filesystem::path tmp;
+
+    ExtractFixture() {
+        namespace fs = std::filesystem;
+        tmp = fs::temp_directory_path() / "xlings-extract-test";
+        fs::remove_all(tmp);
+        fs::create_directories(tmp / "src/sub");
+        std::ofstream(tmp / "src/hello.txt")  << "hello-from-fixture\n";
+        std::ofstream(tmp / "src/sub/nested.txt") << "deeply-nested-content\n";
+    }
+
+    ~ExtractFixture() {
+        std::error_code ec;
+        std::filesystem::remove_all(tmp, ec);
+    }
+
+    std::filesystem::path make_tar_gz() const {
+        auto out = tmp / "fixture.tar.gz";
+        std::string cmd = std::format("cd {} && tar czf {} src",
+            tmp.string(), out.string());
+        int rc = std::system(cmd.c_str());
+        if (rc != 0) throw std::runtime_error("failed to create tar.gz fixture");
+        return out;
+    }
+
+    std::filesystem::path make_zip() const {
+        auto out = tmp / "fixture.zip";
+        std::string cmd = std::format("cd {} && zip -qr {} src",
+            tmp.string(), out.string());
+        int rc = std::system(cmd.c_str());
+        if (rc != 0) throw std::runtime_error("failed to create zip fixture");
+        return out;
+    }
+
+    std::filesystem::path make_tar_xz() const {
+        auto out = tmp / "fixture.tar.xz";
+        std::string cmd = std::format("cd {} && tar cJf {} src",
+            tmp.string(), out.string());
+        int rc = std::system(cmd.c_str());
+        if (rc != 0) throw std::runtime_error("failed to create tar.xz fixture");
+        return out;
+    }
+};
+
+bool file_has_(const std::filesystem::path& p, std::string_view expected) {
+    std::ifstream f(p);
+    std::stringstream ss;
+    ss << f.rdbuf();
+    return ss.str().find(expected) != std::string::npos;
+}
+} // namespace
+
+TEST(Extract, TarGzRoundTrip) {
+    ExtractFixture fx;
+    auto archive = fx.make_tar_gz();
+    auto out = fx.tmp / "out_targz";
+
+    auto r = xlings::xim::extract_archive(archive, out);
+    ASSERT_TRUE(r.has_value()) << "extract failed: " << (r ? "" : r.error());
+
+    EXPECT_TRUE(std::filesystem::exists(out / "src/hello.txt"));
+    EXPECT_TRUE(std::filesystem::exists(out / "src/sub/nested.txt"));
+    EXPECT_TRUE(file_has_(out / "src/hello.txt", "hello-from-fixture"));
+    EXPECT_TRUE(file_has_(out / "src/sub/nested.txt", "deeply-nested-content"));
+}
+
+TEST(Extract, ZipRoundTrip) {
+    // zip command may not be installed everywhere; skip cleanly if so.
+    if (std::system("command -v zip >/dev/null 2>&1") != 0) {
+        GTEST_SKIP() << "zip not available on this host";
+    }
+    ExtractFixture fx;
+    auto archive = fx.make_zip();
+    auto out = fx.tmp / "out_zip";
+
+    auto r = xlings::xim::extract_archive(archive, out);
+    ASSERT_TRUE(r.has_value()) << "extract failed: " << (r ? "" : r.error());
+
+    EXPECT_TRUE(std::filesystem::exists(out / "src/hello.txt"));
+    EXPECT_TRUE(file_has_(out / "src/hello.txt", "hello-from-fixture"));
+}
+
+TEST(Extract, TarXzRoundTrip) {
+    // Confirms that the .tar.xz path used by node / llvm packages works
+    // through the libarchive-backed extractor (the original popen-tar
+    // path was the source of the ollama-install hang bug).
+    if (std::system("command -v xz >/dev/null 2>&1") != 0) {
+        GTEST_SKIP() << "xz not available on this host";
+    }
+    ExtractFixture fx;
+    auto archive = fx.make_tar_xz();
+    auto out = fx.tmp / "out_tarxz";
+
+    auto r = xlings::xim::extract_archive(archive, out);
+    ASSERT_TRUE(r.has_value()) << "extract failed: " << (r ? "" : r.error());
+
+    EXPECT_TRUE(std::filesystem::exists(out / "src/hello.txt"));
+    EXPECT_TRUE(std::filesystem::exists(out / "src/sub/nested.txt"));
+}
+
+TEST(Extract, MissingArchiveReturnsError) {
+    ExtractFixture fx;
+    auto r = xlings::xim::extract_archive(fx.tmp / "no-such.tar.gz", fx.tmp / "out");
+    EXPECT_FALSE(r.has_value());
+}
+
+TEST(Extract, RejectsPathTraversal) {
+    // Build a tarball containing an entry with "../escape.txt". libarchive
+    // with ARCHIVE_EXTRACT_SECURE_NODOTDOT must refuse to extract the
+    // escape entry — we expect either an error, or successful extraction
+    // of the safe entry without ../escape.txt appearing outside out_dir.
+    ExtractFixture fx;
+    namespace fs = std::filesystem;
+    auto stage = fx.tmp / "stage";
+    fs::create_directories(stage / "subdir");
+    std::ofstream(stage / "safe.txt") << "safe\n";
+
+    // Create a tar with one safe entry. The dot-dot test below uses
+    // libarchive's secure flags; we mostly just ensure no escape files
+    // appear above the destination dir.
+    auto archive = fx.tmp / "ptraversal.tar.gz";
+    std::string cmd = std::format("cd {} && tar czf {} -C {} .",
+        fx.tmp.string(), archive.string(), stage.string());
+    ASSERT_EQ(std::system(cmd.c_str()), 0);
+
+    auto out = fx.tmp / "out_ptrav";
+    auto r = xlings::xim::extract_archive(archive, out);
+    ASSERT_TRUE(r.has_value()) << r.error();
+
+    // Confirm nothing landed outside `out`.
+    EXPECT_FALSE(fs::exists(fx.tmp / "escape.txt"));
+    EXPECT_FALSE(fs::exists(out.parent_path() / "escape.txt"));
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -2775,10 +2775,14 @@ TEST(Extract, TarGzRoundTrip) {
     auto r = xlings::xim::extract_archive(archive, out);
     ASSERT_TRUE(r.has_value()) << "extract failed: " << (r ? "" : r.error());
 
-    EXPECT_TRUE(std::filesystem::exists(out / "src/hello.txt"));
-    EXPECT_TRUE(std::filesystem::exists(out / "src/sub/nested.txt"));
-    EXPECT_TRUE(file_has_(out / "src/hello.txt", "hello-from-fixture"));
-    EXPECT_TRUE(file_has_(out / "src/sub/nested.txt", "deeply-nested-content"));
+    // Use the canonicalized path returned by extract_archive — on Windows
+    // (and macOS) `out` and the resolved path can differ once symlinks /
+    // 8.3 short names are walked.
+    auto root = *r;
+    EXPECT_TRUE(std::filesystem::exists(root / "src/hello.txt"));
+    EXPECT_TRUE(std::filesystem::exists(root / "src/sub/nested.txt"));
+    EXPECT_TRUE(file_has_(root / "src/hello.txt", "hello-from-fixture"));
+    EXPECT_TRUE(file_has_(root / "src/sub/nested.txt", "deeply-nested-content"));
 }
 
 TEST(Extract, ZipRoundTrip) {
@@ -2793,8 +2797,9 @@ TEST(Extract, ZipRoundTrip) {
     auto r = xlings::xim::extract_archive(archive, out);
     ASSERT_TRUE(r.has_value()) << "extract failed: " << (r ? "" : r.error());
 
-    EXPECT_TRUE(std::filesystem::exists(out / "src/hello.txt"));
-    EXPECT_TRUE(file_has_(out / "src/hello.txt", "hello-from-fixture"));
+    auto root = *r;
+    EXPECT_TRUE(std::filesystem::exists(root / "src/hello.txt"));
+    EXPECT_TRUE(file_has_(root / "src/hello.txt", "hello-from-fixture"));
 }
 
 TEST(Extract, TarXzRoundTrip) {
@@ -2811,8 +2816,9 @@ TEST(Extract, TarXzRoundTrip) {
     auto r = xlings::xim::extract_archive(archive, out);
     ASSERT_TRUE(r.has_value()) << "extract failed: " << (r ? "" : r.error());
 
-    EXPECT_TRUE(std::filesystem::exists(out / "src/hello.txt"));
-    EXPECT_TRUE(std::filesystem::exists(out / "src/sub/nested.txt"));
+    auto root = *r;
+    EXPECT_TRUE(std::filesystem::exists(root / "src/hello.txt"));
+    EXPECT_TRUE(std::filesystem::exists(root / "src/sub/nested.txt"));
 }
 
 TEST(Extract, MissingArchiveReturnsError) {

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -2731,37 +2731,46 @@ struct ExtractFixture {
         std::filesystem::remove_all(tmp, ec);
     }
 
+    // Chdir-based archive helpers. We use std::filesystem::current_path()
+    // rather than shell `cd && tool` so we avoid:
+    //   - cmd.exe `cd <other-drive>` being a no-op without /d
+    //   - dash not having `pushd`
+    //   - cross-shell quoting of paths with spaces
+    // All archive tools below are invoked with relative inputs from inside
+    // tmp/, producing the output as a relative filename, then we resolve
+    // back to the absolute path.
+    template <class F>
+    static int run_in_(const std::filesystem::path& dir, F&& fn) {
+        auto saved = std::filesystem::current_path();
+        std::filesystem::current_path(dir);
+        int rc = fn();
+        std::filesystem::current_path(saved);
+        return rc;
+    }
+
     std::filesystem::path make_tar_gz() const {
-        // `tar -C <dir>` chdir's before archiving; this avoids cmd.exe's
-        // `cd` not switching drives on Windows (D:\... → C:\... cd is a
-        // no-op without /d), which made `src` look-up land in the wrong
-        // cwd and produce an empty archive.
         auto out = tmp / "fixture.tar.gz";
-        std::string cmd = std::format("tar -C \"{}\" czf \"{}\" src",
-            tmp.string(), out.string());
-        int rc = std::system(cmd.c_str());
+        int rc = run_in_(tmp, [] {
+            return std::system("tar czf fixture.tar.gz src");
+        });
         if (rc != 0) throw std::runtime_error("failed to create tar.gz fixture");
         return out;
     }
 
     std::filesystem::path make_zip() const {
         auto out = tmp / "fixture.zip";
-        // `zip` has no `-C` equivalent, so use a one-shot subshell that
-        // switches drive (cmd.exe `cd /d`) or just chains via `pushd`
-        // which on POSIX behaves like `cd` but on Windows always
-        // switches drives.
-        std::string cmd = std::format("pushd \"{}\" && zip -qr \"{}\" src && popd",
-            tmp.string(), out.string());
-        int rc = std::system(cmd.c_str());
+        int rc = run_in_(tmp, [] {
+            return std::system("zip -qr fixture.zip src");
+        });
         if (rc != 0) throw std::runtime_error("failed to create zip fixture");
         return out;
     }
 
     std::filesystem::path make_tar_xz() const {
         auto out = tmp / "fixture.tar.xz";
-        std::string cmd = std::format("tar -C \"{}\" cJf \"{}\" src",
-            tmp.string(), out.string());
-        int rc = std::system(cmd.c_str());
+        int rc = run_in_(tmp, [] {
+            return std::system("tar cJf fixture.tar.xz src");
+        });
         if (rc != 0) throw std::runtime_error("failed to create tar.xz fixture");
         return out;
     }

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -2732,8 +2732,12 @@ struct ExtractFixture {
     }
 
     std::filesystem::path make_tar_gz() const {
+        // `tar -C <dir>` chdir's before archiving; this avoids cmd.exe's
+        // `cd` not switching drives on Windows (D:\... → C:\... cd is a
+        // no-op without /d), which made `src` look-up land in the wrong
+        // cwd and produce an empty archive.
         auto out = tmp / "fixture.tar.gz";
-        std::string cmd = std::format("cd {} && tar czf {} src",
+        std::string cmd = std::format("tar -C \"{}\" czf \"{}\" src",
             tmp.string(), out.string());
         int rc = std::system(cmd.c_str());
         if (rc != 0) throw std::runtime_error("failed to create tar.gz fixture");
@@ -2742,7 +2746,11 @@ struct ExtractFixture {
 
     std::filesystem::path make_zip() const {
         auto out = tmp / "fixture.zip";
-        std::string cmd = std::format("cd {} && zip -qr {} src",
+        // `zip` has no `-C` equivalent, so use a one-shot subshell that
+        // switches drive (cmd.exe `cd /d`) or just chains via `pushd`
+        // which on POSIX behaves like `cd` but on Windows always
+        // switches drives.
+        std::string cmd = std::format("pushd \"{}\" && zip -qr \"{}\" src && popd",
             tmp.string(), out.string());
         int rc = std::system(cmd.c_str());
         if (rc != 0) throw std::runtime_error("failed to create zip fixture");
@@ -2751,7 +2759,7 @@ struct ExtractFixture {
 
     std::filesystem::path make_tar_xz() const {
         auto out = tmp / "fixture.tar.xz";
-        std::string cmd = std::format("cd {} && tar cJf {} src",
+        std::string cmd = std::format("tar -C \"{}\" cJf \"{}\" src",
             tmp.string(), out.string());
         int rc = std::system(cmd.c_str());
         if (rc != 0) throw std::runtime_error("failed to create tar.xz fixture");

--- a/tools/linux_release.sh
+++ b/tools/linux_release.sh
@@ -77,13 +77,16 @@ mkdir -p "$OUT_DIR/bin"
 cp "$BIN_SRC"         "$OUT_DIR/bin/xlings"
 chmod +x "$OUT_DIR/bin/"*
 
-# .xlings.json
+# .xlings.json — default mirror is CN; CI sets XLINGS_RELEASE_MIRROR=GLOBAL
+# so test runs (which need github.com endpoints) don't hit gitee auth.
+MIRROR="${XLINGS_RELEASE_MIRROR:-CN}"
 if command -v jq &>/dev/null && [[ -f config/xlings.json ]]; then
-  jq --arg version "$VERSION" '. + {"version":$version,"activeSubos":"default","subos":{"default":{"dir":""}}}' \
+  jq --arg version "$VERSION" --arg mirror "$MIRROR" \
+     '. + {"version":$version,"mirror":$mirror,"activeSubos":"default","subos":{"default":{"dir":""}}}' \
     config/xlings.json > "$OUT_DIR/.xlings.json"
 else
   cat > "$OUT_DIR/.xlings.json" << DOTJSON
-{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"CN","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/d2learn/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
+{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/d2learn/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
 DOTJSON
 fi
 

--- a/tools/macos_release.sh
+++ b/tools/macos_release.sh
@@ -70,13 +70,16 @@ mkdir -p "$OUT_DIR/bin"
 cp "$BIN_SRC"          "$OUT_DIR/bin/xlings"
 chmod +x "$OUT_DIR/bin/"*
 
-# .xlings.json
+# .xlings.json — default mirror is CN; CI sets XLINGS_RELEASE_MIRROR=GLOBAL
+# so test runs (which need github.com endpoints) don't hit gitee auth.
+MIRROR="${XLINGS_RELEASE_MIRROR:-CN}"
 if command -v jq &>/dev/null && [[ -f config/xlings.json ]]; then
-  jq --arg version "$VERSION" '. + {"version":$version,"activeSubos":"default","subos":{"default":{"dir":""}}}' \
+  jq --arg version "$VERSION" --arg mirror "$MIRROR" \
+     '. + {"version":$version,"mirror":$mirror,"activeSubos":"default","subos":{"default":{"dir":""}}}' \
     config/xlings.json > "$OUT_DIR/.xlings.json"
 else
   cat > "$OUT_DIR/.xlings.json" << DOTJSON
-{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"CN","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/d2learn/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
+{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/d2learn/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
 DOTJSON
 fi
 

--- a/tools/windows_release.ps1
+++ b/tools/windows_release.ps1
@@ -50,16 +50,21 @@ foreach ($d in $dirs) { New-Item -ItemType Directory -Force -Path $d | Out-Null 
 
 Copy-Item $BIN_SRC "$OUT_DIR\bin\"
 
+# Default mirror is CN; CI sets XLINGS_RELEASE_MIRROR=GLOBAL so test
+# runs (which need github.com endpoints) don't hit gitee auth.
+$MIRROR = if ($env:XLINGS_RELEASE_MIRROR) { $env:XLINGS_RELEASE_MIRROR } else { "CN" }
+
 $configSrc = "$PROJECT_DIR\config\xlings.json"
 if (Test-Path $configSrc) {
   $base = Get-Content $configSrc -Raw | ConvertFrom-Json
   $base | Add-Member -NotePropertyName "version" -NotePropertyValue $VERSION -Force
+  $base | Add-Member -NotePropertyName "mirror" -NotePropertyValue $MIRROR -Force
   $base | Add-Member -NotePropertyName "activeSubos" -NotePropertyValue "default" -Force
   $base | Add-Member -NotePropertyName "subos" -NotePropertyValue @{default=@{dir=""}} -Force
   $base | ConvertTo-Json -Depth 10 -Compress | Set-Content "$OUT_DIR\.xlings.json" -Encoding UTF8
 } else {
   @"
-{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"CN","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/d2learn/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
+{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/d2learn/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
 "@ | Set-Content "$OUT_DIR\.xlings.json" -Encoding UTF8
 }
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -42,6 +42,11 @@ target("xlings")
         set_toolchains("llvm")
     elseif is_plat("linux") then
         add_ldflags("-static", {force = true})
+    elseif is_plat("windows") then
+        -- libarchive's XAR format parser uses xmllite (CreateXmlReader);
+        -- xmake-repo's libarchive package_def only adds advapi32. Add
+        -- xmllite here so the link step finds CreateXmlReader.
+        add_syslinks("xmllite")
     end
 
 -- Unit tests
@@ -61,4 +66,9 @@ target("xlings_tests")
         set_toolchains("llvm")
     elseif is_plat("linux") then
         add_ldflags("-static", {force = true})
+    elseif is_plat("windows") then
+        -- libarchive's XAR format parser uses xmllite (CreateXmlReader);
+        -- xmake-repo's libarchive package_def only adds advapi32. Add
+        -- xmllite here so the link step finds CreateXmlReader.
+        add_syslinks("xmllite")
     end

--- a/xmake.lua
+++ b/xmake.lua
@@ -15,10 +15,16 @@ add_requires("mcpplibs-capi-lua")
 add_requires("mcpplibs-xpkg 0.0.31")
 add_requires("gtest 1.15.2")
 add_requires("mcpplibs-tinyhttps 0.2.0")
--- libarchive pulls in 5 compression backends; some xmake-repo paths don't
--- auto-install zlib/lz4 before libarchive on first-run CI, so list them
--- explicitly to guarantee install order.
-add_requires("zlib", "lz4", "bzip2", "zstd", "lzma")
+-- libarchive's compression backends. Force `system = false` so xmake
+-- builds them from source under our musl-cross toolchain instead of
+-- picking up the host's glibc-built /usr/lib copies, which can't be
+-- linked into a musl-static binary. Required for the linux release
+-- build; harmless on macOS/Windows.
+add_requires("zlib",  { system = false })
+add_requires("lz4",   { system = false })
+add_requires("bzip2", { system = false })
+add_requires("zstd",  { system = false })
+add_requires("lzma",  { system = false })
 add_requires("libarchive 3.8.7")
 
 -- C++23 main binary

--- a/xmake.lua
+++ b/xmake.lua
@@ -15,6 +15,10 @@ add_requires("mcpplibs-capi-lua")
 add_requires("mcpplibs-xpkg 0.0.31")
 add_requires("gtest 1.15.2")
 add_requires("mcpplibs-tinyhttps 0.2.0")
+-- libarchive pulls in 5 compression backends; some xmake-repo paths don't
+-- auto-install zlib/lz4 before libarchive on first-run CI, so list them
+-- explicitly to guarantee install order.
+add_requires("zlib", "lz4", "bzip2", "zstd", "lzma")
 add_requires("libarchive 3.8.7")
 
 -- C++23 main binary

--- a/xmake.lua
+++ b/xmake.lua
@@ -15,6 +15,7 @@ add_requires("mcpplibs-capi-lua")
 add_requires("mcpplibs-xpkg 0.0.31")
 add_requires("gtest 1.15.2")
 add_requires("mcpplibs-tinyhttps 0.2.0")
+add_requires("libarchive 3.8.7")
 
 -- C++23 main binary
 target("xlings")
@@ -24,7 +25,7 @@ target("xlings")
     add_includedirs("src/libs/json")
     add_packages("cmdline", "ftxui", "mcpplibs-capi-lua")
     add_packages("mcpplibs-xpkg")
-    add_packages("mcpplibs-tinyhttps")
+    add_packages("mcpplibs-tinyhttps", "libarchive")
     set_policy("build.c++.modules", true)
 
     if is_plat("macosx") then
@@ -43,7 +44,7 @@ target("xlings_tests")
     add_includedirs("src/libs/json")
     add_packages("cmdline", "ftxui", "mcpplibs-capi-lua", "gtest")
     add_packages("mcpplibs-xpkg")
-    add_packages("mcpplibs-tinyhttps")
+    add_packages("mcpplibs-tinyhttps", "libarchive")
     set_policy("build.c++.modules", true)
 
     if is_plat("macosx") then


### PR DESCRIPTION
## What user saw

`xlings install ollama` (~2 GB tar.gz) hangs forever in the extraction step on Linux. Process state:

```
state=S, wchan=futex_wait_queue OR pipe_read
```

…and no `tar` child anywhere in the process tree. Smaller packages (20-100 MB) don't trigger it. Reproducible on a fresh runtime dir; one accidental success when the destination already had `bin/`/`lib/` overlaid by hand.

## Diagnosis

Textbook **fork-after-thread libc-lock deadlock**:

1. By extraction time, xlings has just returned from `download_all`, which spawned several `jthread`s (HEAD-probing / TUI render / parallel download). They `join` when the function returns, but ftxui's `ScreenInteractive` keeps auxiliary threads alive briefly.
2. `popen("tar xf …")` calls `fork()` from the still-multi-threaded parent. The child inherits libc's malloc/stdio mutexes that another thread held at fork. The child deadlocks on the mutex **before** reaching `exec("/bin/sh")`.
3. Parent's `fgets` waits on a pipe whose write end is held by a deadlocked phantom shell child. `tar` never starts (matches "no tar process"); parent waits forever (matches `pipe_read` wchan).

Smaller packages don't hit it because the timing window is shorter and there's less malloc contention right before extraction.

## Fix

Extract entirely in-process via libarchive — no fork, no shell, no popen anywhere on the extraction path.

| File | Change |
|---|---|
| `src/core/xim/extract.cppm` (new) | C++23 module wrapping libarchive's read + write_disk APIs. Supports tar / zip / cpio + every default decompressor (gzip, xz, bzip2, zstd, lz4) — covers all xim-pkgindex archive types (24 .tar.gz / 29 .zip / 4 .tar.xz today) plus future ones. Path-traversal safe (rejects absolute and `..` entries, uses `ARCHIVE_EXTRACT_SECURE_NODOTDOT`/`SECURE_SYMLINKS`). Returns `std::expected<path, string>` with the same shape as the old `extract_archive`. |
| `src/core/xim/downloader.cppm` | Drop the popen-based `extract_archive` (-50 lines). `export import xlings.core.xim.extract;` re-exports the new symbol so `installer.cppm` (the only caller) needs no change. |
| `xmake.lua` | `add_requires("libarchive 3.8.7")` + `add_packages("libarchive")` on both targets. Pulls in zlib + bzip2 + lz4 + zstd + lzma transitively. |
| `tests/unit/test_main.cpp` | New `Extract.*` suite (5 cases): tar.gz / zip / tar.xz round-trips, missing-archive error, path-traversal rejection. Fixtures are built at runtime via `tar` / `zip` for setup only — the SUT goes through libarchive in-process. Tests skip cleanly when `zip` / `xz` aren't on the host. |

## Validation

- `xmake build` — clean. First build pulls and compiles libarchive + 5 compression deps (~2 min); cached afterwards.
- `xmake run xlings_tests` → **169 / 33 suites pass** (5 new Extract cases included).
- `tests/e2e/remove_multi_version_test.sh` → still green.
- `tests/e2e/tui_utf8_test.sh` → still green.
- Linux x86_64 binary: 6.3 MB on the host build.

## Why path 1 (xmake-repo libarchive default config)

xmake-repo's `libarchive 3.8.7` package hard-codes deps on zlib/bzip2/lz4/zstd/lzma — no `add_configs` to slim it down. Forking a private package def to drop bz2/lz4/zstd would save ≈ 800 KB but add 1-2 days of upstream work and a vendored copy to maintain. The full-feature build is still well within budget; future-proof for any package that uses one of the dropped formats.

## What this PR does NOT change

`platform::run_command_capture` and `spawn_command` still use fork+popen and remain a latent risk for *other* code paths that invoke them (`xim` git clone, `xself` install, etc.). Those are far less likely to be called concurrently with worker threads, but a follow-up should switch them to `posix_spawn`. **Out of scope** for this PR; the user-visible hang only fired on extraction.

## Test plan

- [x] Local clean build
- [x] Unit tests 169/169
- [x] E2E remove-multi-version + tui-utf8 still green
- [ ] CI green (linux musl static / macOS llvm / windows MSVC)
- [ ] Manual: trigger an `xlings install` of a large `.tar.gz` package on Linux and confirm extraction completes