### PR TITLE
chore(release): bump version to 0.4.6

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.5";
+    static constexpr std::string_view VERSION = "0.4.6";
     static constexpr std::string_view REPO = "https://github.com/d2learn/xlings";
 };
 


### PR DESCRIPTION
Bumps `Info::VERSION` in `src/core/config.cppm` from 0.4.5 → 0.4.6 in preparation for the 0.4.6 release.

Highlights since 0.4.5:
- #234 `xlings install` keeps the current active version (no more silent upgrades) and prints the matched version when already installed; new `-u, --use` flag opts into the legacy "install also switches" behavior.