### PR TITLE
feat(install): self-replace bootstrap when activating xlings/xim/xvm

### DIFF
--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -18,6 +18,7 @@ import xlings.core.xself;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
 import xlings.core.xvm.commands;
+import xlings.core.xvm.shim;
 import xlings.core.xim.libxpkg.types.script;
 import xlings.runtime.cancellation;
 
@@ -448,7 +449,8 @@ void process_xvm_operations_(const PlanNode& node,
             if (type == "program") {
                 auto& ws = Config::workspace();
                 bool hasActive = ws.contains(op.name) && !ws.at(op.name).empty();
-                if (!hasActive || useAfterInstall) {
+                bool didActivate = !hasActive || useAfterInstall;
+                if (didActivate) {
                     Config::workspace_mut()[op.name] = ver_key;
                 }
                 if (std::filesystem::exists(xlings_bin)) {
@@ -458,6 +460,31 @@ void process_xvm_operations_(const PlanNode& node,
                     std::filesystem::create_directories(paths.binDir);
                     xself::create_shim(xlings_bin, paths.binDir / shim_name);
                     common::mirror_shim_to_global_bin(xlings_bin, shim_name);
+                }
+
+                // Self-replace bootstrap when activating xlings/xim/xvm.
+                // main.cpp's multiplexer short-circuits these names to the
+                // local cli::run() — it doesn't consult the workspace at
+                // runtime. So the only way to make "active xlings = X.Y.Z"
+                // visible to the user is to physically replace the bootstrap
+                // binary at xlings_bin with the version we just installed.
+                // Atomic replace (POSIX rename / Windows MoveFileEx-old-then-
+                // copy) is safe even when the running process IS the bootstrap.
+                if (didActivate
+                    && xvm::is_xlings_binary(op.name)
+                    && std::filesystem::exists(xlings_bin)
+                    && !op.bindir.empty()) {
+                    auto active_bin = std::filesystem::path(op.bindir)
+                                    / ("xlings" + std::string(shim_ext));
+                    if (std::filesystem::exists(active_bin)) {
+                        if (platform::atomic_replace_executable(active_bin, xlings_bin)) {
+                            log::debug("[self-replace] bootstrap {} <- {}",
+                                      xlings_bin.string(), active_bin.string());
+                        } else {
+                            log::warn("[self-replace] failed: bootstrap {} <- {}",
+                                     xlings_bin.string(), active_bin.string());
+                        }
+                    }
                 }
             } else if (type == "lib" && !op.bindir.empty()) {
                 // Install lib symlink to subos lib dir

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -11,6 +11,7 @@ import xlings.libs.json;
 import xlings.core.xself;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
+import xlings.core.xvm.shim;
 
 export namespace xlings::xvm {
 
@@ -249,6 +250,34 @@ int cmd_use(const std::string& target, const std::string& version, EventStream& 
                 shim_name += shim_ext;
             xself::create_shim(xlings_bin, p.binDir / shim_name);
             common::mirror_shim_to_global_bin(xlings_bin, shim_name);
+        }
+    }
+
+    // Self-replace: when the user switches to a different version of xlings
+    // (or its multicall aliases xim/xvm), physically replace the bootstrap
+    // binary with that version. Symmetric with the install-time replace in
+    // installer.cppm — they share the same condition: "we just made this
+    // version active for the running binary's identity".
+    //
+    // main.cpp's multiplexer short-circuits xlings/xim/xvm names to the
+    // local cli::run() without consulting the workspace at runtime, so
+    // updating workspace[xlings] alone has no observable effect; the
+    // bootstrap file itself must change for `xlings --version` etc. to
+    // reflect the switch.
+    if (is_xlings_binary(target) && fs::exists(xlings_bin)) {
+        auto* vd = get_vdata(db, target, resolved);
+        if (vd && !vd->path.empty()) {
+            auto active_bin = fs::path(vd->path)
+                            / ("xlings" + std::string(shim_ext));
+            if (fs::exists(active_bin)) {
+                if (platform::atomic_replace_executable(active_bin, xlings_bin)) {
+                    log::debug("[self-replace] bootstrap synced to {}@{}",
+                              target, resolved);
+                } else {
+                    log::warn("[self-replace] failed: {}@{} -> {}",
+                             target, resolved, xlings_bin.string());
+                }
+            }
         }
     }
 

--- a/src/platform.cppm
+++ b/src/platform.cppm
@@ -38,6 +38,7 @@ namespace platform {
     export using platform_impl::spawn_command;
     export using platform_impl::wait_or_kill;
     export using platform_impl::Icon;
+    export using platform_impl::atomic_replace_executable;
 
     export [[nodiscard]] std::string get_rundir() {
         return gRundir;

--- a/src/platform/unix.cppm
+++ b/src/platform/unix.cppm
@@ -80,6 +80,72 @@ namespace platform_impl {
         return (0.299 * r + 0.587 * g + 0.114 * b) > 32768.0;
     }
 
+    // Atomically replace `dst` with the contents of `src`, even when `dst`
+    // is the currently running executable.
+    //
+    // POSIX semantics: rename(2) is atomic and the kernel keeps the old inode
+    // alive for the running process's executable mapping. New invocations
+    // resolve the path to the new inode; the running process continues to
+    // execute from the old one until it exits. This is the canonical
+    // self-update pattern used by apt / brew / rustup / et al.
+    //
+    // Steps:
+    //   1. copy src -> "<dst>.xlings.new" (staged on the same FS as dst so
+    //      the rename below is intra-FS and atomic)
+    //   2. chmod 0755
+    //   3. rename(tmp, dst) — atomic
+    //
+    // Returns true on success.
+    export bool atomic_replace_executable(const std::filesystem::path& src,
+                                          const std::filesystem::path& dst) {
+        namespace fs = std::filesystem;
+        std::error_code ec;
+
+        if (!fs::exists(src, ec) || ec) return false;
+
+        fs::create_directories(dst.parent_path(), ec);
+        ec.clear();
+
+        auto tmp = dst;
+        tmp += ".xlings.new";
+
+        // Pre-clean any leftover from a previous interrupted run.
+        if (fs::exists(tmp, ec)) {
+            fs::remove(tmp, ec);
+            ec.clear();
+        }
+
+        fs::copy_file(src, tmp, fs::copy_options::overwrite_existing, ec);
+        if (ec) {
+            std::error_code rmec;
+            fs::remove(tmp, rmec);
+            return false;
+        }
+
+        fs::permissions(tmp,
+            fs::perms::owner_all
+          | fs::perms::group_read | fs::perms::group_exec
+          | fs::perms::others_read | fs::perms::others_exec,
+            fs::perm_options::replace, ec);
+        ec.clear();
+
+        fs::rename(tmp, dst, ec);
+        if (!ec) return true;
+
+        // Cross-filesystem fallback (rare: ec == EXDEV). copy + remove tmp.
+        if (ec == std::errc::cross_device_link) {
+            ec.clear();
+            fs::copy_file(tmp, dst, fs::copy_options::overwrite_existing, ec);
+            std::error_code rmec;
+            fs::remove(tmp, rmec);
+            return !ec;
+        }
+
+        std::error_code rmec;
+        fs::remove(tmp, rmec);
+        return false;
+    }
+
 } // namespace platform_impl
 } // namespace xlings
 

--- a/src/platform/windows.cppm
+++ b/src/platform/windows.cppm
@@ -257,6 +257,76 @@ namespace platform_impl {
         static constexpr auto info       = ">";
     };
 
+    // Atomically replace `dst` with the contents of `src`, even when `dst`
+    // is a currently running executable.
+    //
+    // Windows semantics: a running .exe is locked for delete and direct
+    // overwrite — but RENAME of a locked file is allowed. So the canonical
+    // pattern is "move old out of the way, then install new":
+    //   1. MoveFileEx(dst -> "<dst>.xlings.old")  — succeeds even when locked
+    //   2. CopyFile(src -> dst)                   — destination path is now
+    //                                                free, no lock conflict
+    //   3. DeleteFile(.old) best-effort, falling back to MOVEFILE_DELAY_UNTIL_REBOOT
+    //      if the file is still locked by the running process.
+    //
+    // Pattern used in production by Chrome auto-updater, VS Code,
+    // rustup self-update, etc.
+    //
+    // Returns true on success.
+    export bool atomic_replace_executable(const std::filesystem::path& src,
+                                          const std::filesystem::path& dst) {
+        namespace fs = std::filesystem;
+        std::error_code ec;
+
+        if (!fs::exists(src, ec) || ec) return false;
+
+        fs::create_directories(dst.parent_path(), ec);
+        ec.clear();
+
+        // Easy case: dst doesn't exist yet — just copy.
+        if (!fs::exists(dst, ec)) {
+            fs::copy_file(src, dst, fs::copy_options::overwrite_existing, ec);
+            return !ec;
+        }
+        ec.clear();
+
+        auto old_path = dst;
+        old_path += ".xlings.old";
+
+        // Best-effort cleanup of a leftover .old (may fail if still locked).
+        if (fs::exists(old_path, ec)) {
+            ::DeleteFileW(old_path.wstring().c_str());
+            ec.clear();
+        }
+
+        // Step 1: rename live binary out of the way (works even if running).
+        if (!::MoveFileExW(dst.wstring().c_str(),
+                           old_path.wstring().c_str(),
+                           MOVEFILE_REPLACE_EXISTING)) {
+            return false;
+        }
+
+        // Step 2: copy new binary into the now-free dst path.
+        fs::copy_file(src, dst, fs::copy_options::overwrite_existing, ec);
+        if (ec) {
+            // Try to restore old binary so we don't leave the user broken.
+            ::MoveFileExW(old_path.wstring().c_str(),
+                          dst.wstring().c_str(),
+                          MOVEFILE_REPLACE_EXISTING);
+            return false;
+        }
+
+        // Step 3: best-effort cleanup. If the .old file is still locked
+        // (because the running process is mapping it), schedule for
+        // deletion at next reboot.
+        if (!::DeleteFileW(old_path.wstring().c_str())) {
+            ::MoveFileExW(old_path.wstring().c_str(), nullptr,
+                          MOVEFILE_DELAY_UNTIL_REBOOT);
+        }
+
+        return true;
+    }
+
 } // namespace platform_impl
 }
 

--- a/tests/e2e/xlings_self_replace_test.sh
+++ b/tests/e2e/xlings_self_replace_test.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# E2E: `xim install` / `xvm use` of xlings itself must atomically replace the
+# bootstrap binary at $XLINGS_HOME/bin/xlings, so the active version actually
+# takes effect when invoked through PATH.
+#
+# Background: main.cpp's multiplexer short-circuits xlings/xim/xvm names to
+# cli::run() without consulting the workspace, so updating workspace[xlings]
+# alone has no observable effect — the bootstrap file itself must change.
+#
+# Scenarios (uses a fake xpkg named "xlings" that drops a printable script
+# at <bindir>/xlings; we rely only on the file-replacement contract):
+#
+#   1. fresh subos, install xlings@1.0.0   → bootstrap replaced (no prior active)
+#   2. install xlings@2.0.0 (1.0.0 active) → bootstrap NOT replaced (preserve)
+#   3. install xlings@2.0.0 --use          → bootstrap replaced
+#   4. xvm use xlings 1.0.0                → bootstrap replaced (back to 1.0.0)
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/xlings_self_replace"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+
+FIXTURE_PKG="$LOCAL_INDEX_DIR/pkgs/x/xlings.lua"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+RUN() {
+  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+}
+
+# Read the marker line from a "fake xlings" script: each version drops
+# `BOOTSTRAP_VERSION=<version>` as the second line. We hash against this
+# rather than trying to exec the script (avoids worrying about /bin/sh
+# semantics inside a sandbox).
+bootstrap_version() {
+  local f="$HOME_DIR/bin/xlings"
+  [[ -f "$f" ]] || { echo "<missing>"; return; }
+  grep -oE 'BOOTSTRAP_VERSION=[0-9.]+' "$f" 2>/dev/null | head -1 \
+    | cut -d= -f2 || echo "<unparseable>"
+}
+
+active_version() {
+  python3 - "$HOME_DIR" <<'PY'
+import json, sys, pathlib
+home = sys.argv[1]
+ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
+print((ws.get("workspace") or {}).get("xlings", "<none>"))
+PY
+}
+
+mkdir -p "$HOME_DIR"
+
+# Private copy of the shared fixture index, neutralise sub-index repos.
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$(dirname "$FIXTURE_PKG")"
+
+# Override pkgs/x/xlings.lua with a fixture that:
+#   - declares two versions (1.0.0, 2.0.0), no URL (no downloads)
+#   - install hook drops a printable script at <install_dir>/bin/xlings
+#     containing a parseable BOOTSTRAP_VERSION=<ver> marker
+#   - config hook registers via xvm.add("xlings", { bindir = ... })
+cat > "$FIXTURE_PKG" <<'LUA'
+package = {
+    spec = "1",
+    name = "xlings",
+    description = "Local fixture for tests/e2e/xlings_self_replace_test.sh",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+
+    xpm = {
+        linux   = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+        windows = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(bindir)
+    local fake = "#!/bin/sh\n# BOOTSTRAP_VERSION=" .. pkginfo.version() .. "\n"
+                .. "echo 'fake xlings " .. pkginfo.version() .. "'\n"
+    io.writefile(path.join(bindir, "xlings"), fake)
+    return true
+end
+
+function config()
+    xvm.add("xlings", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+
+function uninstall()
+    xvm.remove("xlings")
+    return true
+end
+LUA
+
+# Seed XLINGS_HOME with a sentinel "old bootstrap" file so we can detect
+# replacement (not the real xlings binary — we only care about file content).
+mkdir -p "$HOME_DIR/subos/default/bin" "$HOME_DIR/bin"
+printf '#!/bin/sh\n# BOOTSTRAP_VERSION=0.0.0\necho original\n' > "$HOME_DIR/bin/xlings"
+chmod +x "$HOME_DIR/bin/xlings"
+
+# Standard config — point at our private (neutralised) index.
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
+EOF
+
+log "Initializing sandbox XLINGS_HOME at $HOME_DIR"
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+# self init writes a real xlings binary into $HOME_DIR/bin/xlings, clobbering
+# our sentinel. Restore the sentinel so scenario 1 has a known starting
+# point ("bootstrap = 0.0.0").
+printf '#!/bin/sh\n# BOOTSTRAP_VERSION=0.0.0\necho original\n' > "$HOME_DIR/bin/xlings"
+chmod +x "$HOME_DIR/bin/xlings"
+[[ "$(bootstrap_version)" == "0.0.0" ]] || fail "setup: bootstrap should be 0.0.0; got $(bootstrap_version)"
+
+# ── Scenario 1: fresh install (no prior active) → bootstrap replaced to 1.0.0
+log "S1: install xlings@1.0.0 (fresh, no active) → bootstrap replaced"
+RUN install xlings@1.0.0 -y >/dev/null 2>&1 || fail "S1: install failed"
+[[ "$(active_version)" == "1.0.0" ]] || fail "S1: active should be 1.0.0; got $(active_version)"
+got=$(bootstrap_version)
+[[ "$got" == "1.0.0" ]] || fail "S1: bootstrap should be 1.0.0 (replaced); got $got"
+
+# ── Scenario 2: install xlings@2.0.0 with 1.0.0 active → bootstrap PRESERVED
+log "S2: install xlings@2.0.0 (1.0.0 active, no --use) → bootstrap preserved"
+RUN install xlings@2.0.0 -y >/dev/null 2>&1 || fail "S2: install failed"
+[[ "$(active_version)" == "1.0.0" ]] || fail "S2: active should still be 1.0.0; got $(active_version)"
+got=$(bootstrap_version)
+[[ "$got" == "1.0.0" ]] || fail "S2: bootstrap should still be 1.0.0 (preserved); got $got"
+
+# ── Scenario 3: install xlings@2.0.0 --use → bootstrap replaced to 2.0.0
+log "S3: install xlings@2.0.0 --use → bootstrap replaced"
+RUN install xlings@2.0.0 --use -y >/dev/null 2>&1 || fail "S3: install --use failed"
+[[ "$(active_version)" == "2.0.0" ]] || fail "S3: active should be 2.0.0; got $(active_version)"
+got=$(bootstrap_version)
+[[ "$got" == "2.0.0" ]] || fail "S3: bootstrap should be 2.0.0 (replaced via --use); got $got"
+
+# ── Scenario 4: xvm use xlings 1.0.0 → bootstrap replaced back to 1.0.0
+log "S4: xlings use xlings 1.0.0 → bootstrap replaced"
+RUN use xlings 1.0.0 >/dev/null 2>&1 || fail "S4: use failed"
+[[ "$(active_version)" == "1.0.0" ]] || fail "S4: active should be 1.0.0; got $(active_version)"
+got=$(bootstrap_version)
+[[ "$got" == "1.0.0" ]] || fail "S4: bootstrap should be 1.0.0 (synced via use); got $got"
+
+log "PASS: xlings self-replace scenarios 1, 2, 3, 4"


### PR DESCRIPTION
## Summary

When users invoke \`xim install xlings@X\` or \`xvm use xlings X\`, the active version had no observable effect — the bootstrap binary at \`\$XLINGS_HOME/bin/xlings\` always ran whatever \`quick_install.sh\` originally laid down. \`xlings --version\` reported the bootstrap version, not the active one, and bug fixes in newer xlings versions were unreachable.

Root cause: \`main.cpp\` multiplexer short-circuits xlings/xim/xvm names directly to \`cli::run()\` and never consults the workspace at runtime.

Fix: when activation happens for a name in the multicall set (xlings/xim/xvm), atomically replace the bootstrap binary with the active version's binary.

## Behavior contract (matches #234's activation gate)

| Operation | Bootstrap replaced? |
| --- | --- |
| fresh install (no prior active) | ✅ |
| install another version (active exists) | ❌ (preserved) |
| install ... \`--use\` | ✅ |
| \`xlings use <self> <version>\` | ✅ |
| \`xlings update xlings\` | ✅ (cmd_update passes \`useAfterInstall=true\`) |

## Implementation

- New \`platform::atomic_replace_executable(src, dst)\`:
  - **POSIX** (\`unix.cppm\`): copy → chmod 0755 → \`rename(2)\`. The kernel keeps the old inode alive for any running process's executable mapping, so this is safe even when bootstrap is the running process.
  - **Windows** (\`windows.cppm\`): \`MoveFileEx(dst → dst.xlings.old)\` (rename of a locked .exe is allowed) → \`copy(src, dst)\` → best-effort \`DeleteFile\` of \`.old\` with \`MOVEFILE_DELAY_UNTIL_REBOOT\` fallback. Same pattern used by Chrome auto-updater, VS Code, rustup self-update.

- Wire-in points (symmetric):
  - \`installer.cppm\` \`process_xvm_operations_\`: after the workspace assignment (gated by \`!hasActive || useAfterInstall\` per #234).
  - \`xvm/commands.cppm\` \`cmd_use\`: after switching workspace.

- Trigger predicate: reuses existing \`xvm::is_xlings_binary\` (\`shim.cppm:20-28\`) — the multicall name set is already authoritative there. No new hardcoded list.

- libxpkg / xim-pkgindex: **not changed**.

## Test plan

- [x] New e2e: \`tests/e2e/xlings_self_replace_test.sh\` (4 scenarios, isolated sandbox)
- [x] All 30 functional e2e tests pass (3 release-tarball smoke tests skip due to missing \`build/release.tar.gz\` — unrelated)
- [x] Sandbox verifies: install fresh / install + active / install --use / use → bootstrap reflects active version
- [x] System \`~/.xlings\` not touched during local testing
- [ ] CI: linux / archlinux / macos / windows