### PR TITLE
feat(subos): route create/use/remove through EventStream

### DIFF
--- a/src/capabilities.cppm
+++ b/src/capabilities.cppm
@@ -307,11 +307,14 @@ public:
             .destructive = true,
         };
     }
-    auto execute(Params params, EventStream&) -> Result override {
+    auto execute(Params params, EventStream& stream) -> Result override {
         auto json = nlohmann::json::parse(params, nullptr, false);
         auto name = json.value("name", "");
         auto dir  = json.value("dir", "");
-        return exit_result(subos::create(name, dir.empty() ? std::filesystem::path{} : std::filesystem::path{dir}));
+        return exit_result(subos::create(
+            name,
+            dir.empty() ? std::filesystem::path{} : std::filesystem::path{dir},
+            stream));
     }
 };
 
@@ -326,9 +329,9 @@ public:
             .destructive = true,
         };
     }
-    auto execute(Params params, EventStream&) -> Result override {
+    auto execute(Params params, EventStream& stream) -> Result override {
         auto json = nlohmann::json::parse(params, nullptr, false);
-        return exit_result(subos::use(json.value("name", "")));
+        return exit_result(subos::use(json.value("name", ""), stream));
     }
 };
 
@@ -343,9 +346,9 @@ public:
             .destructive = true,
         };
     }
-    auto execute(Params params, EventStream&) -> Result override {
+    auto execute(Params params, EventStream& stream) -> Result override {
         auto json = nlohmann::json::parse(params, nullptr, false);
-        return exit_result(subos::remove(json.value("name", "")));
+        return exit_result(subos::remove(json.value("name", ""), stream));
     }
 };
 

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -146,6 +146,17 @@ static void dispatch_data_event(const DataEvent& e) {
         }
         ui::print_subos_list(entries);
     }
