### PR TITLE
feat(install): keep active version on install; add --use to switch

### DIFF
--- a/src/capabilities.cppm
+++ b/src/capabilities.cppm
@@ -50,7 +50,7 @@ public:
         return {
             .name = "install_packages",
             .description = "Install one or more packages",
-            .inputSchema = R"({"type":"object","properties":{"targets":{"type":"array","items":{"type":"string"},"description":"Format: name, name@version, or namespace:name@version"},"yes":{"type":"boolean","description":"Auto-confirm without prompting"},"noDeps":{"type":"boolean","description":"Skip dependency installation"},"global":{"type":"boolean","description":"Install to global scope"}},"required":["targets"]})",
+            .inputSchema = R"({"type":"object","properties":{"targets":{"type":"array","items":{"type":"string"},"description":"Format: name, name@version, or namespace:name@version"},"yes":{"type":"boolean","description":"Auto-confirm without prompting"},"noDeps":{"type":"boolean","description":"Skip dependency installation"},"global":{"type":"boolean","description":"Install to global scope"},"useAfterInstall":{"type":"boolean","description":"Activate the installed version even if another version is currently active"}},"required":["targets"]})",
             .outputSchema = R"({"type":"object","properties":{"exitCode":{"type":"integer"}}})",
             .destructive = true,
         };
@@ -67,7 +67,9 @@ public:
         bool yes = json.value("yes", false);
         bool noDeps = json.value("noDeps", false);
         bool global = json.value("global", false);
-        return exit_result(xim::cmd_install(targets, yes, noDeps, stream, global, cancel));
+        bool useAfter = json.value("useAfterInstall", false);
+        return exit_result(xim::cmd_install(targets, yes, noDeps, stream, global,
+                                             cancel, /*dryRun=*/false, useAfter));
     }
 };
 

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -346,7 +346,15 @@ int install_from_project_config_(EventStream& stream) {
                     auto workspace = xvm::workspace_from_json(json["workspace"]);
                     auto targets = Config::workspace_install_targets(workspace);
                     if (!targets.empty()) {
-                        return xim::cmd_install(targets, true, false, stream);
+                        // Project-config install: the workspace file declares
+                        // which versions should be active in this subos, so
+                        // force-activate to keep workspace state in sync with
+                        // the config.
+                        return xim::cmd_install(targets, true, false, stream,
+                                                /*forceGlobal=*/false,
+                                                /*cancel=*/nullptr,
+                                                /*dryRun=*/false,
+                                                /*useAfterInstall=*/true);
                     }
                 }
             } catch (...) {
@@ -365,7 +373,11 @@ int install_from_project_config_(EventStream& stream) {
                 generate_xlings_json_(cur, workspace);
                 log::println("generated: {}", (cur / ".xlings.json").string());
                 auto targets = Config::workspace_install_targets(workspace);
-                return xim::cmd_install(targets, true, false, stream);
+                return xim::cmd_install(targets, true, false, stream,
+                                        /*forceGlobal=*/false,
+                                        /*cancel=*/nullptr,
+                                        /*dryRun=*/false,
+                                        /*useAfterInstall=*/true);
             }
         }
 
