### PR TITLE
chore(release): bump version to 0.4.5

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.4";
+    static constexpr std::string_view VERSION = "0.4.5";
     static constexpr std::string_view REPO = "https://github.com/d2learn/xlings";
 };
 


### PR DESCRIPTION
Bumps `Info::VERSION` in `src/core/config.cppm` from 0.4.4 → 0.4.5 in preparation for the 0.4.5 release.

Highlights since 0.4.4:
- #229 `xlings remove <pkg>` confirms before removing and shows subos+version on plan & summary
- #230 `xlings update <pkg>` actually upgrades (was a TODO no-op before)
- #231 SubOS create/use/remove route through EventStream (with `ErrorCode` + hints)
- #232 `xlings install` is now idempotent in the current sub-OS — no more silent upgrades; use `update` for that