+    else if (e.kind == "subos_created") {
+        ui::print_subos_created(
+            json.value("name", ""), json.value("dir", ""));
+    }
+    else if (e.kind == "subos_switched") {
+        ui::print_subos_switched(
+            json.value("name", ""), json.value("dir", ""));
+    }
+    else if (e.kind == "subos_removed") {
+        ui::print_subos_removed(json.value("name", ""));
+    }
     else if (e.kind == "search_results") {
         std::vector<std::pair<std::string, std::string>> results;
         if (json.contains("results") && json["results"].is_array()) {
@@ -507,13 +518,28 @@ export int run(int argc, char* argv[]) {
 
     // Create EventStream for core→UI decoupling
     EventStream stream;
-    // Default TUI consumer for CLI mode (will be toggled in agent mode)
+    // Default TUI consumer for CLI mode (will be toggled in agent mode).
+    // ErrorEvent/LogEvent surfacing keeps capability-emitted errors visible
+    // to CLI users — without it, anything that emits an ErrorEvent (subos
+    // operations, repo helpers) would silently fail in CLI mode.
     int tui_listener = stream.on_event([&stream](const Event& e) {
         if (auto* d = std::get_if<DataEvent>(&e)) {
             dispatch_data_event(*d);
         }
-        if (auto* p = std::get_if<PromptEvent>(&e)) {
+        else if (auto* p = std::get_if<PromptEvent>(&e)) {
             handle_prompt(stream, *p);
+        }
+        else if (auto* er = std::get_if<ErrorEvent>(&e)) {
+            log::error("{}", er->message);
+            if (!er->hint.empty()) log::error("  {}", er->hint);
+        }
+        else if (auto* l = std::get_if<LogEvent>(&e)) {
+            switch (l->level) {
+                case LogLevel::debug: log::debug("{}", l->message); break;
+                case LogLevel::info:  log::info("{}",  l->message); break;
+                case LogLevel::warn:  log::warn("{}",  l->message); break;
+                case LogLevel::error: log::error("{}", l->message); break;
+            }
         }
     });
 

--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -65,25 +65,43 @@ export std::vector<SubosInfo> list_all() {
     return result;
 }
 
-void update_current_symlink_(const fs::path& homeDir, const fs::path& targetDir) {
+void update_current_symlink_(EventStream& stream,
+                              const fs::path& homeDir,
+                              const fs::path& targetDir) {
     auto linkPath = homeDir / "subos" / "current";
     std::error_code ec;
     fs::remove(linkPath, ec);
     fs::create_directory_symlink(targetDir, linkPath, ec);
-    if (ec) log::error("[xlings:subos] failed to update current symlink: {}", ec.message());
+    if (ec) {
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::Permission,
+            .message = "failed to update current symlink: " + ec.message(),
+            .recoverable = true,
+        });
+    }
 }
 
-export int create(const std::string& name, const fs::path& customDir = {}) {
+export int create(const std::string& name, const fs::path& customDir,
+                  EventStream& stream) {
     auto& p = Config::paths();
 
     if (name == "current") {
-        log::error("[xlings:subos] 'current' is reserved");
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::InvalidInput,
+            .message = "'current' is a reserved subos name",
+            .recoverable = false,
+        });
         return 1;
     }
 
     for (char c : name) {
         if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_' && c != '-') {
-            log::error("[xlings:subos] invalid name: {}", name);
+            stream.emit(ErrorEvent{
+                .code = ErrorCode::InvalidInput,
+                .message = "invalid subos name: '" + name
+                           + "' (allowed: alphanumeric, underscore, dash)",
+                .recoverable = false,
+            });
             return 1;
         }
     }
@@ -91,7 +109,11 @@ export int create(const std::string& name, const fs::path& customDir = {}) {
     auto configPath = p.homeDir / ".xlings.json";
     auto json = read_config_json_(configPath);
     if (json.contains("subos") && json["subos"].contains(name)) {
-        log::error("[xlings:subos] '{}' already exists", name);
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::InvalidInput,
+            .message = "subos '" + name + "' already exists",
+            .recoverable = false,
+        });
         return 1;
     }
 
@@ -122,19 +144,25 @@ export int create(const std::string& name, const fs::path& customDir = {}) {
     json["subos"][name] = {{"dir", customDir.empty() ? "" : customDir.string()}};
     write_config_json_(configPath, json);
 
-    log::println("[xlings:subos] created '{}'", name);
-    log::println("  dir: {}", dir.string());
+    nlohmann::json payload;
+    payload["name"] = name;
+    payload["dir"]  = dir.string();
+    stream.emit(DataEvent{"subos_created", payload.dump()});
     return 0;
 }
 
-export int use(const std::string& name) {
+export int use(const std::string& name, EventStream& stream) {
     auto& p = Config::paths();
     auto configPath = p.homeDir / ".xlings.json";
     auto json = read_config_json_(configPath);
 
     if (!json.contains("subos") || !json["subos"].contains(name)) {
-        log::error("[xlings:subos] '{}' not found", name);
-        log::error("  run: xlings subos new {}", name);
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::NotFound,
+            .message = "subos '" + name + "' not found",
+            .recoverable = true,
+            .hint = "create it first: xlings subos new " + name,
+        });
         return 1;
     }
 
@@ -142,22 +170,33 @@ export int use(const std::string& name) {
     write_config_json_(configPath, json);
 
     auto dir = Config::subos_dir(name);
-    update_current_symlink_(p.homeDir, dir);
+    update_current_symlink_(stream, p.homeDir, dir);
 
-    log::println("[xlings:subos] switched to '{}' ({})", name, dir.string());
+    nlohmann::json payload;
+    payload["name"] = name;
+    payload["dir"]  = dir.string();
+    stream.emit(DataEvent{"subos_switched", payload.dump()});
     return 0;
 }
 
-export int remove(const std::string& name) {
+export int remove(const std::string& name, EventStream& stream) {
     if (name == "default") {
-        log::error("[xlings:subos] cannot remove the default subos");
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::InvalidInput,
+            .message = "cannot remove the 'default' subos",
+            .recoverable = false,
+        });
         return 1;
     }
 
     auto& p = Config::paths();
     if (p.activeSubos == name) {
-        log::error("[xlings:subos] cannot remove the active subos '{}'", name);
-        log::error("  switch first: xlings subos use default");
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::InvalidInput,
+            .message = "cannot remove the active subos '" + name + "'",
+            .recoverable = true,
+            .hint = "switch first: xlings subos use default",
+        });
         return 1;
     }
 
