### PR TITLE
feat(cli): confirm before remove + show subos/version on plan & summary

### DIFF
--- a/src/capabilities.cppm
+++ b/src/capabilities.cppm
@@ -104,14 +104,15 @@ public:
         return {
             .name = "remove_package",
             .description = "Remove one package or one specific version. Only removes one target per call — to remove multiple versions, call multiple times",
-            .inputSchema = R"({"type":"object","properties":{"target":{"type":"string","description":"Format: name, name@version, or namespace:name@version"}},"required":["target"]})",
+            .inputSchema = R"({"type":"object","properties":{"target":{"type":"string","description":"Format: name, name@version, or namespace:name@version"},"yes":{"type":"boolean","description":"Auto-confirm without prompting"}},"required":["target"]})",
             .outputSchema = R"({"type":"object","properties":{"exitCode":{"type":"integer"}}})",
             .destructive = true,
         };
     }
     auto execute(Params params, EventStream& stream) -> Result override {
         auto json = nlohmann::json::parse(params, nullptr, false);
-        return exit_result(xim::cmd_remove(json.value("target", ""), stream));
+        bool yes = json.value("yes", false);
+        return exit_result(xim::cmd_remove(json.value("target", ""), yes, stream));
     }
 };
 

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -117,8 +117,20 @@ static void dispatch_data_event(const DataEvent& e) {
     else if (e.kind == "install_summary") {
         ui::print_install_summary(json.value("success", 0), json.value("failed", 0));
     }
+    else if (e.kind == "remove_plan") {
+        ui::print_remove_plan(
+            json.value("subos", ""),
+            json.value("name", ""),
+            json.value("version", ""));
+    }
     else if (e.kind == "remove_summary") {
-        ui::print_remove_summary(json.value("target", ""));
+        // Tolerate the legacy "target" key (older interface clients) by
+        // falling back when name/version were not provided.
+        auto name = json.value("name", json.value("target", ""));
+        ui::print_remove_summary(
+            json.value("subos", ""),
+            name,
+            json.value("version", ""));
     }
     else if (e.kind == "subos_list") {
         std::vector<std::tuple<std::string, std::string, int, bool>> entries;
@@ -731,7 +743,8 @@ export int run(int argc, char* argv[]) {
             .arg("package").required().help("Package to remove")
             .action([&stream](const cmdline::ParsedArgs& args) -> int {
                 apply_global_opts_(args);
-                return xim::cmd_remove(std::string(args.positional(0)), stream);
+                bool yes = args.is_flag_set("yes");
+                return xim::cmd_remove(std::string(args.positional(0)), yes, stream);
             })
 
         // update

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -54,7 +54,7 @@ std::string detect_platform() {
 }
 
 // Forward declaration for deferred install request processing
-int cmd_remove(const std::string& target, EventStream& stream);
+int cmd_remove(const std::string& target, bool yes, EventStream& stream);
 
 // === install command ===
 //
@@ -313,7 +313,7 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
                     cmd_install(subTargets, /*yes=*/true, /*noDeps=*/false, stream, forceGlobal);
                 } else if (req.op == "remove") {
                     log::debug("removing sub-dependency: {}", req.target);
-                    cmd_remove(req.target, stream);
+                    cmd_remove(req.target, /*yes=*/true, stream);
                 }
             }
         },
@@ -335,11 +335,73 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
 }
 
 // === remove command ===
