### PR TITLE
feat(cli): implement xlings update <pkg> for package upgrade

### DIFF
--- a/src/capabilities.cppm
+++ b/src/capabilities.cppm
@@ -121,15 +121,16 @@ public:
     auto spec() const -> CapabilitySpec override {
         return {
             .name = "update_packages",
-            .description = "Update package index or a specific package",
-            .inputSchema = R"({"type":"object","properties":{"target":{"type":"string","description":"Package name to update, or omit to update index"}}})",
+            .description = "Update package index or upgrade a specific package to the latest declared version",
+            .inputSchema = R"({"type":"object","properties":{"target":{"type":"string","description":"Package name to upgrade, or omit to refresh the index only"},"yes":{"type":"boolean","description":"Auto-confirm the upgrade prompt"}}})",
             .outputSchema = R"({"type":"object","properties":{"exitCode":{"type":"integer"}}})",
             .destructive = true,
         };
     }
     auto execute(Params params, EventStream& stream) -> Result override {
         auto json = nlohmann::json::parse(params, nullptr, false);
-        return exit_result(xim::cmd_update(json.value("target", ""), stream));
+        bool yes = json.value("yes", false);
+        return exit_result(xim::cmd_update(json.value("target", ""), yes, stream));
     }
 };
 

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -756,7 +756,8 @@ export int run(int argc, char* argv[]) {
                 std::string target;
                 if (args.positional_count() > 0)
                     target = std::string(args.positional(0));
-                return xim::cmd_update(target, stream);
+                bool yes = args.is_flag_set("yes");
+                return xim::cmd_update(target, yes, stream);
             })
 
         // search

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -686,7 +686,18 @@ int cmd_add_xpkg(const std::string& fileOrUrl, EventStream& stream) {
 }
 
 // === update command ===