@@ -617,7 +629,10 @@ export int run(int argc, char* argv[]) {
             if (match("install")) h = SubHelp{
                 "install", "Install packages (e.g. xlings install gcc@15 node)",
                 { {"packages", "Package names with optional version"} },
-                { {"-g, --global", "Install to global scope (not project-local subos)"} },
+                {
+                    {"-g, --global", "Install to global scope (not project-local subos)"},
+                    {"-u, --use",    "Activate the installed version even if another version is currently active"},
+                },
             };
             else if (match("remove")) h = SubHelp{
                 "remove", "Remove a package",
@@ -748,6 +763,7 @@ export int run(int argc, char* argv[]) {
         .subcommand("install")
             .description("Install packages (e.g. xlings install gcc@15 node)")
             .option(cmdline::Option("global").short_name('g').help("Install to global scope (not project-local subos)"))
+            .option(cmdline::Option("use").short_name('u').help("Activate the installed version even if another version is currently active"))
             .arg("packages").help("Package names with optional version")
             .action([&stream](const cmdline::ParsedArgs& args) -> int {
                 apply_global_opts_(args);
@@ -760,7 +776,10 @@ export int run(int argc, char* argv[]) {
 
                 bool yes = args.is_flag_set("yes");
                 bool global = args.is_flag_set("global");
-                return xim::cmd_install(targets, yes, false, stream, global);
+                bool useAfter = args.is_flag_set("use");
+                return xim::cmd_install(targets, yes, false, stream, global,
+                                        /*cancel=*/nullptr, /*dryRun=*/false,
+                                        useAfter);
             })
 
         // remove

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -62,9 +62,15 @@ int cmd_remove(const std::string& target, bool yes, EventStream& stream);
 // data event but does NOT download or install anything. The capability layer
 // uses this to back the plan_install capability — clients can preflight
 // what would be installed without making changes.
+//
+// useAfterInstall (`--use`): force the installed version to become active
+// even when another version is already active. Default behavior preserves
+// the existing active version; this flag opts back into the legacy
+// "install also switches" behavior on a per-invocation basis.
 int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
                 EventStream& stream, bool forceGlobal = false,
-                CancellationToken* cancel = nullptr, bool dryRun = false) {
+                CancellationToken* cancel = nullptr, bool dryRun = false,
+                bool useAfterInstall = false) {
     auto& catalog = get_catalog();
     if (!catalog.is_loaded()) {
         log::info("package index not available, updating...");
@@ -221,8 +227,12 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
         auto db = Config::versions();
         for (auto& match : requestedMatches) {
             auto active = xvm::get_active_version(Config::effective_workspace(), match.name);
-            if (xvm::has_version(db, match.name, match.version) &&
-                active != match.version) {
+            // Only switch when nothing is active yet for this program OR the
+            // user passed --use to force activation. Otherwise preserve the
+            // existing active version. Pairs with the symmetric guard in
+            // installer.cppm process_xvm_operations_.
+            if ((active.empty() || useAfterInstall) &&
+                xvm::has_version(db, match.name, match.version)) {
                 auto useRet = xvm::cmd_use(match.name, match.version, stream);
                 if (useRet != 0) {
                     log::warn("failed to activate {}@{} in current subos",
@@ -241,7 +251,9 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
     auto pending = plan.pending_count();
     auto allAlreadyInstalled = (pending == 0);
     if (allAlreadyInstalled) {
-        log::println("all packages already installed");
+        for (auto& m : requestedMatches) {
+            log::println("{}@{} is already installed", m.canonicalName, m.version);
+        }
     }
 
     // Show install plan with themed UI
@@ -338,19 +350,21 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
         },
         // Process deferred pkgmanager.install()/remove() requests synchronously
         // between install and config hooks so config can access sub-dependencies
-        [forceGlobal, &stream](const std::vector<mcpplibs::xpkg::InstallRequest>& reqs) {
+        [forceGlobal, useAfterInstall, &stream](const std::vector<mcpplibs::xpkg::InstallRequest>& reqs) {
             for (auto& req : reqs) {
                 if (req.op == "install") {
                     log::debug("installing sub-dependency: {}", req.target);
                     std::vector<std::string> subTargets = { req.target };
-                    cmd_install(subTargets, /*yes=*/true, /*noDeps=*/false, stream, forceGlobal);
+                    cmd_install(subTargets, /*yes=*/true, /*noDeps=*/false, stream,
+                                forceGlobal, /*cancel=*/nullptr, /*dryRun=*/false,
+                                useAfterInstall);
                 } else if (req.op == "remove") {
                     log::debug("removing sub-dependency: {}", req.target);
                     cmd_remove(req.target, /*yes=*/true, stream);
                 }
             }
         },
-        dlRenderer, cancel);
+        dlRenderer, cancel, useAfterInstall);
 
     if (!result) {
         log::error("install failed: {}", result.error());
@@ -793,11 +807,14 @@ int cmd_update(const std::string& target, bool yes, EventStream& stream) {
     }
 
     // Install the new version. cmd_install handles dependency resolution,
-    // download, hooks, and switches the active version on success. We pass
-    // yes=true because the user already confirmed the upgrade above (and
-    // hook-driven sub-installs should never re-prompt regardless).
+    // download, and hooks. We pass yes=true because the user already
+    // confirmed the upgrade above (and hook-driven sub-installs should
+    // never re-prompt regardless). useAfterInstall=true because update by
+    // definition moves the active pointer forward to the new version.
     std::vector<std::string> installTargets = { bareName + "@" + latest };
-    auto rc = cmd_install(installTargets, /*yes=*/true, /*noDeps=*/false, stream);
+    auto rc = cmd_install(installTargets, /*yes=*/true, /*noDeps=*/false, stream,
+                          /*forceGlobal=*/false, /*cancel=*/nullptr,
+                          /*dryRun=*/false, /*useAfterInstall=*/true);
     if (rc != 0) return rc;
 
     nlohmann::json summaryPayload;

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -388,7 +388,8 @@ void detach_current_subos_(const std::string& target, const std::string& version
 
 void process_xvm_operations_(const PlanNode& node,
                              const std::filesystem::path& dataDir,
-                             mcpplibs::xpkg::PackageExecutor& executor) {
+                             mcpplibs::xpkg::PackageExecutor& executor,
+                             bool useAfterInstall) {
     auto xvm_ops = executor.xvm_operations();
     auto sysroot_include = Config::paths().subosDir / "usr" / "include";
     auto sysroot_lib = Config::paths().libDir;
@@ -439,9 +440,17 @@ void process_xvm_operations_(const PlanNode& node,
                 }
             }
 
-            // Activate and create shim for each added program
+            // Activate and create shim for each added program.
+            // Auto-activate only when no version is currently active for this
+            // program OR the caller passed useAfterInstall (`--use`). Otherwise
+            // preserve the user's existing choice. The shim is always
+            // (re-)created so the program is reachable on PATH once activated.
             if (type == "program") {
-                Config::workspace_mut()[op.name] = ver_key;
+                auto& ws = Config::workspace();
+                bool hasActive = ws.contains(op.name) && !ws.at(op.name).empty();
+                if (!hasActive || useAfterInstall) {
+                    Config::workspace_mut()[op.name] = ver_key;
+                }
                 if (std::filesystem::exists(xlings_bin)) {
                     std::string shim_name = op.name;
                     if (!shim_ext.empty() && !shim_name.ends_with(shim_ext))
@@ -506,7 +515,8 @@ bool run_config_hook_(const PlanNode& node,
                       const std::filesystem::path& dataDir,
                       mcpplibs::xpkg::PackageExecutor& executor,
                       mcpplibs::xpkg::ExecutionContext& ctx,
-                      std::function<void(const InstallStatus&)> onStatus) {
+                      std::function<void(const InstallStatus&)> onStatus,
+                      bool useAfterInstall) {
     if (!executor.has_hook(mcpplibs::xpkg::HookType::Config)) return true;
     if (onStatus) {
         onStatus({ node.name, InstallPhase::Configuring, 0.8f, "" });
@@ -517,7 +527,7 @@ bool run_config_hook_(const PlanNode& node,
         log::warn("config hook failed for {}: {}", node.name, hookResult.error);
         return false;
     }
-    process_xvm_operations_(node, dataDir, executor);
+    process_xvm_operations_(node, dataDir, executor, useAfterInstall);
     return true;
 }
 
@@ -677,14 +687,18 @@ public:
     explicit Installer(IndexManager& index) : index_(&index) {}
     explicit Installer(PackageCatalog& catalog) : catalog_(&catalog) {}
 
-    // Execute an install plan
+    // Execute an install plan.
+    // useAfterInstall: when true, force the installed program version to
+    // become the active one even if another version is currently active.
+    // Default behavior preserves the existing active version.
     std::expected<void, std::string>
     execute(const InstallPlan& plan,
             const DownloaderConfig& dlConfig,
             std::function<void(const InstallStatus&)> onStatus,
             InstallRequestHandler onInstallRequests = nullptr,
             DownloadProgressRenderer onRender = nullptr,
-            CancellationToken* cancel = nullptr) {
+            CancellationToken* cancel = nullptr,
+            bool useAfterInstall = false) {
 
         if (plan.has_errors()) {
             return std::unexpected(
@@ -1007,7 +1021,8 @@ public:
                     }
                     continue;
                 }
-            } else if (!detail_::run_config_hook_(node, dataDir, executor, ctx, onStatus)) {
+            } else if (!detail_::run_config_hook_(node, dataDir, executor, ctx,
+                                                  onStatus, useAfterInstall)) {
                 if (onStatus) {
                     onStatus({ node.name, InstallPhase::Failed, 0.0f,
                                "config hook failed" });

--- a/tests/e2e/remove_multi_version_test.sh
+++ b/tests/e2e/remove_multi_version_test.sh
@@ -128,6 +128,10 @@ printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
 STORE_DIR="$HOME_DIR/data/xpkgs/xim-x-rm-fixture"
 
 # ── install all three versions ───────────────────────────────────
+# `install` is no longer an implicit version-switch: once a version is active
+# in the current sub-OS, subsequent `install <name>@<other>` adds the payload
+# but preserves the active pointer. Explicitly `use` the highest after the
+# install loop so the rest of the test reflects "active was 3.0.0".
 for v in 1.0.0 2.0.0 3.0.0; do
   log "install rm-fixture@$v"
   RUN install "rm-fixture@$v" -y >/dev/null 2>&1 \
@@ -135,6 +139,8 @@ for v in 1.0.0 2.0.0 3.0.0; do
   [[ -f "$STORE_DIR/$v/VERSION" ]] \
     || fail "install marker missing: $STORE_DIR/$v/VERSION"
 done
+RUN use rm-fixture 3.0.0 >/dev/null 2>&1 \
+  || fail "use rm-fixture 3.0.0 failed"
 
 python3 - "$HOME_DIR" 1.0.0 2.0.0 3.0.0 <<'PY' || fail "post-install DB state wrong"
 import json, sys, pathlib


### PR DESCRIPTION
## Summary

Two related improvements to `xlings install`, plus a new opt-in flag:

- **Show matched version when already installed** — replace the generic `all packages already installed` line with one entry per requested package showing the *resolved* version (e.g. `xim:node@22.17.1 is already installed`). Makes fuzzy version requests like `install node@22` self-documenting.
- **Preserve current active version on install** — installing a *different* version of an already-active program no longer silently switches the active pointer. Default = keep current active; auto-activate only when no version is active yet (fresh install).
- **`-u, --use` flag** — opts back into the legacy "install also switches" behavior on a per-invocation basis, for users who really do want to move forward without going through `update`.

### Behavior matrix

| State | `install foo@X` | `install foo@X --use` |
| --- | --- | --- |
| no active | install + activate X | install + activate X |
| active=X (same) | "is already installed", no change | "is already installed", no change |
| active=Y (different) | install X, **active stays Y** | install X, **active switches to X** |

### Touched call sites

- `xlings update <pkg>` still moves active forward (calls `cmd_install` with `useAfterInstall=true`); the previous explicit `cmd_use` follow-up is gone.
- Project workspace install (`.xlings.json`) uses `useAfterInstall=true` to keep workspace state in sync with the config.
- Sub-dependency installs propagate the parent's `--use`.
- `install_packages` agent capability exposes `useAfterInstall` so programmatic clients have parity.

### Test impact

- `tests/e2e/install_idempotent_test.sh` — passes unchanged (its assertions match the new "is already installed" substring).
- `tests/e2e/update_package_test.sh` — passes unchanged (update still switches).
- `tests/e2e/remove_multi_version_test.sh` — **contract update**: the test relied on the implicit "last install wins" switch; it now explicitly `xlings use rm-fixture 3.0.0` after the install loop to set the active version. The e2e otherwise asserts the same remove semantics.

## Test plan

- [x] All 29 functional e2e tests pass locally (3 release-tarball smoke tests skip due to missing `build/release.tar.gz`, unrelated)
- [x] Sandboxed Node.js verification of all behavior cells in the matrix above (fresh install / re-install / different version / prefix match / `-u` short / `--use` long)
- [x] `xlings update` still upgrades active version
- [x] Shim still resolves correctly after `xlings use <pkg> <ver>`
- [ ] CI: linux / archlinux / macos / windows