-int cmd_remove(const std::string& target, EventStream& stream) {
+//
+// yes: skip the interactive confirmation. Recursive calls from install hooks
+// (pkgmanager.remove inside an xpkg) always pass yes=true: the user already
+// approved the parent install, so the connected uninstall is implicit.
+// CLI-driven `xlings remove <pkg>` defaults to yes=false and bails on n.
+int cmd_remove(const std::string& target, bool yes, EventStream& stream) {
     auto& catalog = get_catalog();
     if (!catalog.is_loaded()) {
         log::error("package index not available");
         return 1;
+    }
+
+    // Resolve up-front so the prompt and summary can show the canonical
+    // name + version + active subos. When the user did not pin a version,
+    // prefer the active one — catalog.resolve_target's default is the
+    // highest *declared* version, which may not be installed.
+    std::string displayName = target;
+    std::string displayVersion;
+    std::string subos = Config::paths().activeSubos;
+
+    std::string resolveTarget = target;
+    if (target.find('@') == std::string::npos) {
+        auto bareName = target.substr(target.rfind(':') + 1);
+        auto active = xvm::get_active_version(
+            Config::effective_workspace(), bareName);
+        if (!active.empty()) {
+            resolveTarget = target + "@" + active;
+        }
+    }
+    bool resolvedToDefiniteVersion = (resolveTarget.find('@') != std::string::npos);
+
+    auto match = catalog.resolve_target(resolveTarget, detect_platform());
+    if (match) {
+        displayName = match->canonicalName;
+        displayVersion = match->version;
+        // Only short-circuit "not installed" when the resolution is
+        // unambiguous (user pinned, or matches the active version).
+        // Otherwise the catalog may have picked the highest *declared*
+        // version, which can differ from what's actually installed —
+        // let installer.uninstall handle that path.
+        if (!match->installed && resolvedToDefiniteVersion) {
+            log::warn("{}@{} is not installed", displayName, displayVersion);
+            return 0;
+        }
+    }
+
+    nlohmann::json planPayload;
+    planPayload["subos"] = subos;
+    planPayload["name"] = displayName;
+    planPayload["version"] = displayVersion;
+    stream.emit(DataEvent{"remove_plan", planPayload.dump()});
+
+    if (!yes) {
+        std::string suffix = displayVersion.empty()
+            ? std::string{}
+            : "@" + displayVersion;
+        PromptEvent confirmReq;
+        confirmReq.id = "confirm_remove";
+        confirmReq.question = std::format(
+            "Remove {}{} from subos '{}' ?", displayName, suffix, subos);
+        confirmReq.options = {"y", "n"};
+        confirmReq.defaultValue = "n";
+        auto answer = stream.prompt(std::move(confirmReq));
+        if (answer != "y") {
+            log::println("cancelled");
+            return 0;
+        }
     }
 
     Installer installer(catalog);
@@ -349,7 +411,11 @@ int cmd_remove(const std::string& target, EventStream& stream) {
         return 1;
     }
 
-    stream.emit(DataEvent{"remove_summary", nlohmann::json{{"target", target}}.dump()});
+    nlohmann::json summaryPayload;
+    summaryPayload["subos"] = subos;
+    summaryPayload["name"] = displayName;
+    summaryPayload["version"] = displayVersion;
+    stream.emit(DataEvent{"remove_summary", summaryPayload.dump()});
     return 0;
 }
 

--- a/src/ui/info_panel.cppm
+++ b/src/ui/info_panel.cppm
@@ -224,15 +224,57 @@ void print_install_summary(int success, int failed) {
     std::println("");
 }
 
-// Print uninstall summary
-void print_remove_summary(const std::string& name) {
+// Format "<name>[@<version>]" for display. Centralized so the plan and
+// summary lines stay aligned when version is absent.
+inline std::string remove_target_label_(const std::string& name,
+                                        const std::string& version) {
+    if (version.empty()) return name;
+    return name + "@" + version;
+}
+
+// Print remove plan (shown before the confirmation prompt)
+void print_remove_plan(const std::string& subos,
+                       const std::string& name,
+                       const std::string& version) {
     using namespace ftxui;
+
+    auto label = remove_target_label_(name, version);
+
+    Elements rows;
+    rows.push_back(text(""));
+    rows.push_back(hbox({
+        text("  Package to remove:") | color(theme::text_color()),
+    }));
+    rows.push_back(text(""));
+    rows.push_back(hbox({
+        text("    " + std::string(theme::icon::package) + " ") | color(theme::magenta()),
+        text(label) | bold | color(theme::magenta()),
+        text("  (subos: " + subos + ")") | color(theme::dim_color()),
+    }));
+    rows.push_back(text(""));
+
+    auto doc = vbox(std::move(rows));
+    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(doc));
+    Render(screen, doc);
+    screen.Print();
+}
+
+// Print uninstall summary
+void print_remove_summary(const std::string& subos,
+                          const std::string& name,
+                          const std::string& version) {
+    using namespace ftxui;
+
+    auto label = remove_target_label_(name, version);
 
     Elements rows;
     rows.push_back(text(""));
     rows.push_back(hbox({
         text("  " + std::string(theme::icon::done) + " ") | color(theme::green()),
-        text(name + " removed") | color(theme::green()) | bold,
+        text(label + " removed") | color(theme::green()) | bold,
+        subos.empty()
+            ? text("")
+            : (text("  (subos: " + subos + ")") | color(theme::dim_color())),
     }));
     rows.push_back(text(""));
 

--- a/tests/e2e/subos_payload_refcount_test.sh
+++ b/tests/e2e/subos_payload_refcount_test.sh
@@ -63,12 +63,12 @@ NODE_VER_S2="$(
 [[ "$NODE_VER_S2" == "v22.17.1" ]] || fail "s2 node shim did not resolve to v22.17.1"
 
 run_xlings "$HOME_DIR" "$ROOT_DIR" subos use s1 >/dev/null
-REMOVE_S1="$(run_and_capture run_xlings "$HOME_DIR" "$ROOT_DIR" remove node)"
+REMOVE_S1="$(run_and_capture run_xlings "$HOME_DIR" "$ROOT_DIR" remove node -y)"
 [[ -x "$PAYLOAD_DIR/bin/node" ]] || fail "payload removed even though s2 still referenced it"
 [[ ! -e "$HOME_DIR/subos/s1/bin/node" ]] || fail "s1 shim still present after detach"
 
 run_xlings "$HOME_DIR" "$ROOT_DIR" subos use s2 >/dev/null
-REMOVE_S2="$(run_and_capture run_xlings "$HOME_DIR" "$ROOT_DIR" remove node)"
+REMOVE_S2="$(run_and_capture run_xlings "$HOME_DIR" "$ROOT_DIR" remove node -y)"
 [[ ! -e "$PAYLOAD_DIR" ]] || fail "payload still present after last subos reference was removed"
 [[ ! -e "$HOME_DIR/subos/s2/bin/node" ]] || fail "s2 shim still present after final remove"
 


### PR DESCRIPTION
## Summary

`xlings remove <pkg>` now prompts for confirmation before destructive uninstall and prints richer information about *what* is being removed.

### Before
- No prompt — typing `xlings remove gcc` goes straight to uninstall.
- Output: `gcc removed` (no version, no subos).

### After
- A plan panel is printed first:
  ```
    Package to remove:

      ◆ xim:gcc@15.1.0  (subos: default)
  ```
- A confirmation prompt with default **n** (uninstall is destructive — matches apt/dnf convention):
  ```
   ▸ Remove xim:gcc@15.1.0 from subos 'default' ?[y/N]
  ```
- Summary now includes subos + version:
  ```
    ✓ xim:gcc@15.1.0 removed  (subos: default)
  ```
- The existing global `-y` / `--yes` flag bypasses the prompt — same UX as `install`.

### Internal: hook-driven recursive removes stay silent
xpkgs can emit `pkgmanager.remove(...)` from their install hooks (e.g. `rust-crates-mirror.lua` cleans an old version when installing a new one). Those connected uninstalls now pass `yes=true` — the user already approved the parent install, no extra prompt.

### Resolve-active-version fix
The pre-resolve step uses `xvm::get_active_version` when the user did not pin a version. `catalog.resolve_target`'s default is the highest *declared* version, which would mis-report "not installed" when only an older active version is on disk (caught by the existing `remove_multi_version` e2e scenario 3).

## Files changed
- `src/core/xim/commands.cppm` — new `yes` parameter, plan event, prompt, active-version resolve.
- `src/cli.cppm` — pass `-y` through, handle `remove_plan` event.
- `src/capabilities.cppm` — accept `"yes": bool` in `remove_package` capability schema.
- `src/ui/info_panel.cppm` — `print_remove_plan` and updated `print_remove_summary` signature.
- `tests/e2e/subos_payload_refcount_test.sh` — add `-y` (relied on old no-prompt behavior).

## Test plan
- [x] `xmake build xlings` — passes
- [x] `xmake run xlings_tests` — 184 passed, 4 unrelated skipped
- [x] `tests/e2e/remove_multi_version_test.sh` — passes (covers active-version resolve fix in S3)
- [x] `tests/e2e/subos_payload_refcount_test.sh` — passes after `-y` update
- [x] `tests/e2e/script_type_install_test.sh` — passes (output shows the new summary line)
- [x] `tests/e2e/legacy_config_test.sh` / `sub_index_install_test.sh` — passes
- [x] Manual: piping `n` to `xlings remove <pkg>` cancels and prints `cancelled`; default-no-input also cancels via the `-n` default.