### PR TITLE
fix(install): make install idempotent w.r.t. the active version

### DIFF
--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -80,8 +80,36 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
     std::vector<std::string> targetVec(targets.begin(), targets.end());
     std::vector<PackageMatch> requestedMatches;
 
+    // Idempotency: `install` is NOT supposed to be a silent upgrader.
+    // If the package already has a version active in the current sub-OS
+    // that satisfies the user's request — bare name (no @ver) accepts
+    // anything, `name@<prefix>` accepts any active version starting with
+    // the prefix — pin the resolution to that exact version. The existing
+    // "all packages already installed" fast path takes it from there.
+    // For deliberate upgrades, users should run `xlings update <pkg>`.
+    auto pin_to_active_if_satisfies_ = [&](const std::string& t) -> std::string {
+        auto at        = t.find('@');
+        auto namePart  = (at == std::string::npos) ? t : t.substr(0, at);
+        auto verHint   = (at == std::string::npos) ? std::string{} : t.substr(at + 1);
+        auto bareName  = namePart.substr(namePart.rfind(':') + 1);
+        auto active    = xvm::get_active_version(
+                            Config::effective_workspace(), bareName);
+        if (active.empty()) return t;
+        if (verHint.empty() || active.rfind(verHint, 0) == 0) {
+            return namePart + "@" + active;
+        }
+        return t;
+    };
+
     for (auto& target : targetVec) {
-        auto match = catalog.resolve_target(target, platform);
+        auto pinned = pin_to_active_if_satisfies_(target);
+        auto match = catalog.resolve_target(pinned, platform);
+        if (!match && pinned != target) {
+            // Active version no longer in the catalog (xpm declaration changed
+            // since install) — fall back to the original target so the user
+            // still gets a useful resolve / error / fuzzy-match path.
+            match = catalog.resolve_target(target, platform);
+        }
         if (!match) {
             // Ambiguous matches: show error directly, don't fall through to fuzzy
             if (match.error().contains("ambiguous")) {
@@ -135,11 +163,16 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
                     return 0;
                 }
             }
-            // Update target so dependency resolution uses the resolved name
-            target = match->canonicalName;
-            if (!match->version.empty()) {
-                target += "@" + match->version;
-            }
+        }
+        // Update target to the canonical "<ns:name>@<version>" form so that
+        // the downstream dependency resolver (which calls resolve_target
+        // again on each item in targetVec) lands on this exact version.
+        // Without this, pin_to_active_if_satisfies_ above is silently undone
+        // when the resolver picks the catalog's highest-declared version for
+        // bare-name targets.
+        target = match->canonicalName;
+        if (!match->version.empty()) {
+            target += "@" + match->version;
         }
         requestedMatches.push_back(*match);
     }

