### PR TITLE
chore(release): bump version to 0.4.7 + fix(remove): preserve shim across multi-version uninstall

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.6";
+    static constexpr std::string_view VERSION = "0.4.7";
     static constexpr std::string_view REPO = "https://github.com/d2learn/xlings";
 };
 

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -344,17 +344,41 @@ void remove_target_shims_(const std::string& target, const std::string& version)
     auto& binDir = Config::paths().binDir;
     std::error_code ec;
 
+    // A program's shim is a generic dispatcher to the bootstrap; the actual
+    // version it routes to is the workspace pointer (read at runtime). So
+    // the shim is only stale when the *last* version of the name is being
+    // removed. With surviving versions still in the DB, the shim must stay
+    // — the uninstall path elsewhere auto-switches the workspace to the
+    // highest remaining version, and the shim resolves through that.
+    //
+    // Removing the shim too eagerly (the previous behavior) leaves PATH
+    // pointing nowhere even though the version DB still holds installs,
+    // surfacing as "command not found" for node/npm/npx/mdbook etc. after
+    // `xlings remove <pkg>@<one-version>`.
+    auto is_last_version_for = [&](const std::string& name,
+                                   const std::string& ver) {
+        auto* vi = xvm::get_vinfo(db, name);
+        if (!vi) return true;
+        for (auto& [v, _] : vi->versions) {
+            if (v != ver) return false;
+        }
+        return true;
+    };
+
     auto mainName = (vinfo && !vinfo->filename.empty()) ? vinfo->filename : target;
