### PR TITLE
refactor(cli): drop short-command aliases (xim/xvm/xself/xsubos/xinstall)

### DIFF
--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -163,6 +163,10 @@ jobs:
         run: |
           bash tests/e2e/cli_target_compat_test.sh
 
+      - name: "E2E-18: short-command aliases removal (xim/xvm/xself/xsubos/xinstall)"
+        run: |
+          bash tests/e2e/cli_short_alias_removal_test.sh
+
       - name: Attach artifact
         uses: actions/upload-artifact@v4
         if: success()

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -509,6 +509,10 @@ void process_xvm_operations_(const PlanNode& node,
                                      xlings_bin.string(), active_bin.string());
                         }
                     }
+                    // Opportunistic migration: drop legacy alias symlinks
+                    // (xim/xvm/...) left over from older xlings, alongside
+                    // the bootstrap replacement.
+                    xself::cleanup_legacy_alias_shims(paths.binDir, xlings_bin);
                 }
             } else if (type == "lib" && !op.bindir.empty()) {
                 // Install lib symlink to subos lib dir

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -509,10 +509,9 @@ void process_xvm_operations_(const PlanNode& node,
                                      xlings_bin.string(), active_bin.string());
                         }
                     }
-                    // Opportunistic migration: drop legacy alias symlinks
-                    // (xim/xvm/...) left over from older xlings, alongside
-                    // the bootstrap replacement.
-                    xself::cleanup_legacy_alias_shims(paths.binDir, xlings_bin);
+                    // COMPAT(0.4.8 → drop in 0.6.0): opportunistic legacy
+                    // alias cleanup, alongside the bootstrap replacement.
+                    xself::compat::cleanup_legacy_alias_shims(paths.binDir, xlings_bin);
                 }
             } else if (type == "lib" && !op.bindir.empty()) {
                 // Install lib symlink to subos lib dir

--- a/src/core/xself.cppm
+++ b/src/core/xself.cppm
@@ -6,14 +6,17 @@
 // surface from those partitions and (b) route subcommand names to them.
 //
 // Layout:
-//   xself.cppm           — this file (router + help)
-//   xself/init.cppm      — home layout helpers + `self init`
-//   xself/install.cppm   — `self install` (bootstrap from release tarball)
-//   xself/update.cppm    — `self update`
-//   xself/config.cppm    — `self config`
-//   xself/clean.cppm     — `self clean [--dry-run]`
-//   xself/migrate.cppm   — `self migrate`
-//   xself/doctor.cppm    — `self doctor [--fix]`
+//   xself.cppm                  — this file (router + help)
+//   xself/init.cppm             — home layout helpers + `self init`
+//   xself/install.cppm          — `self install` (bootstrap from release tarball)
+//   xself/update.cppm           — `self update`
+//   xself/config.cppm           — `self config`
+//   xself/clean.cppm            — `self clean [--dry-run]`
+//   xself/migrate.cppm          — `self migrate`
+//   xself/doctor.cppm           — `self doctor [--fix]`
+//   xself/compat_0_4_8.cppm     — COMPAT(0.4.8 → drop in 0.6.0): legacy
+//                                 alias migration. See its header comment
+//                                 for the removal procedure.
 
 export module xlings.core.xself;
 
@@ -26,6 +29,11 @@ export import xlings.core.xself.config;
 export import xlings.core.xself.clean;
 export import xlings.core.xself.migrate;
 export import xlings.core.xself.doctor;
+// COMPAT(0.4.8 → drop in 0.6.0): re-exported so external callers
+// (main.cpp, xvm/commands.cppm, xim/installer.cppm) reach
+// `xself::compat::*` through the umbrella module without depending
+// on the partition file directly.
+export import xlings.core.xself.compat_0_4_8;
 
 import xlings.libs.json;
 import xlings.runtime;

--- a/src/core/xself/compat_0_4_8.cppm
+++ b/src/core/xself/compat_0_4_8.cppm
@@ -1,0 +1,131 @@
+// COMPAT(0.4.8 → drop in 0.6.0)
+//
+// Migration code for "short-command aliases removed in 0.4.8".
+//
+// 0.4.8 collapsed the multicall surface to a single canonical entry point
+// (`xlings`). The five legacy aliases — xim / xvm / xself / xsubos / xinstall
+// — were created as symlinks-to-bootstrap by xlings ≤ 0.4.7 and are now
+// migration artifacts. Everything below exists only to ease the upgrade
+// path for users who still have those leftover shims on disk.
+//
+// This module is deliberately a single, isolated translation unit so the
+// future removal is a one-shot operation:
+//
+//   1. Bump the codebase to >= 0.6.0
+//   2. `git rm src/core/xself/compat_0_4_8.cppm`
+//   3. Rebuild — every `import xlings.core.xself.compat_0_4_8;` and every
+//      `xself::compat::` reference will surface as a hard build error.
+//      Delete each, and any surrounding `COMPAT(0.4.8 → drop in 0.6.0)`
+//      marker comments. No grep necessary.
+//
+// What lives here (all marked `export`, all temporary):
+//   * LEGACY_ALIAS_NAMES — the 5 names, used by cleanup callers and
+//     `xlings self doctor`.
+//   * DEPRECATED_ALIASES — name + suggested-replacement message, used
+//     only by main.cpp's argv[0] migration-error path.
+//   * is_legacy_alias_symlink_to_bootstrap — safety predicate shared
+//     between cleanup and doctor so they agree on what is "safe to remove".
+//   * cleanup_legacy_alias_shims — silent removal of leftover shims, hooked
+//     into every code path that re-pins the active bootstrap binary
+//     (self init / self update / use xlings / install xlings --use).
+//   * report_deprecated_alias_if_match — the user-facing migration error
+//     printed when a removed alias is invoked directly.
+
+export module xlings.core.xself.compat_0_4_8;
+
+import std;
+import xlings.core.log;
+
+namespace xlings::xself::compat {
+
+namespace fs = std::filesystem;
+
+// Names that older xlings versions sprayed into ~/.xlings/bin as multicall
+// symlinks → bootstrap. 0.4.8 collapses to a single canonical xlings entry,
+// so any leftover entry of these names is a migration artifact.
+export inline constexpr std::array<std::string_view, 5> LEGACY_ALIAS_NAMES = {
+    "xim", "xvm", "xself", "xsubos", "xinstall"
+};
+
+// (alias name, suggested replacement command-line) — used only by main.cpp
+// to print a helpful message when the user invokes a removed alias.
+export struct DeprecatedAlias {
+    std::string_view name;
+    std::string_view replacement;
+};
+export inline constexpr std::array<DeprecatedAlias, 5> DEPRECATED_ALIASES = {{
+    {"xim",      "xlings install/remove/search/list/info ..."},
+    {"xvm",      "xlings use ..."},
+    {"xself",    "xlings self ..."},
+    {"xsubos",   "xlings subos ..."},
+    {"xinstall", "xlings install ..."},
+}};
+
+// Safety predicate shared by cleanup_legacy_alias_shims and cmd_doctor:
+// "is `path` a symlink whose target canonicalizes to `canonical_bootstrap`?".
+// Both callers gate on this so they stay consistent on what counts as
+// "safe to remove" — a user file that merely happens to share a name is
+// never touched.
+export bool is_legacy_alias_symlink_to_bootstrap(
+    const fs::path& path,
+    const fs::path& canonical_bootstrap);
+
+// Remove leftover legacy alias symlinks under `bin_dir`. Hooked into every
+// path that re-pins the active bootstrap binary so the cleanup happens
+// opportunistically — the user never needs to run a separate migration
+// step. Callers:
+//   * `xlings self init`            (init.cppm)
+//   * `xlings install xlings --use` (xim/installer.cppm self-replace path)
+//   * `xlings use xlings <ver>`     (xvm/commands.cppm self-replace path)
+//   * `xlings self doctor --fix`    (doctor.cppm)
+export void cleanup_legacy_alias_shims(const fs::path& bin_dir,
+                                       const fs::path& bootstrap_path);
+
+// `main.cpp` calls this with the argv[0] basename. Returns true after
+// printing the migration error to stderr; main.cpp then exits with code 2.
+export bool report_deprecated_alias_if_match(std::string_view program_name);
+
+bool is_legacy_alias_symlink_to_bootstrap(const fs::path& path,
+                                          const fs::path& canonical_bootstrap)
+{
+    std::error_code ec;
+    if (!fs::is_symlink(path, ec)) return false;
+    ec.clear();
+    auto target = fs::weakly_canonical(path, ec);
+    if (ec) return false;
+    return target == canonical_bootstrap;
+}
+
+void cleanup_legacy_alias_shims(const fs::path& bin_dir,
+                                const fs::path& bootstrap_path) {
+    std::error_code ec;
+    auto canonical_bootstrap = fs::weakly_canonical(bootstrap_path, ec);
+    if (ec) return;
+
+    std::string ext = bootstrap_path.extension().string();
+    for (auto name : LEGACY_ALIAS_NAMES) {
+        auto path = bin_dir / (std::string(name) + ext);
+        if (!is_legacy_alias_symlink_to_bootstrap(path, canonical_bootstrap))
+            continue;
+        ec.clear();
+        fs::remove(path, ec);
+        log::debug("[migrate] removed legacy alias shim: {}", path.string());
+    }
+}
+
+bool report_deprecated_alias_if_match(std::string_view program_name) {
+    for (auto& [alias, suggestion] : DEPRECATED_ALIASES) {
+        if (alias == program_name) {
+            std::println(std::cerr,
+                "[error] `{}` was removed in 0.4.8. Use `{}` instead.",
+                alias, suggestion);
+            std::println(std::cerr,
+                "        Run `xlings self doctor --fix` to clean up "
+                "leftover shortcuts.");
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace xlings::xself::compat

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -2,6 +2,10 @@ export module xlings.core.xself.doctor;
 
 import std;
 import xlings.core.xself.init;   // create_shim, LinkResult
+// COMPAT(0.4.8 → drop in 0.6.0): legacy alias names + safety predicate.
+// When the compat module is removed, delete this import and the
+// "Check 2.5: legacy alias shims" block below.
+import xlings.core.xself.compat_0_4_8;
 
 import xlings.core.config;
 import xlings.libs.json;
@@ -154,29 +158,22 @@ export int cmd_doctor(EventStream& stream, bool fix) {
         }
     }
 
-    // Check 2.5: legacy alias shims (xim/xvm/xself/xsubos/xinstall).
+    // COMPAT(0.4.8 → drop in 0.6.0): Check 2.5 — legacy alias shims
+    // (xim/xvm/xself/xsubos/xinstall).
     //
-    // 0.4.8 collapsed to a single canonical entry point. Shims for these
-    // names that older xlings versions sprayed into binDir are no longer
-    // functional — the multicall in main.cpp short-circuits them to a
-    // "removed in 0.4.8" error. Detect-and-remove eliminates the leftover
-    // before the user trips over them.
+    // Names + predicate are owned by xself::compat. Doctor differs from
+    // the silent cleanup helper only in that it reports each finding and
+    // gates removal on `--fix`. Both share the safety predicate so they
+    // agree on what counts as "safe to remove".
     //
-    // Safe-by-default: only act when the entry is a symlink AND resolves
-    // to the bootstrap binary; never touch unrelated user files.
+    // When the compat module is removed, delete this entire block.
     if (fs::exists(p.binDir)) {
         std::error_code bec;
         auto canonical_bootstrap = fs::weakly_canonical(xlings_bin, bec);
-        static constexpr std::array<std::string_view, 5> LEGACY_ALIASES = {
-            "xim", "xvm", "xself", "xsubos", "xinstall"
-        };
-        for (auto alias : LEGACY_ALIASES) {
+        for (auto alias : compat::LEGACY_ALIAS_NAMES) {
             auto path = p.binDir / shim_filename(std::string(alias));
-            std::error_code ec;
-            if (!fs::is_symlink(path, ec)) continue;
-            ec.clear();
-            auto target = fs::weakly_canonical(path, ec);
-            if (ec || target != canonical_bootstrap) continue;
+            if (!compat::is_legacy_alias_symlink_to_bootstrap(path,
+                    canonical_bootstrap)) continue;
 
             ++orphans;
             std::string detail = std::format(
@@ -184,7 +181,7 @@ export int cmd_doctor(EventStream& stream, bool fix) {
                 "removed in 0.4.8)",
                 path.string(), alias);
             if (fix) {
-                ec.clear();
+                std::error_code ec;
                 fs::remove(path, ec);
                 if (!ec) {
                     ++healed;

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -154,6 +154,49 @@ export int cmd_doctor(EventStream& stream, bool fix) {
         }
     }
 
+    // Check 2.5: legacy alias shims (xim/xvm/xself/xsubos/xinstall).
+    //
+    // 0.4.8 collapsed to a single canonical entry point. Shims for these
+    // names that older xlings versions sprayed into binDir are no longer
+    // functional — the multicall in main.cpp short-circuits them to a
+    // "removed in 0.4.8" error. Detect-and-remove eliminates the leftover
+    // before the user trips over them.
+    //
+    // Safe-by-default: only act when the entry is a symlink AND resolves
+    // to the bootstrap binary; never touch unrelated user files.
+    if (fs::exists(p.binDir)) {
+        std::error_code bec;
+        auto canonical_bootstrap = fs::weakly_canonical(xlings_bin, bec);
+        static constexpr std::array<std::string_view, 5> LEGACY_ALIASES = {
+            "xim", "xvm", "xself", "xsubos", "xinstall"
+        };
+        for (auto alias : LEGACY_ALIASES) {
+            auto path = p.binDir / shim_filename(std::string(alias));
+            std::error_code ec;
+            if (!fs::is_symlink(path, ec)) continue;
+            ec.clear();
+            auto target = fs::weakly_canonical(path, ec);
+            if (ec || target != canonical_bootstrap) continue;
+
+            ++orphans;
+            std::string detail = std::format(
+                "{} is a leftover symlink from older xlings (alias `{}` "
+                "removed in 0.4.8)",
+                path.string(), alias);
+            if (fix) {
+                ec.clear();
+                fs::remove(path, ec);
+                if (!ec) {
+                    ++healed;
+                    detail += " — removed";
+                } else {
+                    detail += " — remove failed";
+                }
+            }
+            add_field("✗ legacy alias shim", std::move(detail));
+        }
+    }
+
     // Check 3: payload existence + executability for every (name, version)
     // in the versions DB. Reuses the same `resolve_executable` helper that
     // shim_dispatch uses at runtime so doctor's verdict matches what the

--- a/src/core/xself/init.cppm
+++ b/src/core/xself/init.cppm
@@ -118,8 +118,16 @@ LinkResult create_shim(const fs::path& source, const fs::path& target) {
 // from <bin_dir>. Only files that ARE symlinks AND resolve to the
 // canonical bootstrap path are removed — never touch unrelated user
 // files that happen to share a name.
-void cleanup_legacy_alias_shims_(const fs::path& bin_dir,
-                                 const fs::path& bootstrap_path) {
+//
+// Exported so the install/use-time self-replace paths (which run during
+// `xlings self update` and any direct `xlings install xlings --use`)
+// can opportunistically clean up old shims at the same moment they
+// replace the bootstrap. That makes the 0.4.7 → 0.4.8 first-upgrade
+// auto-heal without requiring the user to run `self init` separately.
+export void cleanup_legacy_alias_shims(const fs::path& bin_dir,
+                                       const fs::path& bootstrap_path);
+void cleanup_legacy_alias_shims(const fs::path& bin_dir,
+                                const fs::path& bootstrap_path) {
     std::error_code ec;
     auto canonical_bootstrap = fs::weakly_canonical(bootstrap_path, ec);
     if (ec) return;
@@ -166,7 +174,7 @@ void ensure_subos_shims(const fs::path& target_bin_dir,
     // One-shot migration: drop any legacy alias symlinks that older xlings
     // versions sprayed into binDir. Safe-by-default — see helper for the
     // is-symlink + resolves-to-bootstrap gate.
-    cleanup_legacy_alias_shims_(target_bin_dir, shim_src);
+    cleanup_legacy_alias_shims(target_bin_dir, shim_src);
 
     platform::make_files_executable(target_bin_dir);
 }

--- a/src/core/xself/init.cppm
+++ b/src/core/xself/init.cppm
@@ -6,6 +6,10 @@ import xlings.core.config;
 import xlings.libs.json;
 import xlings.core.log;
 import xlings.platform;
+// COMPAT(0.4.8 → drop in 0.6.0): legacy alias cleanup helper.
+// When this whole module goes away, delete the import and the cleanup
+// call at the bottom of ensure_subos_shims.
+import xlings.core.xself.compat_0_4_8;
 
 namespace xlings::xself {
 
@@ -13,25 +17,16 @@ namespace fs = std::filesystem;
 
 // Base shim names (always created).
 //
-// 0.4.8 collapses to a single canonical entry point. Earlier releases
-// also created shims for {xim, xvm, xinstall, xsubos, xself} as multicall
+// 0.4.8 collapsed to a single canonical entry point. Earlier releases also
+// created shims for {xim, xvm, xinstall, xsubos, xself} as multicall
 // aliases, but they were removed (see main.cpp's deprecated-alias path).
-// Old user installs may still have those leftover symlinks pointing to
-// the bootstrap; LEGACY_ALIAS_NAMES below drives one-shot cleanup.
+// One-shot cleanup of leftover symlinks is delegated to the compat module.
 inline constexpr std::array<std::string_view, 1> SHIM_NAMES_BASE = {
     "xlings"
 };
 
 // Optional shims (created only when pkg_root/bin/<name> exists)
 inline constexpr std::array<std::string_view, 0> SHIM_NAMES_OPTIONAL = {};
-
-// Names that USED to be created by older xlings versions. ensure_subos_shims
-// removes any of these still lingering as symlinks-to-bootstrap on disk.
-// Removal is gated on "is symlink AND points to the bootstrap binary" so
-// we never touch a user's package that happens to share a name.
-inline constexpr std::array<std::string_view, 5> LEGACY_ALIAS_NAMES = {
-    "xim", "xvm", "xinstall", "xsubos", "xself"
-};
 
 export enum class LinkResult { Symlink, Hardlink, Copy, Failed };
 
@@ -114,40 +109,6 @@ LinkResult create_shim(const fs::path& source, const fs::path& target) {
     return LinkResult::Failed;
 }
 
-// Remove leftover legacy alias symlinks (xim/xvm/xself/xsubos/xinstall)
-// from <bin_dir>. Only files that ARE symlinks AND resolve to the
-// canonical bootstrap path are removed — never touch unrelated user
-// files that happen to share a name.
-//
-// Exported so the install/use-time self-replace paths (which run during
-// `xlings self update` and any direct `xlings install xlings --use`)
-// can opportunistically clean up old shims at the same moment they
-// replace the bootstrap. That makes the 0.4.7 → 0.4.8 first-upgrade
-// auto-heal without requiring the user to run `self init` separately.
-export void cleanup_legacy_alias_shims(const fs::path& bin_dir,
-                                       const fs::path& bootstrap_path);
-void cleanup_legacy_alias_shims(const fs::path& bin_dir,
-                                const fs::path& bootstrap_path) {
-    std::error_code ec;
-    auto canonical_bootstrap = fs::weakly_canonical(bootstrap_path, ec);
-    if (ec) return;
-
-    std::string ext = bootstrap_path.extension().string();
-    for (auto name : LEGACY_ALIAS_NAMES) {
-        auto path = bin_dir / (std::string(name) + ext);
-        ec.clear();
-        if (!fs::is_symlink(path, ec)) continue;
-        ec.clear();
-        auto target = fs::weakly_canonical(path, ec);
-        if (ec) continue;
-        if (target == canonical_bootstrap) {
-            ec.clear();
-            fs::remove(path, ec);
-            log::debug("[migrate] removed legacy alias shim: {}", path.string());
-        }
-    }
-}
-
 void ensure_subos_shims(const fs::path& target_bin_dir,
                         const fs::path& shim_src,
                         const fs::path& pkg_root) {
@@ -171,10 +132,8 @@ void ensure_subos_shims(const fs::path& target_bin_dir,
         }
     }
 
-    // One-shot migration: drop any legacy alias symlinks that older xlings
-    // versions sprayed into binDir. Safe-by-default — see helper for the
-    // is-symlink + resolves-to-bootstrap gate.
-    cleanup_legacy_alias_shims(target_bin_dir, shim_src);
+    // COMPAT(0.4.8 → drop in 0.6.0): one-shot migration cleanup.
+    compat::cleanup_legacy_alias_shims(target_bin_dir, shim_src);
 
     platform::make_files_executable(target_bin_dir);
 }

--- a/src/core/xself/init.cppm
+++ b/src/core/xself/init.cppm
@@ -11,13 +11,27 @@ namespace xlings::xself {
 
 namespace fs = std::filesystem;
 
-// Base shim names (always created)
-inline constexpr std::array<std::string_view, 5> SHIM_NAMES_BASE = {
-    "xlings", "xim", "xinstall", "xsubos", "xself"
+// Base shim names (always created).
+//
+// 0.4.8 collapses to a single canonical entry point. Earlier releases
+// also created shims for {xim, xvm, xinstall, xsubos, xself} as multicall
+// aliases, but they were removed (see main.cpp's deprecated-alias path).
+// Old user installs may still have those leftover symlinks pointing to
+// the bootstrap; LEGACY_ALIAS_NAMES below drives one-shot cleanup.
+inline constexpr std::array<std::string_view, 1> SHIM_NAMES_BASE = {
+    "xlings"
 };
 
 // Optional shims (created only when pkg_root/bin/<name> exists)
 inline constexpr std::array<std::string_view, 0> SHIM_NAMES_OPTIONAL = {};
+
+// Names that USED to be created by older xlings versions. ensure_subos_shims
+// removes any of these still lingering as symlinks-to-bootstrap on disk.
+// Removal is gated on "is symlink AND points to the bootstrap binary" so
+// we never touch a user's package that happens to share a name.
+inline constexpr std::array<std::string_view, 5> LEGACY_ALIAS_NAMES = {
+    "xim", "xvm", "xinstall", "xsubos", "xself"
+};
 
 export enum class LinkResult { Symlink, Hardlink, Copy, Failed };
 
@@ -100,6 +114,32 @@ LinkResult create_shim(const fs::path& source, const fs::path& target) {
     return LinkResult::Failed;
 }
 
+// Remove leftover legacy alias symlinks (xim/xvm/xself/xsubos/xinstall)
+// from <bin_dir>. Only files that ARE symlinks AND resolve to the
+// canonical bootstrap path are removed — never touch unrelated user
+// files that happen to share a name.
+void cleanup_legacy_alias_shims_(const fs::path& bin_dir,
+                                 const fs::path& bootstrap_path) {
+    std::error_code ec;
+    auto canonical_bootstrap = fs::weakly_canonical(bootstrap_path, ec);
+    if (ec) return;
+
+    std::string ext = bootstrap_path.extension().string();
+    for (auto name : LEGACY_ALIAS_NAMES) {
+        auto path = bin_dir / (std::string(name) + ext);
+        ec.clear();
+        if (!fs::is_symlink(path, ec)) continue;
+        ec.clear();
+        auto target = fs::weakly_canonical(path, ec);
+        if (ec) continue;
+        if (target == canonical_bootstrap) {
+            ec.clear();
+            fs::remove(path, ec);
+            log::debug("[migrate] removed legacy alias shim: {}", path.string());
+        }
+    }
+}
+
 void ensure_subos_shims(const fs::path& target_bin_dir,
                         const fs::path& shim_src,
                         const fs::path& pkg_root) {
@@ -122,6 +162,11 @@ void ensure_subos_shims(const fs::path& target_bin_dir,
             }
         }
     }
+
+    // One-shot migration: drop any legacy alias symlinks that older xlings
+    // versions sprayed into binDir. Safe-by-default — see helper for the
+    // is-symlink + resolves-to-bootstrap gate.
+    cleanup_legacy_alias_shims_(target_bin_dir, shim_src);
 
     platform::make_files_executable(target_bin_dir);
 }

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -279,6 +279,12 @@ int cmd_use(const std::string& target, const std::string& version, EventStream& 
                 }
             }
         }
+        // Opportunistic migration: any time we re-pin the active xlings
+        // binary, also drop legacy alias symlinks (xim/xvm/...) left over
+        // from xlings ≤ 0.4.7. This is what makes the 0.4.7 → 0.4.8
+        // first-upgrade self-heal — `xlings self update` ends with
+        // `xlings use xlings latest`, which now lands here.
+        xself::cleanup_legacy_alias_shims(p.binDir, xlings_bin);
     }
 
     log::info("{} -> {}", target, resolved);

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -279,12 +279,11 @@ int cmd_use(const std::string& target, const std::string& version, EventStream& 
                 }
             }
         }
-        // Opportunistic migration: any time we re-pin the active xlings
-        // binary, also drop legacy alias symlinks (xim/xvm/...) left over
-        // from xlings ≤ 0.4.7. This is what makes the 0.4.7 → 0.4.8
-        // first-upgrade self-heal — `xlings self update` ends with
-        // `xlings use xlings latest`, which now lands here.
-        xself::cleanup_legacy_alias_shims(p.binDir, xlings_bin);
+        // COMPAT(0.4.8 → drop in 0.6.0): opportunistically drop legacy
+        // alias symlinks (xim/xvm/...) left over from xlings ≤ 0.4.7.
+        // Lands on this path during `xlings self update`, which ends with
+        // `xlings use xlings latest` — so first-upgrade self-heals.
+        xself::compat::cleanup_legacy_alias_shims(p.binDir, xlings_bin);
     }
 
     log::info("{} -> {}", target, resolved);

--- a/src/core/xvm/shim.cppm
+++ b/src/core/xvm/shim.cppm
@@ -16,15 +16,14 @@ import xlings.core.xvm.db;
 
 export namespace xlings::xvm {
 
-// Check if a program name is the xlings binary itself (not a shim target)
+// Check if a program name is the xlings binary itself (not a shim target).
+//
+// xlings is the single canonical entry point. Earlier releases also accepted
+// `xim` / `xvm` as multicall aliases, but they have been removed (see
+// main.cpp's deprecated-alias path for the migration error). The set is
+// closed and intentional: only the literal name `xlings`.
 bool is_xlings_binary(std::string_view name) {
-    static constexpr std::array<std::string_view, 3> XLINGS_NAMES = {
-        "xlings", "xim", "xvm"
-    };
-    for (auto n : XLINGS_NAMES) {
-        if (n == name) return true;
-    }
-    return false;
+    return name == "xlings";
 }
 
 // Extract basename from argv[0], stripping path and extension

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,10 @@ import xlings.cli;
 import xlings.core.config;
 import xlings.platform;
 import xlings.core.xvm.shim;
+// COMPAT(0.4.8 → drop in 0.6.0): see compat_0_4_8.cppm.
+// When this import is removed, also delete the
+// `report_deprecated_alias_if_match` call below.
+import xlings.core.xself.compat_0_4_8;
 
 #ifdef _WIN32
 #include <io.h>
@@ -35,29 +39,14 @@ int main(int argc, char* argv[]) {
     // Multicall: check argv[0] to determine mode.
     auto program_name = xlings::xvm::extract_program_name(argv[0]);
 
-    // 0.4.8: short-command aliases (xim/xvm/xself/xsubos/xinstall) were
-    // removed. If the user invoked one — usually via a leftover symlink
-    // from an older install or a hand-typed habit — give them a clear
-    // migration message instead of the cryptic "no version set for X"
-    // they'd otherwise hit when shim_dispatch tries to resolve the name.
-    static constexpr std::array<std::pair<std::string_view, std::string_view>, 5>
-        DEPRECATED_ALIASES = {{
-            {"xim",      "xlings install/remove/search/list/info ..."},
-            {"xvm",      "xlings use ..."},
-            {"xself",    "xlings self ..."},
-            {"xsubos",   "xlings subos ..."},
-            {"xinstall", "xlings install ..."},
-        }};
-    for (auto& [alias, suggestion] : DEPRECATED_ALIASES) {
-        if (alias == program_name) {
-            std::println(std::cerr,
-                "[error] `{}` was removed in 0.4.8. Use `{}` instead.",
-                alias, suggestion);
-            std::println(std::cerr,
-                "        Run `xlings self doctor --fix` to clean up "
-                "leftover shortcuts.");
-            return 2;
-        }
+    // COMPAT(0.4.8 → drop in 0.6.0): short-command aliases (xim/xvm/xself/
+    // xsubos/xinstall) were removed in 0.4.8. If the user invoked one —
+    // usually via a leftover symlink from an older install or a hand-typed
+    // habit — print a migration error (centralized in xself::compat) and
+    // exit with code 2 instead of falling through to shim_dispatch's
+    // cryptic "no version set for X".
+    if (xlings::xself::compat::report_deprecated_alias_if_match(program_name)) {
+        return 2;
     }
 
     int rc;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,8 +32,33 @@ int main(int argc, char* argv[]) {
     auto& p = xlings::Config::paths();
     xlings::platform::set_env_variable("XLINGS_HOME", p.homeDir.string());
 
-    // Multicall: check argv[0] to determine mode
+    // Multicall: check argv[0] to determine mode.
     auto program_name = xlings::xvm::extract_program_name(argv[0]);
+
+    // 0.4.8: short-command aliases (xim/xvm/xself/xsubos/xinstall) were
+    // removed. If the user invoked one — usually via a leftover symlink
+    // from an older install or a hand-typed habit — give them a clear
+    // migration message instead of the cryptic "no version set for X"
+    // they'd otherwise hit when shim_dispatch tries to resolve the name.
+    static constexpr std::array<std::pair<std::string_view, std::string_view>, 5>
+        DEPRECATED_ALIASES = {{
+            {"xim",      "xlings install/remove/search/list/info ..."},
+            {"xvm",      "xlings use ..."},
+            {"xself",    "xlings self ..."},
+            {"xsubos",   "xlings subos ..."},
+            {"xinstall", "xlings install ..."},
+        }};
+    for (auto& [alias, suggestion] : DEPRECATED_ALIASES) {
+        if (alias == program_name) {
+            std::println(std::cerr,
+                "[error] `{}` was removed in 0.4.8. Use `{}` instead.",
+                alias, suggestion);
+            std::println(std::cerr,
+                "        Run `xlings self doctor --fix` to clean up "
+                "leftover shortcuts.");
+            return 2;
+        }
+    }
 
     int rc;
     if (xlings::xvm::is_xlings_binary(program_name)) {

--- a/tests/e2e/cli_short_alias_removal_test.sh
+++ b/tests/e2e/cli_short_alias_removal_test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# E2E: short-command aliases (xim/xvm/xself/xsubos/xinstall) were
+# removed in 0.4.8.
+#
+# Verifies:
+#   1. self init creates ONLY the `xlings` shim — not xim/xvm/xself/...
+#   2. self init also auto-cleans pre-existing legacy alias symlinks
+#      (covers users upgrading from 0.4.7 or earlier).
+#   3. Invoking xlings binary via a legacy alias name (argv[0] = xim
+#      etc.) prints a clear migration error and exits 2.
+#   4. self doctor detects leftover legacy alias shims as findings.
+#   5. self doctor --fix removes leftover legacy alias shims.
+#   6. A user's real (non-symlink) program named `xim` is NOT touched.
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/cli_short_alias_removal"
+HOME_DIR="$RUNTIME_DIR/home"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+# Plain RUN — invoke as canonical `xlings`.
+RUN() {
+  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+}
+
+# RUN_AS — invoke the binary via a temporary symlink whose basename is
+# exactly `<alias_name>` so argv[0] basename matches what the multicall
+# dispatcher inspects. Used to simulate a user typing `xim foo`.
+RUN_AS() {
+  local alias_name="$1"; shift
+  local link_dir="$RUNTIME_DIR/.alias-link"
+  local link="$link_dir/$alias_name"
+  mkdir -p "$link_dir"
+  ln -sf "$XLINGS_BIN" "$link"
+  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$link" "$@"
+}
+
+mkdir -p "$HOME_DIR/bin"
+cp "$XLINGS_BIN" "$HOME_DIR/bin/xlings"
+
+# ── S1: self init only creates `xlings` shim ───────────────────────
+log "S1: self init produces only `xlings` shim under subos/default/bin"
+RUN self init >/dev/null 2>&1 || fail "S1: self init failed"
+shims=$(ls "$HOME_DIR/subos/default/bin" | sort | tr '\n' ' ')
+[[ "$shims" == "xlings " ]] \
+  || fail "S1: only `xlings` should be present in bin/, got: $shims"
+
+# ── S2: pre-existing legacy alias symlinks are cleaned by self init ─
+log "S2: legacy alias symlinks (from older xlings) are auto-cleaned"
+ln -s "$HOME_DIR/bin/xlings" "$HOME_DIR/subos/default/bin/xim"
+ln -s "$HOME_DIR/bin/xlings" "$HOME_DIR/subos/default/bin/xvm"
+ln -s "$HOME_DIR/bin/xlings" "$HOME_DIR/subos/default/bin/xself"
+ln -s "$HOME_DIR/bin/xlings" "$HOME_DIR/subos/default/bin/xsubos"
+ln -s "$HOME_DIR/bin/xlings" "$HOME_DIR/subos/default/bin/xinstall"
+RUN self init >/dev/null 2>&1 || fail "S2: self init failed"
+shims=$(ls "$HOME_DIR/subos/default/bin" | sort | tr '\n' ' ')
+[[ "$shims" == "xlings " ]] \
+  || fail "S2: legacy alias symlinks should be removed, but found: $shims"
+
+# ── S3: invoking via legacy alias prints migration error + exits 2 ──
+log "S3: invoking via legacy alias names → clear error + exit 2"
+for alias in xim xvm xself xsubos xinstall; do
+  rc=0
+  out=$(RUN_AS "$alias" install foo 2>&1) || rc=$?
+  [[ $rc -eq 2 ]] || fail "S3[$alias]: expected exit 2, got $rc"
+  echo "$out" | grep -q "was removed in 0.4.8" \
+    || fail "S3[$alias]: should mention 'was removed in 0.4.8'; got:\n$out"
+  echo "$out" | grep -q "Use \`xlings " \
+    || fail "S3[$alias]: should suggest 'xlings' replacement"
+done
+
+# ── S4: self doctor reports legacy alias shim ──────────────────────
+log "S4: self doctor reports legacy alias as a finding"
+ln -s "$HOME_DIR/bin/xlings" "$HOME_DIR/subos/default/bin/xvm"
+out=$(RUN self doctor 2>&1) || true
+echo "$out" | grep -q "legacy alias shim" \
+  || fail "S4: doctor should report 'legacy alias shim'; got:\n$out"
+
+# ── S5: self doctor --fix removes legacy alias shim ────────────────
+log "S5: self doctor --fix cleans leftover legacy alias shim"
+RUN self doctor --fix >/dev/null 2>&1 || true
+[[ ! -e "$HOME_DIR/subos/default/bin/xvm" ]] \
+  || fail "S5: legacy alias shim should be removed by --fix"
+
+# ── S6: user's real (non-symlink) file named `xim` is preserved ────
+log "S6: user's real file named `xim` (not a symlink) must NOT be touched"
+echo '#!/bin/sh' > "$HOME_DIR/subos/default/bin/xim"
+chmod +x "$HOME_DIR/subos/default/bin/xim"
+RUN self init >/dev/null 2>&1
+[[ -f "$HOME_DIR/subos/default/bin/xim" && ! -L "$HOME_DIR/subos/default/bin/xim" ]] \
+  || fail "S6: user's real `xim` file was unexpectedly removed"
+
+# Equally for doctor --fix
+RUN self doctor --fix >/dev/null 2>&1
+[[ -f "$HOME_DIR/subos/default/bin/xim" && ! -L "$HOME_DIR/subos/default/bin/xim" ]] \
+  || fail "S6: user's real `xim` file removed by doctor --fix"
+
+log "PASS: cli short-alias removal — scenarios 1-6"

--- a/tests/e2e/release_self_install_test.ps1
+++ b/tests/e2e/release_self_install_test.ps1
@@ -36,10 +36,15 @@ $INSTALLED_HOME = Join-Path $INSTALL_USER '.xlings'
 if (-not (Test-Path "$INSTALLED_HOME\bin\xlings.exe")) { Fail "installed home missing bin\xlings.exe" }
 if (-not (Test-Path "$INSTALLED_HOME\subos\current")) { Fail "installed home missing subos\current link" }
 
-$shims = @('xlings.exe', 'xim.exe', 'xsubos.exe', 'xself.exe')
-foreach ($s in $shims) {
-    if (-not (Test-Path "$INSTALLED_HOME\subos\default\bin\$s")) {
-        Fail "shim $s missing after self install"
+# 0.4.8 collapsed to a single canonical entry point. The xim/xvm/xself/
+# xsubos/xinstall shims were removed (see src/core/xself/compat_0_4_8.cppm).
+if (-not (Test-Path "$INSTALLED_HOME\subos\default\bin\xlings.exe")) {
+    Fail "shim xlings.exe missing after self install"
+}
+$legacy = @('xim.exe', 'xvm.exe', 'xsubos.exe', 'xself.exe', 'xinstall.exe')
+foreach ($s in $legacy) {
+    if (Test-Path "$INSTALLED_HOME\subos\default\bin\$s") {
+        Fail "legacy alias shim '$s' should NOT be created (removed in 0.4.8)"
     }
 }
 

--- a/tests/e2e/release_self_install_test.sh
+++ b/tests/e2e/release_self_install_test.sh
@@ -23,8 +23,12 @@ INSTALLED_HOME="$INSTALL_USER_DIR/.xlings"
 [[ -L "$INSTALLED_HOME/subos/current" ]] || fail "installed home missing subos/current link"
 [[ -f "$INSTALLED_HOME/config/shell/xlings-profile.sh" ]] || fail "installed home missing shell profile"
 
-for shim in xlings xim xsubos xself; do
-  [[ -x "$INSTALLED_HOME/subos/default/bin/$shim" ]] || fail "shim $shim missing after self install"
+# 0.4.8 collapsed to a single canonical entry point. The xim/xvm/xself/xsubos/
+# xinstall shims were removed (see src/core/xself/compat_0_4_8.cppm).
+[[ -x "$INSTALLED_HOME/subos/default/bin/xlings" ]] || fail "shim xlings missing after self install"
+for legacy in xim xvm xsubos xself xinstall; do
+  [[ ! -e "$INSTALLED_HOME/subos/default/bin/$legacy" ]] || \
+    fail "legacy alias shim '$legacy' should NOT be created (removed in 0.4.8)"
 done
 
 INSTALLED_PATH="$INSTALLED_HOME/subos/current/bin:$INSTALLED_HOME/bin:$(minimal_system_path)"

--- a/tests/e2e/shim_link_test.sh
+++ b/tests/e2e/shim_link_test.sh
@@ -46,9 +46,12 @@ pushd "$RUNTIME_DIR/portable" >/dev/null
 env -u XLINGS_HOME ./bin/xlings self init >/dev/null 2>&1 || fail "self init failed"
 
 # --- Verify base shims are symlinks ---
+# 0.4.8 collapsed to a single canonical entry point (`xlings`) — earlier
+# releases also created xim/xinstall/xsubos/xself shims, which were
+# removed. The legacy aliases now print a migration error if invoked.
 SHIM_DIR="$RUNTIME_DIR/portable/subos/default/bin"
 
-for shim in xlings xim xinstall xsubos xself; do
+for shim in xlings; do
   SHIM_PATH="$SHIM_DIR/$shim"
   [[ -e "$SHIM_PATH" ]] || fail "shim '$shim' does not exist"
   [[ -x "$SHIM_PATH" ]] || fail "shim '$shim' is not executable"
@@ -67,6 +70,12 @@ for shim in xlings xim xinstall xsubos xself; do
     fail "shim '$shim' resolves to '$RESOLVED', expected '$EXPECTED'"
 done
 
+# --- Verify legacy alias shims are NOT created ---
+for legacy in xim xvm xinstall xsubos xself; do
+  [[ ! -e "$SHIM_DIR/$legacy" ]] || \
+    fail "legacy alias shim '$legacy' should NOT be created (removed in 0.4.8)"
+done
+
 # --- Verify shim works (can execute via symlink) ---
 "$SHIM_DIR/xlings" -h >/dev/null 2>&1 || fail "shim xlings -h failed"
 
@@ -83,10 +92,15 @@ popd >/dev/null
 
 INSTALLED_SHIM_DIR="$INSTALL_USER_DIR/.xlings/subos/default/bin"
 
-for shim in xlings xim xinstall xsubos xself; do
+for shim in xlings; do
   SHIM_PATH="$INSTALLED_SHIM_DIR/$shim"
   [[ -e "$SHIM_PATH" ]] || fail "installed shim '$shim' does not exist"
   [[ -L "$SHIM_PATH" ]] || fail "installed shim '$shim' is not a symlink"
+done
+
+for legacy in xim xvm xinstall xsubos xself; do
+  [[ ! -e "$INSTALLED_SHIM_DIR/$legacy" ]] || \
+    fail "installed legacy alias shim '$legacy' should NOT exist"
 done
 
 echo "PASS: all shims are relative symlinks and functional"

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -1172,8 +1172,14 @@ TEST(XvmShimTest, ResolveExecutableFindsProgram) {
 }
 
 TEST(XvmShimTest, IsXlingsBinary) {
+    // 0.4.8 collapsed the multicall surface to a single canonical name.
+    // {xim, xvm, xself, xsubos, xinstall} are deprecated aliases that
+    // main.cpp short-circuits to a migration error — they must NOT be
+    // recognized as xlings here, otherwise they'd skip the error path.
     EXPECT_TRUE(xlings::xvm::is_xlings_binary("xlings"));
-    EXPECT_TRUE(xlings::xvm::is_xlings_binary("xim"));
+    EXPECT_FALSE(xlings::xvm::is_xlings_binary("xim"));
+    EXPECT_FALSE(xlings::xvm::is_xlings_binary("xvm"));
+    EXPECT_FALSE(xlings::xvm::is_xlings_binary("xself"));
     EXPECT_FALSE(xlings::xvm::is_xlings_binary("gcc"));
     EXPECT_FALSE(xlings::xvm::is_xlings_binary("node"));
     EXPECT_FALSE(xlings::xvm::is_xlings_binary("g++"));
@@ -1773,13 +1779,14 @@ TEST_F(ShimCreateTest, SourceNotExistReturnsFailed) {
 }
 
 TEST_F(ShimCreateTest, IsBuiltinShimCoversAll) {
-    // Base shims
+    // 0.4.8: only the canonical `xlings` is a builtin shim. The legacy
+    // aliases (xim/xinstall/xsubos/xself) were removed.
     EXPECT_TRUE(xlings::xself::is_builtin_shim("xlings"));
-    EXPECT_TRUE(xlings::xself::is_builtin_shim("xim"));
-    EXPECT_TRUE(xlings::xself::is_builtin_shim("xinstall"));
-    EXPECT_TRUE(xlings::xself::is_builtin_shim("xsubos"));
-    EXPECT_TRUE(xlings::xself::is_builtin_shim("xself"));
-    // Non-builtin (xmake removed from optional shims)
+    EXPECT_FALSE(xlings::xself::is_builtin_shim("xim"));
+    EXPECT_FALSE(xlings::xself::is_builtin_shim("xvm"));
+    EXPECT_FALSE(xlings::xself::is_builtin_shim("xinstall"));
+    EXPECT_FALSE(xlings::xself::is_builtin_shim("xsubos"));
+    EXPECT_FALSE(xlings::xself::is_builtin_shim("xself"));
     EXPECT_FALSE(xlings::xself::is_builtin_shim("xmake"));
     EXPECT_FALSE(xlings::xself::is_builtin_shim("gcc"));
     EXPECT_FALSE(xlings::xself::is_builtin_shim("node"));
@@ -1793,13 +1800,53 @@ TEST_F(ShimCreateTest, EnsureSubosShimsCreatesAll) {
 
     xlings::xself::ensure_subos_shims(binDir, src, fs::path{});
 
-    for (auto name : {"xlings", "xim", "xinstall", "xsubos", "xself"}) {
-        auto shim = binDir / name;
-        EXPECT_TRUE(fs::exists(shim)) << "missing shim: " << name;
+    // 0.4.8: only the canonical `xlings` shim is created.
+    auto xlings_shim = binDir / "xlings";
+    EXPECT_TRUE(fs::exists(xlings_shim));
 #if !defined(_WIN32)
-        EXPECT_TRUE(fs::is_symlink(shim)) << "shim should be symlink: " << name;
+    EXPECT_TRUE(fs::is_symlink(xlings_shim));
 #endif
+
+    // Legacy alias shims must NOT be created.
+    for (auto name : {"xim", "xvm", "xinstall", "xsubos", "xself"}) {
+        EXPECT_FALSE(fs::exists(binDir / name))
+            << "legacy alias shim '" << name << "' should not be created in 0.4.8+";
     }
+}
+
+// COMPAT(0.4.8 → drop in 0.6.0): tests for xself::compat::cleanup_legacy_alias_shims.
+// Delete this whole TEST_F block when the compat module is removed.
+TEST_F(ShimCreateTest, CleanupLegacyAliasShimsRemovesOnlyMatchingSymlinks) {
+#if defined(_WIN32)
+    GTEST_SKIP() << "symlink semantics differ on Windows";
+#else
+    namespace fs = std::filesystem;
+    auto src = testDir_ / "src" / "xlings";
+    auto binDir = testDir_ / "dst";
+    fs::create_directories(binDir);
+
+    // Layout under test:
+    //   xvm, xself, xsubos, xinstall — symlinks → bootstrap (must be removed)
+    //   xim                          — regular user file with colliding name
+    //                                  (must survive — gate is "is symlink")
+    for (auto name : {"xvm", "xself", "xsubos", "xinstall"}) {
+        fs::create_symlink(src, binDir / name);
+    }
+    auto userFile = binDir / "xim";
+    std::ofstream(userFile) << "user data\n";
+
+    xlings::xself::compat::cleanup_legacy_alias_shims(binDir, src);
+
+    // Regular user file with a colliding name must survive.
+    EXPECT_TRUE(fs::exists(userFile));
+    EXPECT_FALSE(fs::is_symlink(userFile));
+
+    // Matching symlinks must be removed.
+    for (auto name : {"xvm", "xself", "xsubos", "xinstall"}) {
+        EXPECT_FALSE(fs::exists(binDir / name))
+            << "legacy alias symlink '" << name << "' should have been removed";
+    }
+#endif
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

xlings collapses to a single canonical entry point. The multicall short aliases (`xim`, `xvm`, `xself`, `xsubos`, `xinstall`) — never bound to xlings's version, named-but-not-functional in some configurations, root cause of multiple state-drift bugs — are removed.

Users who hit a leftover alias get a clear migration message; `xlings self doctor --fix` cleans up old shims.

## Behavior changes (user-visible)

| Before | After |
| --- | --- |
| `xlings self init` creates 5 shims: xlings + xim + xinstall + xsubos + xself | Creates 1 shim: just `xlings` |
| Old install with leftover `xim` symlink + run `xim install foo` | `[error] \`xim\` was removed in 0.4.8. Use \`xlings install/remove/search/list/info ...\` instead. Run \`xlings self doctor --fix\` to clean up leftover shortcuts.` (exit 2) |
| `xlings self doctor` doesn't notice legacy alias shims | Reports them as findings; `--fix` removes them |
| Legacy alias shim cleanup | Auto on every `self init`. Safe gate: only acts on symlinks resolving to the bootstrap binary, never user files |

## Code changes

- **`shim.cppm`**: `is_xlings_binary` collapses to `name == "xlings"`. process_xvm_operations / cmd_use self-replace narrow automatically.
- **`xself/init.cppm`**: `SHIM_NAMES_BASE` shrinks to `{xlings}`. New `LEGACY_ALIAS_NAMES` + `cleanup_legacy_alias_shims_` helper. `ensure_subos_shims` calls the helper at every refresh.
- **`main.cpp`**: deprecated-alias short-circuit. Prints migration error + exits 2 instead of falling through to a cryptic shim_dispatch failure.
- **`xself/doctor.cppm`**: detects + heals leftover legacy alias shims (Check 2.5).

## Test plan

- [x] New e2e: `cli_short_alias_removal_test.sh` — 6 scenarios pass
- [x] Existing `shim_link_test.sh` updated for the new contract; passes
- [x] All 33 functional e2e tests pass; the only failures (3) are pre-existing release-tarball smoke tests requiring `build/release.tar.gz` (unrelated)
- [x] CI Linux yaml wires E2E-18
- [ ] CI: linux / archlinux / macos / windows

## External-repo follow-ups (not required for 0.4.8)

- `xim-pkgindex/pkgs/x/xlings.lua`: `programs = {"xlings", "xim", "xinstall"}` → `{"xlings"}`
- `xim-pkgindex/pkgs/s/seeme-report.lua`: `os.exec("xvm remove ...")` → lua `xvm.remove()` API
- `d2x/src/xlings.cppm:62`: `"xim -s d2x:"` → `"xlings search d2x:"`

These execute the old short forms today. With this PR's deprecated-alias path, they will surface a clean error rather than a broken state — they can be fixed at any time without blocking the release.