### PR TITLE
fix(installer): sweep empty package dir after removing last version

### DIFF
--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -1243,6 +1243,45 @@ public:
         if (ec) {
             log::warn("failed to remove payload dir {}: {}", installDir.string(), ec.message());
         }
+
+        // installDir is the version directory (e.g. .../xim-x-node/22.17.1).
+        // Its parent is the per-package directory (.../xim-x-node) which
+        // holds one subdirectory per installed version of the same package.
+        // After we delete the version we just uninstalled, the package
+        // directory may be left as an empty stub if this was its last
+        // version — sweep it.
+        //
+        // Why "list-then-remove" instead of "remove and tolerate ENOTEMPTY":
+        // fs::remove (non-recursive) silently returns false for non-empty
+        // directories, which would conflate the "still has versions, leave
+        // it alone" expected case with real errors (permission denied, IO
+        // failure). It is also a maintenance trap — the next reader can
+        // upgrade it to fs::remove_all and wipe sibling versions. So check
+        // emptiness explicitly first.
+        //
+        // Cross-platform: directory_iterator and fs::remove are part of
+        // std::filesystem and behave identically on Linux/macOS/Windows
+        // for the cases we care about (empty dir → end iterator; remove of
+        // an empty directory → succeeds; non-existent or unreadable parent
+        // → ec set, we skip). One platform-specific edge case worth naming:
+        // file managers occasionally drop hidden metadata into the dir
+        // (.DS_Store on macOS, Thumbs.db on Windows). Those count as
+        // non-empty, so we will leave the package directory alone — that
+        // is the right behavior; never silently delete files we did not
+        // create.
+        auto parent = installDir.parent_path();
+        std::error_code listEc;
+        auto first = std::filesystem::directory_iterator(parent, listEc);
+        if (!listEc && first == std::filesystem::directory_iterator{}) {
+            std::error_code rmEc;
+            if (std::filesystem::remove(parent, rmEc)) {
+                log::debug("swept empty package dir: {}", parent.string());
+            } else if (rmEc) {
+                log::warn("failed to sweep empty package dir {}: {}",
+                          parent.string(), rmEc.message());
+            }
+        }
+
         log::debug("{} uninstalled", resolvedTarget);
         return {};
     }


### PR DESCRIPTION
## Summary

\`xlings remove xim:foo@1.0\` deletes the version directory (\`data/xpkgs/xim-x-foo/1.0\`) but leaves the per-package directory (\`data/xpkgs/xim-x-foo\`) behind as an empty stub when 1.0 was its last installed version. Over time a heavy install/remove user accumulates a fan of empty \`xim-x-*\` / \`config-*\` / \`awesome-*\` directories under \`\$XLINGS_HOME/data/xpkgs\`.

## Fix

After \`fs::remove_all(installDir)\` on the version directory, check whether the parent (per-package) directory is now empty and, if so, remove it.

Implementation deliberately uses an explicit \`directory_iterator\` emptiness check rather than calling \`fs::remove(parent)\` and tolerating \`ENOTEMPTY\`:

- The explicit check makes intent obvious to readers (no need to know POSIX rmdir semantics).
- It distinguishes the "still has versions, leave it alone" expected case from real failures (permission denied, IO error) which are logged.
- It removes a maintenance trap where the next reader could upgrade the call to \`fs::remove_all\` and silently wipe sibling versions.

The block is heavily commented; the comment also calls out the cross-platform behavior (\`std::filesystem\` semantics are identical on Linux/macOS/Windows for the cases we care about) and the deliberately-conservative handling of platform metadata files (\`.DS_Store\` on macOS, \`Thumbs.db\` on Windows count as non-empty — we leave the directory alone rather than silently delete files we did not create).

## Test plan

Verified locally on a fresh \$XLINGS_HOME sandbox:

- [x] install \`xim:node@22.17.1\` (only) → remove → \`xim-x-node/\` is gone
- [x] install both \`22.17.1\` and \`18.20.8\` → remove \`22.17.1\` → \`xim-x-node/\` kept (18.20.8 still inside) → remove \`18.20.8\` → \`xim-x-node/\` swept
- [x] full test suite green: 184 / 188 (4 pre-existing skips, no regressions)
- [ ] CI green (Linux musl / macOS llvm / Windows MSVC)