--- a/tests/e2e/install_idempotent_test.sh
+++ b/tests/e2e/install_idempotent_test.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# E2E test: `xlings install` must be idempotent in the current sub-OS.
+#
+# Bug being fixed: `install` was silently upgrading to the catalog's
+# highest declared version whenever the user typed a bare name (or a
+# version prefix) and any version was already active in the sub-OS.
+# `install` should be a no-op in that case; users wanting an upgrade
+# should use `xlings update <pkg>`.
+#
+# Scenarios:
+#   1. install bare name, fresh subos     → installs latest declared
+#                                           (baseline behavior, unchanged)
+#   2. install bare name, 1.0.0 active    → "all packages already installed"
+#                                           (NO upgrade to 2.0.0)
+#   3. install <name>@1, 1.0.0 active     → "all packages already installed"
+#                                           (active matches the prefix)
+#   4. install <name>@2, 1.0.0 active     → installs 2.0.0
+#                                           (active doesn't match prefix)
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/install_idempotent"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+
+FIXTURE_PKG="$LOCAL_INDEX_DIR/pkgs/i/idempotent-fixture.lua"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+RUN() {
+  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+}
+
+mkdir -p "$HOME_DIR"
+
+# Private copy of the shared fixture index — neutralise sub-index repos
+# so the test stays offline.
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$(dirname "$FIXTURE_PKG")"
+
+# Two declared versions; install hook writes a marker file so we can
+# verify on disk which versions are present.
+cat > "$FIXTURE_PKG" <<'LUA'
+package = {
+    spec = "1",
+    name = "idempotent-fixture",
+    description = "Local fixture for tests/e2e/install_idempotent_test.sh",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+
+    xpm = {
+        linux   = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+        windows = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mkdir(dir)
+    io.writefile(path.join(dir, "VERSION"), pkginfo.version())
+    return true
+end
+
+function config()
+    xvm.add("idempotent-fixture", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("idempotent-fixture")
+    return true
+end
+LUA
+
+# Seed XLINGS_HOME pointing at the private (neutralised) index
+mkdir -p "$HOME_DIR/subos/default/bin"
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
+EOF
+
+log "Initializing sandbox XLINGS_HOME at $HOME_DIR"
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+STORE_DIR="$HOME_DIR/data/xpkgs/xim-x-idempotent-fixture"
+
+# ── Scenario 1: bare name, fresh subos → installs latest declared ─
+log "Scenario 1: install idempotent-fixture (fresh subos) → install 2.0.0"
+RUN install idempotent-fixture -y >/dev/null 2>&1 \
+  || fail "S1: install failed"
+[[ -f "$STORE_DIR/2.0.0/VERSION" ]] \
+  || fail "S1: latest version 2.0.0 should have been installed"
+[[ ! -d "$STORE_DIR/1.0.0" ]] \
+  || fail "S1: 1.0.0 should NOT have been installed"
+
+# Reset to install only 1.0.0 so subsequent scenarios start with that as active
+log "Reset: remove 2.0.0, install 1.0.0 explicitly"
+RUN remove idempotent-fixture -y >/dev/null 2>&1 || fail "reset: remove failed"
+RUN install idempotent-fixture@1.0.0 -y >/dev/null 2>&1 \
+  || fail "reset: install 1.0.0 failed"
+[[ -f "$STORE_DIR/1.0.0/VERSION" ]] || fail "reset: 1.0.0 should be on disk"
+[[ ! -d "$STORE_DIR/2.0.0" ]] || fail "reset: 2.0.0 should NOT be on disk"
+
+python3 - "$HOME_DIR" 1.0.0 <<'PY' || fail "reset: workspace active version wrong"
+import json, sys, pathlib
+home, want = sys.argv[1:]
+ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
+got = (ws.get("workspace") or {}).get("idempotent-fixture")
+assert got == want, f"expected active={want}, got {got!r}"
+PY
+
+# ── Scenario 2: bare name with 1.0.0 active → no upgrade ───────────
+log "Scenario 2: install idempotent-fixture (1.0.0 active) → no upgrade"
+OUT_S2="$(RUN install idempotent-fixture -y 2>&1)" || fail "S2: install exited non-zero"
+echo "$OUT_S2" | grep -q "already installed" \
+  || fail "S2: expected 'already installed'; got:\n$OUT_S2"
+[[ ! -d "$STORE_DIR/2.0.0" ]] \
+  || fail "S2: 2.0.0 must NOT be installed (this is the bug being fixed)"
+
+# ── Scenario 3: name@<prefix> matches active → no upgrade ──────────
+log "Scenario 3: install idempotent-fixture@1 (1.0.0 active) → no upgrade"
+OUT_S3="$(RUN install idempotent-fixture@1 -y 2>&1)" || fail "S3: install exited non-zero"
+echo "$OUT_S3" | grep -q "already installed" \
+  || fail "S3: expected 'already installed'; got:\n$OUT_S3"
+[[ ! -d "$STORE_DIR/2.0.0" ]] \
+  || fail "S3: 2.0.0 must NOT be installed (prefix match against active)"
+
+# ── Scenario 4: name@<prefix> doesn't match active → install latest 2.x ─
+log "Scenario 4: install idempotent-fixture@2 (1.0.0 active) → install 2.0.0"
+RUN install idempotent-fixture@2 -y >/dev/null 2>&1 \
+  || fail "S4: install failed"
+[[ -f "$STORE_DIR/2.0.0/VERSION" ]] \
+  || fail "S4: 2.0.0 should have been installed"
+[[ -f "$STORE_DIR/1.0.0/VERSION" ]] \
+  || fail "S4: 1.0.0 should still be retained"
+
+log "PASS: install idempotency scenarios 1, 2, 3, 4"


### PR DESCRIPTION
## Summary

`xlings install <pkg>` was silently **upgrading** to the catalog's highest declared version whenever the user typed a bare name (no `@`) or a version prefix that resolves to a higher version than the one currently active in the sub-OS. `install` should be idempotent — deliberate upgrades belong in `xlings update <pkg>` (#230).

## Trace of the bug (bare name case)

User has `gcc@9.4.0` active in current sub-OS, runs `xlings install gcc`:

1. `catalog.resolve_target("gcc", platform)` → `select_version_` with empty hint returns the **highest declared** version (e.g. `15.1.0`).
2. `match.installed` checks `xpkgs/.../gcc/15.1.0/` on disk → `false` (user has 9.4.0, not 15.1.0).
3. `plan.pending_count() > 0` → install proceeds → 15.1.0 gets downloaded and replaces 9.4.0 as active.

The user thought they were no-op'ing an existing install; they actually got a silent upgrade.

## Fix

Before `catalog.resolve_target`, if the **active version of the target package in the current sub-OS** satisfies the user's request, pin the lookup to that exact version. The existing "all packages already installed" fast path then takes it.

| Input | Active version in current sub-OS | Behavior after fix |
|---|---|---|
| `install gcc` | `9.4.0` | "all packages already installed", no upgrade |
| `install gcc@15` | `15.0.0` | "all packages already installed" (prefix match) |
| `install gcc@15` | `9.4.0` | install 15.x (active doesn't match prefix — user opted in) |
| `install gcc` | (none) | install latest declared (baseline, unchanged) |
| `install gcc@9.4.0` | `9.4.0` | "all packages already installed" (already worked correctly) |

If the active version is no longer in the catalog (e.g. xpm declaration changed since install), we fall back to the original target so `resolve_target` / fuzzy match still produces a useful error path.

## Latent issue also fixed

`target` was only being rewritten to the canonical `<ns>:<name>@<version>` form **inside the fuzzy-fallback branch** of the resolve loop. The dependency resolver (`resolve(catalog, targetVec, ...)`) calls `resolve_target` again on each item in `targetVec`, so a bare-name target would silently re-resolve to the catalog's highest declared version and undo the pin. Now `target` is always rewritten after a successful match.

## Test plan

- [x] `xmake build xlings` — passes
- [x] `xmake run xlings_tests` — 184 pass, 4 unrelated skips (same as `main`)
- [x] **New** `tests/e2e/install_idempotent_test.sh` — 4 scenarios:
  1. fresh sub-OS, bare name → installs latest (baseline)
  2. 1.0.0 active, bare name → no upgrade
  3. 1.0.0 active, `@1` prefix → no upgrade (prefix match against active)
  4. 1.0.0 active, `@2` prefix → installs 2.0.0 (active doesn't match prefix)
- [x] `tests/e2e/remove_multi_version_test.sh` — passes
- [x] `tests/e2e/script_type_install_test.sh` — passes
- [x] `tests/e2e/subos_payload_refcount_test.sh` — passes
- [x] `tests/e2e/legacy_config_test.sh` — passes
- [x] `tests/e2e/sub_index_install_test.sh` — passes