-int cmd_update(const std::string& target, EventStream& stream) {
+//
+// Flow:
+//   xlings update            → sync index only (legacy behavior)
+//   xlings update <pkg>      → sync index, then upgrade <pkg> if a newer
+//                              version is declared in the catalog
+//   xlings update <pkg> -y   → same, skip the confirmation prompt
+//
+// Old payloads are NOT removed automatically — xlings is multi-version, and
+// keeping the previous install lets the user `xlings use <pkg> <oldver>` if
+// the upgrade misbehaves. We surface a hint at the end pointing at how to
+// remove old versions.
+int cmd_update(const std::string& target, bool yes, EventStream& stream) {
     // Sync repos
     if (!sync_all_repos(true)) {
         log::error("failed to sync repositories");
@@ -695,19 +706,76 @@ int cmd_update(const std::string& target, EventStream& stream) {
 
     // Force rebuild index (writes fresh cache)
     auto& catalog = get_catalog();
-    auto result = catalog.rebuild(true);
-    if (!result) {
-        log::error("failed to rebuild catalog: {}", result.error());
+    auto rebuildResult = catalog.rebuild(true);
+    if (!rebuildResult) {
+        log::error("failed to rebuild catalog: {}", rebuildResult.error());
         return 1;
     }
 
     log::println("index updated");
 
-    if (!target.empty()) {
-        // TODO: Upgrade specific package
-        log::println("package upgrade not yet implemented");
+    if (target.empty()) return 0;
+
+    auto match = catalog.resolve_target(target, detect_platform());
+    if (!match) {
+        log::error("{}", match.error());
+        return 1;
     }
 
+    auto bareName = match->name;
+    auto latest = match->version;
+    auto currentActive = xvm::get_active_version(
+        Config::effective_workspace(), bareName);
+
+    nlohmann::json planPayload;
+    planPayload["name"]    = match->canonicalName;
+    planPayload["current"] = currentActive;
+    planPayload["latest"]  = latest;
+    stream.emit(DataEvent{"update_plan", planPayload.dump()});
+
+    if (currentActive.empty()) {
+        log::warn("{} is not installed — run: xlings install {}",
+                  match->canonicalName, bareName);
+        return 0;
+    }
+
+    if (currentActive == latest) {
+        log::println("{}@{} is already the latest", match->canonicalName, currentActive);
+        return 0;
+    }
+
+    if (!yes) {
+        PromptEvent confirmReq;
+        confirmReq.id = "confirm_update";
+        confirmReq.question = std::format(
+            "Upgrade {} from {} to {} ?",
+            match->canonicalName, currentActive, latest);
+        confirmReq.options = {"y", "n"};
+        confirmReq.defaultValue = "y";
+        auto answer = stream.prompt(std::move(confirmReq));
+        if (answer != "y") {
+            log::println("cancelled");
+            return 0;
+        }
+    }
+
+    // Install the new version. cmd_install handles dependency resolution,
+    // download, hooks, and switches the active version on success. We pass
+    // yes=true because the user already confirmed the upgrade above (and
+    // hook-driven sub-installs should never re-prompt regardless).
+    std::vector<std::string> installTargets = { bareName + "@" + latest };
+    auto rc = cmd_install(installTargets, /*yes=*/true, /*noDeps=*/false, stream);
+    if (rc != 0) return rc;
+
+    nlohmann::json summaryPayload;
+    summaryPayload["name"] = match->canonicalName;
+    summaryPayload["from"] = currentActive;
+    summaryPayload["to"]   = latest;
+    stream.emit(DataEvent{"update_summary", summaryPayload.dump()});
+
+    log::println("upgraded {}: {} -> {}", match->canonicalName, currentActive, latest);
+    log::println("  old version retained — remove with: xlings remove {}@{}",
+                 bareName, currentActive);
     return 0;
 }
 

--- a/tests/e2e/update_package_test.sh
+++ b/tests/e2e/update_package_test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# E2E test for `xlings update <pkg>` (specific package upgrade).
+#
+# Scenarios:
+#   1. update non-installed pkg     → warn, exit 0
+#   2. update active=1.0.0          → upgrade to latest (2.0.0); old version
+#                                     remains installed (multi-version semantics)
+#   3. update again                 → "already the latest"; no install attempt
+#   4. bare `xlings update`         → only refreshes the index, exit 0
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/update_package"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+
+FIXTURE_PKG="$LOCAL_INDEX_DIR/pkgs/u/upgrade-fixture.lua"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+RUN() {
+  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+}
+
+mkdir -p "$HOME_DIR"
+
+# Private copy of the shared fixture index — neutralise the sub-index-repos
+# fetch so the test stays offline.
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$(dirname "$FIXTURE_PKG")"
+
+# Fixture: two versions, no URL (no downloads), simple install hook.
+cat > "$FIXTURE_PKG" <<'LUA'
+package = {
+    spec = "1",
+    name = "upgrade-fixture",
+    description = "Local fixture for tests/e2e/update_package_test.sh",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+
+    xpm = {
+        linux   = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+        windows = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mkdir(dir)
+    io.writefile(path.join(dir, "VERSION"), pkginfo.version())
+    return true
+end
+
+function config()
+    xvm.add("upgrade-fixture", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("upgrade-fixture")
+    return true
+end
+LUA
+
+# Seed XLINGS_HOME
+mkdir -p "$HOME_DIR/subos/default/bin"
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
+EOF
+
+log "Initializing sandbox XLINGS_HOME at $HOME_DIR"
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+STORE_DIR="$HOME_DIR/data/xpkgs/xim-x-upgrade-fixture"
+
+# ── Scenario 1: update on non-installed pkg → warn, exit 0 ─────────
+log "Scenario 1: update upgrade-fixture (not installed) → warn"
+OUT_S1="$(RUN update upgrade-fixture -y 2>&1)" || fail "S1: command exited non-zero"
+echo "$OUT_S1" | grep -q "is not installed" \
+  || fail "S1: expected 'is not installed' warning; got:\n$OUT_S1"
+
+# Confirm nothing was installed
+[[ ! -d "$STORE_DIR" ]] || fail "S1: store dir should not exist before install"
+
+# ── Scenario 2: install 1.0.0 first, then update → upgrade to 2.0.0 ─
+log "Install upgrade-fixture@1.0.0 (precondition for S2)"
+RUN install "upgrade-fixture@1.0.0" -y >/dev/null 2>&1 \
+  || fail "install upgrade-fixture@1.0.0 failed"
+[[ -f "$STORE_DIR/1.0.0/VERSION" ]] || fail "S2 setup: 1.0.0 marker missing"
+
+python3 - "$HOME_DIR" 1.0.0 <<'PY' || fail "S2 setup: workspace active version wrong"
+import json, sys, pathlib
+home, want = sys.argv[1:]
+ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
+got = (ws.get("workspace") or {}).get("upgrade-fixture")
+assert got == want, f"expected active={want}, got {got!r}"
+PY
+
+log "Scenario 2: update upgrade-fixture (1.0.0 → 2.0.0)"
+OUT_S2="$(RUN update upgrade-fixture -y 2>&1)" || fail "S2: command exited non-zero"
+echo "$OUT_S2" | grep -q "upgraded" \
+  || fail "S2: expected 'upgraded' summary; got:\n$OUT_S2"
+
+[[ -f "$STORE_DIR/1.0.0/VERSION" ]] \
+  || fail "S2: 1.0.0 payload should be retained (multi-version)"
+[[ -f "$STORE_DIR/2.0.0/VERSION" ]] \
+  || fail "S2: 2.0.0 payload should be installed"
+
+python3 - "$HOME_DIR" 2.0.0 <<'PY' || fail "S2 DB state wrong"
+import json, sys, pathlib
+home, want = sys.argv[1:]
+ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
+got = (ws.get("workspace") or {}).get("upgrade-fixture")
+assert got == want, f"S2: active should switch to {want}, got {got!r}"
+PY
+
+# ── Scenario 3: update again → already-latest no-op ─────────────────
+log "Scenario 3: update upgrade-fixture (already at 2.0.0) → no-op"
+OUT_S3="$(RUN update upgrade-fixture -y 2>&1)" || fail "S3: command exited non-zero"
+echo "$OUT_S3" | grep -q "already the latest" \
+  || fail "S3: expected 'already the latest'; got:\n$OUT_S3"
+
+# ── Scenario 4: bare `update` refreshes index, exits 0 ──────────────
+log "Scenario 4: bare update (no target) refreshes index"
+OUT_S4="$(RUN update 2>&1)" || fail "S4: command exited non-zero"
+echo "$OUT_S4" | grep -q "index updated" \
+  || fail "S4: expected 'index updated'; got:\n$OUT_S4"
+
+log "PASS: update <pkg> scenarios 1, 2, 3, 4"


### PR DESCRIPTION
## Summary

`xlings update <pkg>` previously printed `package upgrade not yet implemented` and silently no-op'd — it only refreshed the index. This PR implements the actual upgrade flow.

### Behavior

| Command | Before | After |
|---|---|---|
| `xlings update` | Refresh index | Refresh index (unchanged) |
| `xlings update gcc` | Refresh + print "not yet implemented" | Refresh + check active vs latest, prompt, upgrade if newer |
| `xlings update gcc -y` | Same as above | Skip the prompt |

### Flow

1. Sync repos + rebuild catalog (existing behavior)
2. Resolve `<pkg>` → latest declared version from catalog
3. Look up active version from `xvm::get_active_version`
4. Emit `update_plan` event with `{name, current, latest}`
5. If not installed → warn + exit 0 (point at `xlings install`)
6. If `current == latest` → "already the latest" + exit 0
7. Otherwise prompt (`default y`, since this is non-destructive — the old payload is retained); `-y` skips
8. Delegate to `cmd_install("<pkg>@<latest>", yes=true)` for download + dep resolution + active-version switch
9. Emit `update_summary`, print upgrade summary + hint about cleaning up the old version

### Why default y for update (vs default n for remove)

Update doesn't delete anything — xlings is multi-version, so the old payload stays at `data/xpkgs/...` and is reachable via `xlings use <pkg>@<oldver>` if the upgrade misbehaves. Remove deletes payload, so it gets default `n`.

### Files changed

- `src/core/xim/commands.cppm` — `cmd_update` rewritten to do real upgrade, signature now takes `bool yes`
- `src/cli.cppm` — `update` subcommand action passes `-y` through
- `src/capabilities.cppm` — `update_packages` capability schema gains `"yes": bool`
- `tests/e2e/update_package_test.sh` — new e2e test, 4 scenarios

## Test plan
- [x] `xmake build xlings` — passes
- [x] `tests/e2e/update_package_test.sh` — 4/4 scenarios pass (not-installed, upgrade, already-latest, bare-update)
- [x] `tests/e2e/remove_multi_version_test.sh` — still passes (sanity)
- [x] `tests/e2e/script_type_install_test.sh` — still passes (sanity)