@@ -165,7 +204,11 @@ export int remove(const std::string& name) {
     auto json = read_config_json_(configPath);
 
     if (!json.contains("subos") || !json["subos"].contains(name)) {
-        log::error("[xlings:subos] '{}' not found", name);
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::NotFound,
+            .message = "subos '" + name + "' not found",
+            .recoverable = true,
+        });
         return 1;
     }
 
@@ -174,7 +217,11 @@ export int remove(const std::string& name) {
         std::error_code ec;
         fs::remove_all(dir, ec);
         if (ec) {
-            log::error("[xlings:subos] failed to remove {}: {}", dir.string(), ec.message());
+            stream.emit(ErrorEvent{
+                .code = ErrorCode::Permission,
+                .message = "failed to remove " + dir.string() + ": " + ec.message(),
+                .recoverable = false,
+            });
             return 1;
         }
     }
@@ -182,7 +229,9 @@ export int remove(const std::string& name) {
     json["subos"].erase(name);
     write_config_json_(configPath, json);
 
-    log::println("[xlings:subos] removed '{}'", name);
+    nlohmann::json payload;
+    payload["name"] = name;
+    stream.emit(DataEvent{"subos_removed", payload.dump()});
     return 0;
 }
 
@@ -224,7 +273,11 @@ int run_info_(const std::string& name, EventStream& stream) {
     auto target = name.empty() ? p.activeSubos : name;
     auto si = info(target);
     if (!si) {
-        log::error("[xlings:subos] '{}' not found", target);
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::NotFound,
+            .message = "subos '" + target + "' not found",
+            .recoverable = true,
+        });
         return 1;
     }
     nlohmann::json fieldsJson = nlohmann::json::array();
@@ -246,23 +299,31 @@ export int run(int argc, char* argv[], EventStream& stream) {
     if (sub == "rm") sub = "remove";
     if (sub == "i")  sub = "info";
 
+    auto usageError = [&](std::string_view detail) {
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::InvalidInput,
+            .message = std::string(detail),
+            .recoverable = false,
+            .hint = "usage: xlings subos <new|use|list|ls|remove|rm|info|i> [name]",
+        });
+    };
+
     if (sub == "new") {
-        if (argc < 4) { log::error("usage: xlings subos new <name>"); return 1; }
-        return create(argv[3]);
+        if (argc < 4) { usageError("missing <name> for: xlings subos new"); return 1; }
+        return create(argv[3], {}, stream);
     }
     if (sub == "use") {
-        if (argc < 4) { log::error("usage: xlings subos use <name>"); return 1; }
-        return use(argv[3]);
+        if (argc < 4) { usageError("missing <name> for: xlings subos use"); return 1; }
+        return use(argv[3], stream);
     }
     if (sub == "list")   return run_list_(stream);
     if (sub == "remove") {
-        if (argc < 4) { log::error("usage: xlings subos remove|rm <name>"); return 1; }
-        return remove(argv[3]);
+        if (argc < 4) { usageError("missing <name> for: xlings subos remove|rm"); return 1; }
+        return remove(argv[3], stream);
     }
     if (sub == "info")   return run_info_(argc > 3 ? argv[3] : "", stream);
 
-    log::error("[xlings:subos] unknown subcommand: {}", sub);
-    log::error("usage: xlings subos <new|use|list|ls|remove|rm|info|i> [name]");
+    usageError("unknown subcommand: " + sub);
     return 1;
 }
 

--- a/src/ui/info_panel.cppm
+++ b/src/ui/info_panel.cppm
@@ -196,6 +196,41 @@ void print_subos_list(
     std::println("");
 }
 
