### PR TITLE
feat(self): add `xlings self doctor` to verify workspace/shim invariant

### DIFF
--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -676,6 +676,7 @@ export int run(int argc, char* argv[]) {
                     {"config",   "Show configuration details"},
                     {"clean",    "Remove cache + gc orphaned packages (--dry-run)"},
                     {"migrate",  "Migrate old layout to subos/default"},
+                    {"doctor",   "Verify workspace/shim consistency (--fix to repair)"},
                 },
             };
             else if (match("subos")) h = SubHelp{

--- a/src/core/xself.cppm
+++ b/src/core/xself.cppm
@@ -12,6 +12,8 @@ import xlings.platform;
 import xlings.core.profile;
 import xlings.runtime;
 import xlings.core.utils;
+import xlings.core.xvm.types;
+import xlings.core.xvm.db;
 
 namespace xlings::xself {
 
@@ -179,6 +181,139 @@ static int cmd_migrate() {
     return 0;
 }
 
+// `xlings self doctor` — verify the workspace ↔ shim file invariant.
+//
+// Background: every program registered in the active workspace must have a
+// corresponding shim at `<binDir>/<name>` (the file that gets dispatched
+// through the bootstrap multiplexer). The two layers — workspace pointer
+// (logical) and shim file (physical) — must stay in sync, otherwise users
+// see "command not found" for a program their workspace says is active.
+//
+// Doctor verifies:
+//   1. Every program in workspace has its shim file present (and report
+//      missing ones).
+//   2. Every program-typed shim under binDir has a workspace entry (and
+//      report orphans).
+//
+// With `--fix`, it self-heals: missing shims are recreated from the
+// bootstrap binary; orphan shims are deleted.
+static int cmd_doctor(EventStream& stream, bool fix) {
+    auto& p   = Config::paths();
+    auto db   = Config::versions();
+    auto ws   = Config::effective_workspace();
+
+#ifdef _WIN32
+    constexpr std::string_view shim_ext = ".exe";
+    auto xlings_bin = p.homeDir / "bin" / "xlings.exe";
+#else
+    constexpr std::string_view shim_ext = "";
+    auto xlings_bin = p.homeDir / "bin" / "xlings";
+#endif
+    if (!fs::exists(xlings_bin)) {
+        xlings_bin = p.homeDir / "xlings";
+    }
+
+    auto shim_filename = [&](const std::string& name) {
+        std::string fn = name;
+        if (!shim_ext.empty() && !fn.ends_with(shim_ext)) fn += shim_ext;
+        return fn;
+    };
+
+    nlohmann::json fields = nlohmann::json::array();
+    auto add_field = [&](std::string_view label, std::string value, bool hl = false) {
+        fields.push_back({{"label", std::string(label)},
+                          {"value", std::move(value)},
+                          {"highlight", hl}});
+    };
+
+    int missing = 0;
+    int orphans = 0;
+    int healed  = 0;
+
+    // Check 1: every workspace program has its shim.
+    for (auto& [name, version] : ws) {
+        if (version.empty()) continue;
+        auto* vi = xvm::get_vinfo(db, name);
+        if (!vi || vi->type != "program") continue;
+
+        auto shim_path = p.binDir / shim_filename(name);
+        if (fs::exists(shim_path) || fs::is_symlink(shim_path)) continue;
+
+        ++missing;
+        std::string detail = std::format("workspace[{}]={} but {} missing",
+                                         name, version, shim_path.string());
+        if (fix && fs::exists(xlings_bin)) {
+            std::error_code ec;
+            fs::create_directories(p.binDir, ec);
+            auto r = create_shim(xlings_bin, shim_path);
+            if (r != LinkResult::Failed) {
+                ++healed;
+                detail += " — recreated";
+            } else {
+                detail += " — recreate failed";
+            }
+        }
+        add_field("✗ missing shim", std::move(detail));
+    }
+
+    // Check 2: orphan shims (program shim file present, workspace doesn't
+    // know about it). Only consider names that are registered as type
+    // "program" in the version DB — random files under binDir aren't ours.
+    if (fs::exists(p.binDir)) {
+        for (auto& entry : platform::dir_entries(p.binDir)) {
+            std::error_code ec;
+            if (!entry.is_regular_file(ec) && !entry.is_symlink(ec)) continue;
+            auto fname = entry.path().filename().string();
+            std::string base = fname;
+            if (!shim_ext.empty() && base.ends_with(shim_ext)) {
+                base = base.substr(0, base.size() - shim_ext.size());
+            }
+
+            auto* vi = xvm::get_vinfo(db, base);
+            if (!vi || vi->type != "program") continue;
+
+            auto wit = ws.find(base);
+            bool active_present = (wit != ws.end() && !wit->second.empty());
+            if (active_present) continue;
+
+            ++orphans;
+            std::string detail = std::format(
+                "{} exists but workspace has no active version for {}",
+                entry.path().string(), base);
+            if (fix) {
+                ec.clear();
+                fs::remove(entry.path(), ec);
+                if (!ec) {
+                    ++healed;
+                    detail += " — removed";
+                } else {
+                    detail += " — remove failed";
+                }
+            }
+            add_field("✗ orphan shim", std::move(detail));
+        }
+    }
+
+    int issues = missing + orphans;
+    if (issues == 0) {
+        add_field("status", "OK — workspace and shim files are consistent", true);
+    } else {
+        add_field("missing shims", std::to_string(missing));
+        add_field("orphan shims",  std::to_string(orphans));
+        if (fix) add_field("healed", std::to_string(healed), true);
+        else     add_field("hint", "rerun with `--fix` to repair", true);
+    }
+
+    nlohmann::json payload;
+    payload["title"]  = "xlings self doctor";
+    payload["fields"] = std::move(fields);
+    stream.emit(DataEvent{"info_panel", payload.dump()});
+
+    // Exit non-zero only when issues remain after the (optional) fix pass.
+    int unresolved = issues - (fix ? healed : 0);
+    return unresolved == 0 ? 0 : 1;
+}
+
 static int cmd_help(EventStream& stream) {
     nlohmann::json payload;
     payload["name"] = "self";
@@ -191,6 +326,7 @@ static int cmd_help(EventStream& stream) {
         {{"name", "config"},   {"desc", "Show configuration details"}},
         {{"name", "clean"},    {"desc", "Remove cache + gc orphaned packages (--dry-run)"}},
         {{"name", "migrate"},  {"desc", "Migrate old layout to subos/default"}},
+        {{"name", "doctor"},   {"desc", "Verify workspace/shim consistency (--fix to repair)"}},
     });
     stream.emit(DataEvent{"help", payload.dump()});
     return 0;
@@ -207,6 +343,13 @@ export int run(int argc, char* argv[], EventStream& stream) {
         return cmd_clean(dryRun);
     }
     if (action == "migrate") return cmd_migrate();
+    if (action == "doctor") {
+        bool fix = false;
+        for (int i = 3; i < argc; ++i) {
+            if (std::string(argv[i]) == "--fix") { fix = true; break; }
+        }
+        return cmd_doctor(stream, fix);
+    }
     return cmd_help(stream);
 }
 

--- a/tests/e2e/self_doctor_test.sh
+++ b/tests/e2e/self_doctor_test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# E2E: `xlings self doctor` verifies the workspace ↔ shim file invariant
+# and `--fix` repairs detected inconsistencies.
+#
+# The invariant: for every program N in the workspace with non-empty
+# version, a shim file at <binDir>/<N> must exist; conversely, every
+# program-typed shim file under binDir must have a workspace entry.
+#
+# Scenarios:
+#   1. Clean state                              → exit 0, "OK"
+#   2. Corrupt: delete a shim manually          → doctor reports missing
+#   3. --fix recreates the missing shim         → exit 0 after fix
+#   4. Corrupt: drop a stray shim under binDir
+#      (not present in versions DB)             → ignored (not ours)
+#   5. Corrupt: registered program shim with no
+#      workspace entry                          → doctor reports orphan
+#   6. --fix removes the orphan                 → exit 0 after fix
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/self_doctor"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+
+FIXTURE_PKG="$LOCAL_INDEX_DIR/pkgs/d/doctor-fixture.lua"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+RUN() {
+  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+}
+
+mkdir -p "$HOME_DIR"
+
+# Private copy of the shared fixture index, neutralise sub-index repos.
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$(dirname "$FIXTURE_PKG")"
+
+# Fixture: a single-version program named "doctor-fixture" that drops
+# a printable script at <bindir>/doctor-fixture so a shim can be created.
+cat > "$FIXTURE_PKG" <<'LUA'
+package = {
+    spec = "1",
+    name = "doctor-fixture",
+    description = "Local fixture for tests/e2e/self_doctor_test.sh",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+
+    xpm = {
+        linux   = { ["1.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {} },
+        windows = { ["1.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(bindir)
+    io.writefile(path.join(bindir, "doctor-fixture"),
+                 "#!/bin/sh\necho doctor-fixture@" .. pkginfo.version() .. "\n")
+    return true
+end
+
+function config()
+    xvm.add("doctor-fixture", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+
+function uninstall()
+    xvm.remove("doctor-fixture")
+    return true
+end
+LUA
+
+mkdir -p "$HOME_DIR/subos/default/bin"
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
+EOF
+
+log "Initializing sandbox XLINGS_HOME at $HOME_DIR"
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+# Install the fixture so we have a real workspace + shim to mess with.
+RUN install doctor-fixture@1.0.0 -y >/dev/null 2>&1 \
+  || fail "setup: install failed"
+
+SHIM="$HOME_DIR/subos/default/bin/doctor-fixture"
+[[ -e "$SHIM" ]] || fail "setup: shim should exist after install"
+
+# ── S1: clean state → exit 0 ────────────────────────────────────────
+log "S1: doctor on clean state → exit 0"
+RUN self doctor >/dev/null 2>&1 || fail "S1: doctor should report OK on clean state"
+
+# ── S2: delete shim manually → doctor reports missing ──────────────
+log "S2: delete shim, doctor (no --fix) → non-zero, reports missing"
+rm -f "$SHIM"
+[[ ! -e "$SHIM" ]] || fail "S2 setup: shim should be gone"
+out=$(RUN self doctor 2>&1) || rc=$?; rc=${rc:-0}
+[[ $rc -ne 0 ]] || fail "S2: doctor should exit non-zero when shim missing (got 0)"
+echo "$out" | grep -q "missing shim" \
+  || fail "S2: output should mention 'missing shim'; got:\n$out"
+
+# ── S3: --fix recreates the missing shim ───────────────────────────
+log "S3: doctor --fix recreates missing shim → exit 0"
+RUN self doctor --fix >/dev/null 2>&1 || fail "S3: doctor --fix should succeed"
+[[ -e "$SHIM" ]] || fail "S3: shim should be recreated by --fix"
+
+# Re-run doctor without --fix to confirm clean state restored
+RUN self doctor >/dev/null 2>&1 || fail "S3: post-fix doctor should be clean"
+
+# ── S4: stray file under binDir not in versions DB → ignored ───────
+log "S4: stray file under binDir not in versions DB → ignored"
+STRAY="$HOME_DIR/subos/default/bin/some-random-tool"
+echo '#!/bin/sh' > "$STRAY"
+chmod +x "$STRAY"
+RUN self doctor >/dev/null 2>&1 \
+  || fail "S4: doctor should ignore files not registered in versions DB"
+[[ -e "$STRAY" ]] || fail "S4: doctor should NOT touch unregistered files"
+rm -f "$STRAY"
+
+# ── S5: orphan registered shim (workspace entry cleared manually) ──
+log "S5: orphan shim → doctor reports orphan"
+# Manipulate the workspace JSON to remove only the doctor-fixture entry,
+# leaving the shim file in place.
+python3 - "$HOME_DIR" <<'PY'
+import json, sys, pathlib
+home = sys.argv[1]
+ws_path = pathlib.Path(home, "subos/default/.xlings.json")
+data = json.loads(ws_path.read_text())
+ws = data.get("workspace") or {}
+ws.pop("doctor-fixture", None)
+data["workspace"] = ws
+ws_path.write_text(json.dumps(data))
+PY
+
+[[ -e "$SHIM" ]] || fail "S5 setup: shim should still exist"
+out=$(RUN self doctor 2>&1) || rc=$?; rc=${rc:-0}
+[[ $rc -ne 0 ]] || fail "S5: doctor should exit non-zero on orphan (got 0)"
+echo "$out" | grep -q "orphan shim" \
+  || fail "S5: output should mention 'orphan shim'; got:\n$out"
+
+# ── S6: --fix removes orphan shim ──────────────────────────────────
+log "S6: doctor --fix removes orphan shim → exit 0"
+RUN self doctor --fix >/dev/null 2>&1 || fail "S6: doctor --fix should succeed"
+[[ ! -e "$SHIM" ]] || fail "S6: --fix should remove orphan shim"
+
+log "PASS: self doctor scenarios 1-6"


### PR DESCRIPTION
## Summary

Adds a new \`xlings self doctor\` command that verifies the invariant *"every program in workspace has a shim, every program shim is in workspace"*, and \`--fix\` to self-heal any drift.

This complements PR #237 (which fixed one specific drift cause): doctor catches **any** future drift of the same shape, regardless of which mutation introduced it.

## What it checks

| Layer | What it looks at |
| --- | --- |
| Logical | \`Config::effective_workspace()\` — every entry with non-empty version |
| Physical | \`<binDir>/<name>\` files for names registered as programs in versions DB |

| Class | Detection | \`--fix\` action |
| --- | --- | --- |
| missing shim | \`ws[name]=ver\` but file absent | recreate from bootstrap |
| orphan shim | program shim file present but no active workspace entry | delete |

Files unrelated to xlings's own version DB (random binaries under binDir) are deliberately ignored — only programs registered in versions DB participate in the invariant.

## Exit codes

- \`0\` — consistent (or all issues healed when \`--fix\` was used)
- \`1\` — issues remain

## Sample output

\`\`\`
$ xlings self doctor
  ◆ xlings self doctor
  ────────────────────────────────────────
  status   OK — workspace and shim files are consistent

$ rm ~/.xlings/subos/default/bin/rmtool
$ xlings self doctor
  ◆ xlings self doctor
  ✗ missing shim   workspace[rmtool]=1.0.0 but ... missing
  missing shims    1
  orphan shims     0
  hint             rerun with \`--fix\` to repair

$ xlings self doctor --fix
  ✗ missing shim   ... missing — recreated
  healed           1
\`\`\`

## Test plan

- [x] \`tests/e2e/self_doctor_test.sh\` — 6 scenarios (clean / missing / fix-missing / stray-ignored / orphan / fix-orphan)
- [x] All 31 functional e2e tests pass (3 release-tarball smoke tests skip due to missing \`build/release.tar.gz\` — unrelated)
- [ ] CI: linux / archlinux / macos / windows