-    auto mainShim = binDir / mainName;
-    if (fs::exists(mainShim, ec) || fs::is_symlink(mainShim, ec)) {
-        ec.clear();
-        fs::remove(mainShim, ec);
+    if (is_last_version_for(target, version)) {
+        auto mainShim = binDir / mainName;
+        if (fs::exists(mainShim, ec) || fs::is_symlink(mainShim, ec)) {
+            ec.clear();
+            fs::remove(mainShim, ec);
+        }
     }
 
     if (!vinfo) return;
     for (auto& [bindingName, vermap] : vinfo->bindings) {
         auto vit = vermap.find(version);
         if (vit == vermap.end()) continue;
+        if (!is_last_version_for(bindingName, vit->second)) continue;
         auto bindPath = binDir / bindingName;
         ec.clear();
         if (fs::exists(bindPath, ec) || fs::is_symlink(bindPath, ec)) {
@@ -1203,7 +1227,11 @@ public:
 
         for (auto& op : xvm_ops) {
             if (op.op == "remove") {
-                // Remove shim
+                // Compute shim path now; we only delete the shim once we
+                // know there are no surviving versions of this program.
+                // Removing it eagerly (as the previous code did) leaves
+                // the workspace pointing at the highest-remaining version
+                // but the PATH entry is gone — `command not found`.
 #ifdef _WIN32
                 constexpr std::string_view shim_ext = ".exe";
 #else
@@ -1213,9 +1241,11 @@ public:
                 if (!shim_ext.empty() && !shim_name.ends_with(shim_ext))
                     shim_name += shim_ext;
                 auto shim_path = Config::paths().binDir / shim_name;
-                if (std::filesystem::exists(shim_path)) {
-                    std::filesystem::remove(shim_path);
-                }
+                auto remove_shim_if_present = [&]() {
+                    if (std::filesystem::exists(shim_path)) {
+                        std::filesystem::remove(shim_path);
+                    }
+                };
 
                 // Resolve the authoritative version to drop from the DB.
                 // Prefer what the hook sent; fall back to the outer resolve only when the
@@ -1240,6 +1270,7 @@ public:
                     // ops for sibling names that were never registered with a version.
                     Config::versions_mut().erase(op.name);
                     Config::workspace_mut().erase(op.name);
+                    remove_shim_if_present();
                     continue;
                 }
 
@@ -1250,17 +1281,22 @@ public:
                 bool survivors = (dit != Config::versions_mut().end()
                                   && !dit->second.versions.empty());
                 if (!survivors) {
-                    // Package fully gone — clear workspace binding too.
+                    // Package fully gone — clear workspace binding and drop
+                    // the PATH shim with it.
                     Config::workspace_mut().erase(op.name);
+                    remove_shim_if_present();
                 } else if (prev_active.empty() || prev_active == effective_version) {
                     // We just removed the active version (or detach already cleared the
                     // slot for detachTarget). Auto-switch to the highest remaining
-                    // semver so leftover versions stay reachable.
+                    // semver so leftover versions stay reachable. Keep the shim —
+                    // it dispatches to the bootstrap, which resolves the active
+                    // version at runtime via the workspace pointer we just updated.
                     Config::workspace_mut()[op.name] =
                         xvm::pick_highest_version(dit->second.versions);
                 } else {
                     // A non-active version was removed; keep the previous active if still
-                    // present, otherwise fall back to highest remaining.
+                    // present, otherwise fall back to highest remaining. Shim survives
+                    // for the same reason as above.
                     if (dit->second.versions.contains(prev_active)) {
                         Config::workspace_mut()[op.name] = prev_active;
                     } else {

--- a/tests/e2e/remove_multi_version_test.sh
+++ b/tests/e2e/remove_multi_version_test.sh
@@ -126,6 +126,7 @@ printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
 # The fixture repo is registered as name "xim" by write_home_config, so the
 # canonical store prefix is "xim-x-".
 STORE_DIR="$HOME_DIR/data/xpkgs/xim-x-rm-fixture"
+SHIM_PATH="$HOME_DIR/subos/default/bin/rm-fixture"
 
 # ── install all three versions ───────────────────────────────────
 # `install` is no longer an implicit version-switch: once a version is active
@@ -141,6 +142,10 @@ for v in 1.0.0 2.0.0 3.0.0; do
 done
 RUN use rm-fixture 3.0.0 >/dev/null 2>&1 \
   || fail "use rm-fixture 3.0.0 failed"
+
+# Sanity: the per-program shim exists in subos/default/bin after install+use.
+# Subsequent scenarios assert on its survival across remove operations.
+[[ -e "$SHIM_PATH" ]] || fail "setup: shim should exist at $SHIM_PATH after install"
 
 python3 - "$HOME_DIR" 1.0.0 2.0.0 3.0.0 <<'PY' || fail "post-install DB state wrong"
 import json, sys, pathlib
@@ -174,6 +179,12 @@ assert active == "2.0.0", \
     f"S1: active should auto-switch to highest remaining (2.0.0); got {active!r}"
 PY
 
+# Active was switched to 2.0.0 by remove; the shim must still be on PATH so
+# the new active version is actually invokable. Pre-fix, this shim was being
+# eagerly deleted before the survivor check ran, leaving "command not found".
+[[ -e "$SHIM_PATH" ]] \
+  || fail "S1: shim must survive (workspace switched to 2.0.0); was eagerly deleted"
+
 # ── Scenario 2: remove specific non-active 1.0.0 → active still 2.0.0 ──────
 log "Scenario 2: remove rm-fixture@1.0.0 (non-active)"
 RUN remove rm-fixture@1.0.0 -y >/dev/null 2>&1 || fail "remove rm-fixture@1.0.0 failed"
@@ -195,6 +206,10 @@ assert active == "2.0.0", \
     f"S2: active must remain 2.0.0 after removing non-active 1.0.0; got {active!r}"
 PY
 
+# Non-active removal must not touch the shim either.
+[[ -e "$SHIM_PATH" ]] \
+  || fail "S2: shim must survive when removing a non-active version"
+
 # ── Scenario 3: remove the last remaining version → package entry fully gone ──
 log "Scenario 3: remove rm-fixture (last remaining version)"
 RUN remove rm-fixture -y >/dev/null 2>&1 || fail "remove rm-fixture (last) failed"
@@ -212,5 +227,9 @@ ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
 assert "rm-fixture" not in (ws.get("workspace") or {}), \
     "S3: rm-fixture should be cleared from workspace"
 PY
+
+# Last version gone → shim should be removed too (no remaining target to dispatch to).
+[[ ! -e "$SHIM_PATH" ]] \
+  || fail "S3: shim should be removed when the last version is uninstalled"
 
 log "PASS: remove-multi-version scenarios 1, 2, 3"


### PR DESCRIPTION
Bumps `Info::VERSION` in `src/core/config.cppm` from 0.4.6 → 0.4.7 in preparation for the 0.4.7 release.

Highlights since 0.4.6:

- #236 `xim install xlings@X` and `xvm use xlings X` now atomically replace the bootstrap binary (POSIX rename / Windows MoveFileEx). Fixes the long-standing bug where activating a new xlings version had no observable effect.
- **`fix(remove)`** in this PR: `xlings remove <pkg>@<one-version>` no longer wipes the per-program shim in `subos/default/bin/<tool>` when other versions of the package remain registered. Pre-fix, the DB auto-switched active to the highest surviving semver but PATH was already empty → "command not found" on the now-active version. Affected node/npm/npx, mdbook, and xlings itself when uninstalling a single version among several.

## Test plan

- All 30 functional e2e tests pass (3 release-tarball smoke tests skip due to missing `build/release.tar.gz` — unrelated)
- `tests/e2e/remove_multi_version_test.sh` extended with shim-survival assertions (S1/S2 must survive, S3 must remove)
- Sandbox repro of the user-reported flow: install rmtool@1.0.0 + rmtool@2.0.0 → use 2.0.0 → remove 2.0.0 → shim still on PATH, active = 1.0.0
- CI: linux / archlinux / macos / windows