+// Subos status messages are single-line with a possibly-long path. ftxui
+// hbox layout truncates them to the detected terminal width (80 cols when
+// TERM is unset), so use plain std::print + raw ANSI here instead — the
+// content has to stay readable in CI / pipes / non-TTY contexts.
+namespace subos_ansi_ {
+    constexpr auto reset  = "\033[0m";
+    constexpr auto bold   = "\033[1m";
+    constexpr auto cyan   = "\033[38;2;34;211;238m";
+    constexpr auto green  = "\033[38;2;34;197;94m";
+    constexpr auto gray   = "\033[38;2;148;163;184m";
+}
+
+void print_subos_created(const std::string& name, const std::string& dir) {
+    using namespace subos_ansi_;
+    std::println("{}  ✓ subos created: {}{}{}{}", green, bold, name, reset, reset);
+    if (!dir.empty()) {
+        std::println("{}    dir:{} {}", gray, reset, dir);
+    }
+}
+
+void print_subos_switched(const std::string& name, const std::string& dir) {
+    using namespace subos_ansi_;
+    if (dir.empty()) {
+        std::println("{}  ▸ switched to subos {}{}{}", cyan, bold, name, reset);
+    } else {
+        std::println("{}  ▸ switched to subos {}{}{}{}  ({}){}",
+                     cyan, bold, name, reset, cyan, dir, reset);
+    }
+}
+
+void print_subos_removed(const std::string& name) {
+    using namespace subos_ansi_;
+    std::println("{}  ✓ subos removed: {}{}{}", green, bold, name, reset);
+}
+
 // Print install summary with success/fail counts
 void print_install_summary(int success, int failed) {
     using namespace ftxui;

--- a/tests/e2e/subos_events_test.sh
+++ b/tests/e2e/subos_events_test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# E2E test for subos commands routed through EventStream:
+# every subos create/use/remove must surface either a DataEvent
+# (rendered as a styled "subos created/switched/removed" line) or
+# an ErrorEvent (rendered via log::error with optional hint).
+#
+# Scenarios:
+#   1. create good name              → success line
+#   2. create reserved 'current'     → InvalidInput error
+#   3. create invalid char           → InvalidInput error
+#   4. create duplicate              → InvalidInput error
+#   5. switch to non-existent        → NotFound error + hint
+#   6. switch to existing            → success line
+#   7. remove the active subos       → InvalidInput error + hint
+#   8. remove 'default'              → InvalidInput error
+#   9. remove a non-existent         → NotFound error
+#  10. switch back + remove          → success line, dir gone
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/subos_events"
+HOME_DIR="$RUNTIME_DIR/home"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+RUN() {
+  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+}
+
+mkdir -p "$HOME_DIR/subos/default/bin"
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+
+log "Initializing sandbox XLINGS_HOME at $HOME_DIR"
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+
+# Strip ANSI color sequences for portable substring matching.
+strip_ansi() { sed -E 's/\x1b\[[0-9;]*m//g'; }
+
+assert_contains() {
+  local needle=$1 haystack=$2 context=$3
+  local clean
+  clean="$(echo "$haystack" | strip_ansi)"
+  echo "$clean" | grep -Fq -- "$needle" \
+    || fail "$context: expected to find '$needle' in output:\n$clean"
+}
+
+# ── 1. create good name ───────────────────────────────────────────
+log "Scenario 1: create good name"
+OUT="$(RUN subos new s1 2>&1)" || fail "S1: create exited non-zero"
+assert_contains "subos created: s1" "$OUT" "S1"
+[[ -d "$HOME_DIR/subos/s1/bin" ]] || fail "S1: subos dir not created"
+
+# ── 2. create reserved 'current' ──────────────────────────────────
+log "Scenario 2: create 'current' (reserved)"
+OUT="$(RUN subos new current 2>&1)" || true
+assert_contains "'current' is a reserved" "$OUT" "S2"
+
+# ── 3. create invalid char ────────────────────────────────────────
+log "Scenario 3: create invalid name"
+OUT="$(RUN subos new "bad name" 2>&1)" || true
+assert_contains "invalid subos name" "$OUT" "S3"
+
+# ── 4. create duplicate ───────────────────────────────────────────
+log "Scenario 4: create duplicate"
+OUT="$(RUN subos new s1 2>&1)" || true
+assert_contains "already exists" "$OUT" "S4"
+
+# ── 5. switch non-existent ────────────────────────────────────────
+log "Scenario 5: switch to non-existent"
+OUT="$(RUN subos use nope 2>&1)" || true
+assert_contains "subos 'nope' not found" "$OUT" "S5"
+assert_contains "create it first" "$OUT" "S5 hint"
+
+# ── 6. switch to existing ─────────────────────────────────────────
+log "Scenario 6: switch to existing"
+OUT="$(RUN subos use s1 2>&1)" || fail "S6: switch exited non-zero"
+assert_contains "switched to subos s1" "$OUT" "S6"
+
+# ── 7. remove active subos ────────────────────────────────────────
+log "Scenario 7: remove active subos"
+OUT="$(RUN subos remove s1 2>&1)" || true
+assert_contains "cannot remove the active subos" "$OUT" "S7"
+assert_contains "switch first" "$OUT" "S7 hint"
+
+# ── 8. remove 'default' ───────────────────────────────────────────
+log "Scenario 8: remove 'default'"
+RUN subos use default >/dev/null 2>&1
+OUT="$(RUN subos remove default 2>&1)" || true
+assert_contains "cannot remove the 'default' subos" "$OUT" "S8"
+
+# ── 9. remove non-existent ────────────────────────────────────────
+log "Scenario 9: remove non-existent"
+OUT="$(RUN subos remove nope 2>&1)" || true
+assert_contains "subos 'nope' not found" "$OUT" "S9"
+
+# ── 10. switch back to default + remove s1 ────────────────────────
+log "Scenario 10: remove s1 cleanly"
+OUT="$(RUN subos remove s1 2>&1)" || fail "S10: remove exited non-zero"
+assert_contains "subos removed: s1" "$OUT" "S10"
+[[ ! -d "$HOME_DIR/subos/s1" ]] || fail "S10: subos dir still on disk"
+
+log "PASS: subos events scenarios 1-10"


### PR DESCRIPTION
## Summary

`subos::create/use/remove` were calling `log::error` / `log::println` directly. The capability layer (`CreateSubos` / `SwitchSubos` / `RemoveSubos` in `capabilities.cppm`) already received an `EventStream&` but threw it away — non-CLI consumers (NDJSON interface, agents) saw nothing when these operations ran.

## What changed

### `src/core/subos.cppm` — events instead of log calls
`create/use/remove` now take `EventStream&` and emit:

- **ErrorEvent** (with `ErrorCode` + `recoverable` + optional `hint`) for every error path that used to be `log::error`. Maps to NDJSON `kind:error` with stable `E_*` codes (existing wire format).
- **DataEvent** for every success path that used to be `log::println`:
  - `subos_created`   `{name, dir}`
  - `subos_switched`  `{name, dir}`
  - `subos_removed`   `{name}`

### `src/capabilities.cppm` — pass stream through
`CreateSubos`, `SwitchSubos`, `RemoveSubos` now thread `stream` into the underlying calls.

### `src/cli.cppm` — surface ErrorEvent/LogEvent for CLI users
The default TUI consumer gains handlers for `ErrorEvent` and `LogEvent`. Without this, anything that emits an `ErrorEvent` (the new subos paths, AddRepo/RemoveRepo from PR #226) would silently fail in CLI mode — the existing capability code had this bug too. Side-effect fix.

### `src/ui/info_panel.cppm` — new dispatch helpers
`print_subos_{created,switched,removed}` use plain `std::print` + ANSI escapes rather than ftxui hbox layout. ftxui falls back to 80-col width when `TERM` is unset (CI / pipes), and the dir paths in these messages frequently exceed that width; ftxui silently truncates mid-message. Single-line status messages don't need ftxui's layout engine.

## Tests

- New `tests/e2e/subos_events_test.sh` (10 scenarios): create good, create reserved, create invalid char, create duplicate, switch non-existent (verifies hint surfaces), switch existing, remove active (verifies hint), remove default, remove non-existent, remove cleanly.
- Validated `tests/e2e/subos_payload_refcount_test.sh` (uses `subos use`) still passes.
- Unit tests: 184 passed (4 unrelated skips, same as `main`).

## Test plan
- [x] `xmake build xlings` — passes
- [x] `xmake run xlings_tests` — 184 passed, 4 unrelated skips
- [x] `tests/e2e/subos_events_test.sh` — 10/10 pass
- [x] `tests/e2e/subos_payload_refcount_test.sh` — passes