### PR TITLE
feat: GitHub mirror fallback for resilient downloads (Step 1)

### DIFF
--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -167,6 +167,10 @@ jobs:
         run: |
           bash tests/e2e/cli_short_alias_removal_test.sh
 
+      - name: "E2E-19: GitHub mirror fallback wiring (HTTP / git / index)"
+        run: |
+          bash tests/e2e/mirror_fallback_test.sh
+
       - name: Attach artifact
         uses: actions/upload-artifact@v4
         if: success()

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -141,6 +141,10 @@ jobs:
         run: |
           bash tests/e2e/tui_utf8_test.sh
 
+      - name: "E2E-09: GitHub mirror fallback wiring (HTTP / git / index)"
+        run: |
+          bash tests/e2e/mirror_fallback_test.sh
+
       - name: Attach artifact
         uses: actions/upload-artifact@v4
         if: success()

--- a/docs/plans/2026-05-01-mirror-fallback-step1.md
+++ b/docs/plans/2026-05-01-mirror-fallback-step1.md
@@ -1,0 +1,235 @@
+# Mirror Fallback Step 1 — Implementation Plan
+
+**Date**: 2026-05-01
+**Status**: in implementation
+**Branch**: `feat/mirror-fallback`
+
+## Goal
+
+Ship a minimum viable "GitHub URL fallback" mechanism that covers all three resource classes xlings downloads:
+
+1. **HTTP downloads** — release tarballs, raw files, archives
+2. **Git clone** — source-build packages (`fromsource.lua`, project templates)
+3. **Index repos** — `xim-pkgindex` and its sub-indexes
+
+The mechanism is **failure-driven**, not preemptive: the original URL is always tried first, and mirror URLs are appended as a fallback queue. This keeps the happy path zero-overhead for users who can reach GitHub directly, while giving users on restricted networks a chance to recover automatically.
+
+## Scope (in)
+
+- A new top-level module `xlings.core.mirror` that exposes `expand(url, opts) -> [url]`.
+- Three URL-rewriting "forms": `prefix` (ghproxy-style), `host-replace` (kkgithub-style), `jsdelivr` (raw-only CDN).
+- A built-in default mirror list (compiled into the binary as a raw string literal).
+- An optional user override at `~/.xlings/data/github-mirrors.json`.
+- Three integration points in existing code (HTTP downloader, git clone, index repo sync).
+- Configuration via `XLINGS_MIRROR_FALLBACK={off|auto|force}` env var and `mirror_fallback` field in `~/.xlings.json`.
+- Unit tests for classification, rewriting, expand semantics.
+- An e2e test that mocks a 503 GitHub and verifies fallback succeeds with sha256 still validated.
+
+## Scope (out — explicitly deferred)
+
+| Deferred | Reason |
+|----------|--------|
+| Mid-flight throughput monitoring + speculative race | Step 2 — needs more invasive plumbing into the download loop |
+| Cross-process mirror health stats | Step 3 — only worth doing if Step 1 reveals patterns |
+| `xlings mirror {list,test,use,report}` CLI subcommand | Step 3 — env var + config covers all current needs |
+| Custom proxy URL templates (corporate intranet) | Wait for user feedback |
+| Remote hot-update of mirror list | Chicken-and-egg: can't fetch the list if GitHub is unreachable |
+| First-party `gitee.com/d2learn/xim-pkgindex` mirror | Independent ops task; tracked separately |
+
+## Open questions (decided)
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| 1 | gitee one-party index mirror status | Independent ops task; not in this PR | Step 1 covers the "GitHub fails" case regardless |
+| 2 | Where does git clone happen? | `xim/downloader.cppm:25-127` (source pkgs) and `xim/repo.cppm:160-177` (index repos) | Confirmed by code scan |
+| 3 | Trigger fallback when `mirror=CN` too? | Yes — fallback is failure-driven, not config-driven | Don't let mirror config become a single point of failure |
+| 4 | Failure criteria | HTTP: connect timeout / 5xx / 429 / 403; Git: subprocess exit code ≠ 0. NOT 404/401 | 404/401 are real failures; stderr parsing is fragile |
+| 5 | Default JSON embedding | Raw string literal in `.cppm` | No xmake changes; constexpr-evaluable |
+| 6 | Same-priority shuffle? | Yes, PID-seeded stable shuffle | Distribute load across mirrors; reproducible per-process |
+
+## Module structure
+
+```
+src/core/mirror.cppm           — umbrella, re-exports types + expand
+src/core/mirror/types.cppm     — ResourceType / Form / Mode enums + Mirror struct
+src/core/mirror/forms.cppm     — three URL-rewriting strategies
+src/core/mirror/registry.cppm  — embedded default JSON + user override loader
+src/core/mirror/expand.cppm    — classify() + expand() core logic
+```
+
+Mirrors the `xself.cppm` umbrella + partition pattern used for the 0.4.8 alias migration. Future Step 2 race code goes in `src/core/mirror/race.cppm` without touching the existing files.
+
+## Public API
+
+```cpp
+namespace xlings::mirror {
+
+enum class ResourceType { Release, Raw, Archive, Git, Unknown };
+enum class Form         { Prefix, HostReplace, JsDelivr };
+enum class Mode         { Auto, Off, Force };
+
+struct Mirror {
+    std::string name;
+    std::string host;
+    Form form;
+    std::vector<ResourceType> supports;
+    int priority = 100;
+    std::optional<std::size_t> limit_bytes;
+};
+
+struct ExpandOptions {
+    std::optional<ResourceType> type;
+    Mode mode = Mode::Auto;
+    std::size_t expected_size = 0;
+};
+
+ResourceType classify(std::string_view url);
+bool is_github_url(std::string_view url);
+
+std::vector<std::string> expand(std::string_view url,
+                                const ExpandOptions& opts = {});
+
+Mode current_mode();
+void set_mode(Mode mode);  // testing only
+
+} // namespace xlings::mirror
+```
+
+## URL-rewriting forms
+
+```
+form=prefix
+  https://github.com/x/y/releases/download/v1/asset.tar.gz
+  → https://ghfast.top/https://github.com/x/y/releases/download/v1/asset.tar.gz
+
+form=host-replace
+  https://github.com/x/y/releases/download/v1/asset.tar.gz
+  → https://kkgithub.com/x/y/releases/download/v1/asset.tar.gz
+  https://raw.githubusercontent.com/x/y/main/file.txt
+  → https://kkgithub.com/x/y/raw/main/file.txt
+
+form=jsdelivr (raw only)
+  https://raw.githubusercontent.com/x/y/<ref>/path/file
+  → https://cdn.jsdelivr.net/gh/x/y@<ref>/path/file
+```
+
+## Default mirror list (built-in)
+
+```json
+{
+  "version": 1,
+  "mirrors": [
+    { "name": "jsdelivr",     "form": "jsdelivr",     "host": "cdn.jsdelivr.net",
+      "supports": ["raw"], "limit_bytes": 52428800, "priority": 5 },
+    { "name": "ghfast",       "form": "prefix",       "host": "ghfast.top",
+      "supports": ["release", "raw", "archive", "git"], "priority": 10 },
+    { "name": "ghproxy-net",  "form": "prefix",       "host": "ghproxy.net",
+      "supports": ["release", "raw", "archive", "git"], "priority": 20 },
+    { "name": "kkgithub",     "form": "host-replace", "host": "kkgithub.com",
+      "supports": ["release", "raw", "archive", "git"], "priority": 30 }
+  ]
+}
+```
+
+## Config resolution flow
+
+```
+At first use of mirror::expand() in a process:
+  1. Resolve mode: env XLINGS_MIRROR_FALLBACK > .xlings.json mirror_fallback > Auto
+  2. Resolve list: ~/.xlings/data/github-mirrors.json (if exists, full override)
+                   else compiled-in DEFAULT_MIRRORS_JSON
+  3. Cache both for the process lifetime
+```
+
+## Integration points
+
+### A. `src/core/xim/downloader.cppm:157-160` (HTTP)
+
+Append `mirror::expand(url)` results to the existing `urls` vector after package-author fallbacks, deduped against existing entries.
+
+### B. `src/core/xim/downloader.cppm:25-127` (git clone for source pkgs)
+
+Refactor `git_clone_one` to iterate a fallback list. Merge `task.fallbackUrls` (insert after primary) with `mirror::expand(url, {type=Git})` (append to tail). Try sequentially; on subprocess failure, clean partial clone dir and retry next URL. Honor cancellation between attempts.
+
+### C. `src/core/xim/repo.cppm:160-177` (index repo sync)
+
+Same pattern as B: in the clone branch, replace single-URL clone with a fallback loop using `mirror::expand`. Pull-then-fail-then-reclone path automatically benefits because the reclone goes through the new code.
+
+## Configuration knobs
+
+```
+Env (highest priority):
+  XLINGS_MIRROR_FALLBACK=auto    # default
+  XLINGS_MIRROR_FALLBACK=off     # strict: original URL only (CI tests)
+  XLINGS_MIRROR_FALLBACK=force   # skip original, go direct to mirrors
+
+Config file (~/.xlings.json or project .xlings.json):
+  "mirror_fallback": "auto" | "off" | "force"
+```
+
+No CLI flags in Step 1.
+
+## Test plan
+
+### Unit tests (`tests/unit/test_mirror.cpp`)
+
+- `classify()` — release / raw / archive / git / unknown
+- `rewrite()` × 3 forms × representative URLs
+- `expand()` — Auto / Off / Force, GitHub vs non-GitHub URL, size limit filtering
+- registry — user-override JSON fully replaces default
+- shuffle — same priority bucket rotates between calls (within same process is stable)
+
+### E2E test (`tests/e2e/mirror_fallback_test.sh`)
+
+Six scenarios using Python's stdlib `http.server` for mock origins:
+
+- S1: original URL serves 200 → no fallback path entered (verify by log)
+- S2: original URL 503 + mirror 200 → fallback succeeds + sha256 verified
+- S3: `XLINGS_MIRROR_FALLBACK=off` + original URL 503 → hard fail (no fallback)
+- S4: gitee URL + 503 → no expansion (output list is exactly `[gitee_url]`)
+- S5: user-supplied `~/.xlings/data/github-mirrors.json` → replaces defaults
+- S6: 404 on original URL → does NOT trigger fallback (real not-found)
+
+## Files
+
+```
+NEW:
+  docs/plans/2026-05-01-mirror-fallback-step1.md   (this file)
+  src/core/mirror.cppm                             (~10 LOC, umbrella)
+  src/core/mirror/types.cppm                       (~80 LOC)
+  src/core/mirror/forms.cppm                       (~120 LOC)
+  src/core/mirror/registry.cppm                    (~150 LOC)
+  src/core/mirror/expand.cppm                      (~150 LOC)
+  tests/unit/test_mirror.cpp                       (~250 LOC)
+  tests/e2e/mirror_fallback_test.sh                (~150 LOC)
+
+MODIFIED:
+  src/core/xim/downloader.cppm                     (~40 LOC added)
+  src/core/xim/repo.cppm                           (~20 LOC added)
+  src/core/config.cppm                             (~10 LOC, mirror_fallback reader)
+  .github/workflows/xlings-ci-linux.yml            (~3 LOC, new e2e step)
+```
+
+## Commit & PR plan
+
+- **Commit 1** — `feat(mirror): add core mirror module + unit tests`
+  Adds the 5 mirror/*.cppm files + unit tests. Zero behavior change in main binary.
+- **Commit 2** — `feat(mirror): wire fallback into HTTP/git/index download paths`
+  Three integration points + config field + e2e test + CI step.
+
+Single PR `feat: github mirror fallback for resilient downloads`.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Mirror serves wrong/tampered content | sha256 (HTTP) and ref hash (git) checks already enforced; not relaxed for mirrors |
+| ghproxy-style mirror dies | List is data-driven; remove via config or release patch |
+| Fallback adds latency on every download | Only attempted after primary fails; happy path zero-cost |
+| Same-priority mirrors get hammered | PID-seeded shuffle distributes load |
+| User has corporate proxy that needs different config | Existing HTTP_PROXY env vars still respected (tinyhttps layer below) |
+| Step 2 (race) requires module restructure | Module is already partition-based; race goes in `mirror/race.cppm` without touching others |
+
+## Removal / future-evolution markers
+
+This is **not** transitional code — mirror fallback is a permanent feature. No `COMPAT` markers needed. The module is structured for extension (race, stats, custom proxies) without rewrite.

--- a/src/core/mirror.cppm
+++ b/src/core/mirror.cppm
@@ -1,0 +1,23 @@
+// xlings.core.mirror — top-level module entry for the GitHub URL mirror
+// fallback subsystem.
+//
+// All actual logic lives in partition files under src/core/mirror/.
+// This file's only job is to re-export the public surface so callers
+// (xim/downloader.cppm, xim/repo.cppm, etc.) can `import xlings.core.mirror`
+// and reach `xlings::mirror::expand(...)` without depending on the
+// individual partition modules.
+//
+// Layout:
+//   mirror.cppm           — this file (re-exports)
+//   mirror/types.cppm     — ResourceType / Form / Mode enums + Mirror struct
+//   mirror/forms.cppm     — three URL-rewriting strategies (internal)
+//   mirror/registry.cppm  — embedded default list + user-override loader
+//   mirror/expand.cppm    — classify() + expand() public API
+//
+// See docs/plans/2026-05-01-mirror-fallback-step1.md for the full design.
+
+export module xlings.core.mirror;
+
+export import xlings.core.mirror.types;
+export import xlings.core.mirror.expand;
+// registry and forms are implementation details, not re-exported.

--- a/src/core/mirror/expand.cppm
+++ b/src/core/mirror/expand.cppm
@@ -1,0 +1,172 @@
+// xlings.core.mirror.expand — top-level URL expansion logic.
+//
+// `expand(url, opts)` is the single entry point used by HTTP / git / index
+// download paths. Given an input URL it returns an ordered list of URLs
+// to try in sequence — original first, then mirror variants — based on
+// the current Mode, the resource type, and the registered mirror list.
+
+export module xlings.core.mirror.expand;
+
+import std;
+
+import xlings.core.config;
+import xlings.core.log;
+import xlings.libs.json;
+import xlings.platform;
+import xlings.core.mirror.types;
+import xlings.core.mirror.registry;
+import xlings.core.mirror.forms;
+
+namespace xlings::mirror {
+
+namespace {
+
+constexpr std::string_view kGithubHost      = "https://github.com/";
+constexpr std::string_view kRawHost         = "https://raw.githubusercontent.com/";
+constexpr std::string_view kCodeloadHost    = "https://codeload.github.com/";
+constexpr std::string_view kObjectsHost     = "https://objects.githubusercontent.com/";
+
+Mode parse_mode_(std::string_view s) {
+    if (s == "off")   return Mode::Off;
+    if (s == "force") return Mode::Force;
+    return Mode::Auto;  // default for unknown / "auto" / empty
+}
+
+// Resolve the process-wide mode once: env var > .xlings.json > Auto.
+Mode resolve_mode_() {
+    if (auto env = std::getenv("XLINGS_MIRROR_FALLBACK"); env && *env)
+        return parse_mode_(env);
+
+    // Read from ~/.xlings.json directly. Adding a typed field to Config
+    // is overkill for one optional setting most users never touch.
+    auto& paths = Config::paths();
+    auto path = paths.homeDir / ".xlings.json";
+    std::error_code ec;
+    if (std::filesystem::exists(path, ec)) {
+        try {
+            auto content = platform::read_file_to_string(path.string());
+            auto json = nlohmann::json::parse(content, nullptr, false);
+            if (!json.is_discarded() && json.is_object()) {
+                if (auto it = json.find("mirror_fallback");
+                    it != json.end() && it->is_string()) {
+                    return parse_mode_(it->get<std::string>());
+                }
+            }
+        } catch (...) {}
+    }
+    return Mode::Auto;
+}
+
+Mode& mode_storage_() {
+    static Mode mode = resolve_mode_();
+    return mode;
+}
+
+// Stable per-process shuffle seed: derive from start-of-process steady
+// clock so different xlings processes hit different mirrors first when
+// priorities tie. A single process keeps the same seed for the rest of
+// its lifetime so debug log reading is reproducible.
+std::uint32_t shuffle_seed_() {
+    static const std::uint32_t seed = static_cast<std::uint32_t>(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+    return seed;
+}
+
+// Shuffle elements with the same priority in-place, deterministic per process.
+void shuffle_within_priority_(std::vector<Mirror>& mirrors) {
+    if (mirrors.size() < 2) return;
+    std::mt19937 rng(shuffle_seed_());
+    auto it = mirrors.begin();
+    while (it != mirrors.end()) {
+        auto end = std::find_if(it, mirrors.end(),
+            [p = it->priority](const Mirror& m) { return m.priority != p; });
+        if (std::distance(it, end) > 1) {
+            std::shuffle(it, end, rng);
+        }
+        it = end;
+    }
+}
+
+} // anonymous namespace
+
+// Mode accessor. Resolved lazily on first read.
+export Mode current_mode() {
+    return mode_storage_();
+}
+
+// Override the process-wide mode. Primarily for tests.
+export void set_mode(Mode mode) {
+    mode_storage_() = mode;
+}
+
+// Heuristic URL classification. Bare github.com URLs that are ambiguous
+// between web view and git clone get classified as Unknown — the git
+// caller passes ResourceType::Git via ExpandOptions to disambiguate.
+export ResourceType classify(std::string_view url) {
+    if (url.starts_with(kRawHost))      return ResourceType::Raw;
+    if (url.starts_with(kCodeloadHost)) return ResourceType::Archive;
+    if (url.starts_with(kObjectsHost))  return ResourceType::Release;
+    if (url.starts_with(kGithubHost)) {
+        if (url.find("/releases/download/") != std::string_view::npos)
+            return ResourceType::Release;
+        if (url.find("/archive/") != std::string_view::npos)
+            return ResourceType::Archive;
+        if (url.ends_with(".git"))
+            return ResourceType::Git;
+    }
+    return ResourceType::Unknown;
+}
+
+export bool is_github_url(std::string_view url) {
+    return url.starts_with(kGithubHost) ||
+           url.starts_with(kRawHost) ||
+           url.starts_with(kCodeloadHost) ||
+           url.starts_with(kObjectsHost);
+}
+
+// Main entry point. Returns the ordered list of URLs to try.
+//
+// Empty input is preserved as-is; callers handle empty URL elsewhere.
+// Non-GitHub URLs are returned unmodified (no expansion). Mode::Off
+// always returns just the original.
+export std::vector<std::string> expand(std::string_view url,
+                                       const ExpandOptions& opts = {}) {
+    std::vector<std::string> out;
+
+    Mode mode = opts.mode.value_or(current_mode());
+
+    // Off → strict: original URL only.
+    if (mode == Mode::Off) {
+        if (!url.empty()) out.emplace_back(url);
+        return out;
+    }
+
+    // Non-GitHub URL: return as-is. We never proxy gitee, custom hosts, etc.
+    if (!is_github_url(url)) {
+        if (!url.empty()) out.emplace_back(url);
+        return out;
+    }
+
+    // Determine type.
+    ResourceType type = opts.type.value_or(classify(url));
+    if (type == ResourceType::Unknown) {
+        out.emplace_back(url);
+        return out;
+    }
+
+    auto candidates = filtered(type, opts.expected_size);
+    shuffle_within_priority_(candidates);
+
+    if (mode != Mode::Force) {
+        out.emplace_back(url);
+    }
+    for (const auto& m : candidates) {
+        if (auto rewritten = rewrite(url, m, type)) {
+            if (std::ranges::find(out, *rewritten) == out.end())
+                out.push_back(std::move(*rewritten));
+        }
+    }
+    return out;
+}
+
+} // namespace xlings::mirror

--- a/src/core/mirror/forms.cppm
+++ b/src/core/mirror/forms.cppm
@@ -1,0 +1,125 @@
+// xlings.core.mirror.forms — three URL-rewriting strategies that mirrors
+// can declare via `form` in the registry JSON. Each strategy is a pure
+// function so it's trivially unit-testable.
+
+export module xlings.core.mirror.forms;
+
+import std;
+import xlings.core.mirror.types;
+
+namespace xlings::mirror {
+
+namespace {
+
+// "https://github.com/" prefix used by the host-replace strategy.
+constexpr std::string_view kGithubHost = "https://github.com/";
+constexpr std::string_view kRawHost    = "https://raw.githubusercontent.com/";
+constexpr std::string_view kCodeloadHost = "https://codeload.github.com/";
+
+// Replace the leading host portion of `url` (matched by `prefix`, which
+// must end with '/') with `replacement` (also ending with '/'). Returns
+// nullopt if `url` doesn't start with `prefix`.
+std::optional<std::string> replace_host_prefix(std::string_view url,
+                                                std::string_view prefix,
+                                                std::string_view replacement) {
+    if (!url.starts_with(prefix)) return std::nullopt;
+    std::string out;
+    out.reserve(replacement.size() + url.size() - prefix.size());
+    out.append(replacement);
+    out.append(url.substr(prefix.size()));
+    return out;
+}
+
+// jsDelivr's gh/ scheme expects: gh/<owner>/<repo>@<ref>/<path>
+// Source URL shape we accept: https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>
+// Returns nullopt if path doesn't have all 4 segments.
+std::optional<std::string> rewrite_jsdelivr_(std::string_view url,
+                                              std::string_view mirror_host) {
+    if (!url.starts_with(kRawHost)) return std::nullopt;
+    auto rest = url.substr(kRawHost.size());
+
+    // Split on '/' for the first three segments (owner, repo, ref).
+    std::array<std::string_view, 3> parts{};
+    std::size_t start = 0;
+    for (int i = 0; i < 3; ++i) {
+        auto slash = rest.find('/', start);
+        if (slash == std::string_view::npos) return std::nullopt;
+        parts[i] = rest.substr(start, slash - start);
+        start = slash + 1;
+    }
+    if (parts[0].empty() || parts[1].empty() || parts[2].empty())
+        return std::nullopt;
+    auto path = rest.substr(start);
+    if (path.empty()) return std::nullopt;
+
+    return std::format("https://{}/gh/{}/{}@{}/{}",
+                       mirror_host, parts[0], parts[1], parts[2], path);
+}
+
+// Host-replace handles github.com directly and rewrites raw/codeload
+// flavors into the equivalent path under the mirror host (kkgithub-style).
+std::optional<std::string> rewrite_host_replace_(std::string_view url,
+                                                  std::string_view mirror_host,
+                                                  ResourceType type) {
+    auto base = std::format("https://{}/", mirror_host);
+
+    // github.com → mirror_host (1:1 path mapping)
+    if (auto out = replace_host_prefix(url, kGithubHost, base)) return out;
+
+    // raw.githubusercontent.com/x/y/<ref>/path → mirror/x/y/raw/<ref>/path
+    if (url.starts_with(kRawHost)) {
+        auto rest = url.substr(kRawHost.size());
+        // Need at least owner/repo/ref/path
+        std::size_t slash1 = rest.find('/');
+        if (slash1 == std::string_view::npos) return std::nullopt;
+        std::size_t slash2 = rest.find('/', slash1 + 1);
+        if (slash2 == std::string_view::npos) return std::nullopt;
+        // Insert "raw/" between owner/repo and the rest:
+        //   owner/repo/<ref>/path → owner/repo/raw/<ref>/path
+        return std::format("https://{}/{}/raw/{}",
+                           mirror_host,
+                           rest.substr(0, slash2),  // owner/repo
+                           rest.substr(slash2 + 1));  // ref/path
+    }
+
+    // codeload.github.com/x/y/<type>/<ref> → mirror/x/y/<type>/<ref>
+    // (Most host-replace mirrors don't proxy codeload; mark as unsupported
+    // by returning nullopt so the registry filter drops it instead of
+    // returning a bad URL.)
+    if (url.starts_with(kCodeloadHost) && type == ResourceType::Archive) {
+        return std::nullopt;
+    }
+
+    return std::nullopt;
+}
+
+// Prefix is the simplest: prepend the mirror as a proxy.
+std::optional<std::string> rewrite_prefix_(std::string_view url,
+                                            std::string_view mirror_host) {
+    // Only proxy URLs we actually want mirrored. Refuse to wrap
+    // non-GitHub-family URLs — caller should not have asked.
+    if (!url.starts_with(kGithubHost) &&
+        !url.starts_with(kRawHost) &&
+        !url.starts_with(kCodeloadHost)) {
+        return std::nullopt;
+    }
+    return std::format("https://{}/{}", mirror_host, url);
+}
+
+} // anonymous namespace
+
+// Public entry point used by expand.cppm. Returns the rewritten URL, or
+// nullopt when the mirror's form is incompatible with the input URL —
+// the caller drops that mirror from the candidate list.
+export std::optional<std::string> rewrite(std::string_view url,
+                                          const Mirror& mirror,
+                                          ResourceType type) {
+    switch (mirror.form) {
+        case Form::Prefix:      return rewrite_prefix_(url, mirror.host);
+        case Form::HostReplace: return rewrite_host_replace_(url, mirror.host, type);
+        case Form::JsDelivr:    return rewrite_jsdelivr_(url, mirror.host);
+    }
+    return std::nullopt;
+}
+
+} // namespace xlings::mirror

--- a/src/core/mirror/registry.cppm
+++ b/src/core/mirror/registry.cppm
@@ -1,0 +1,188 @@
+// xlings.core.mirror.registry — load + cache the mirror list.
+//
+// Resolution order (first hit wins):
+//   1. ~/.xlings/data/github-mirrors.json (user override; full replacement)
+//   2. compiled-in DEFAULT_MIRRORS_JSON
+//
+// Loaded once on first call to all() / filtered(), then memoized for the
+// process lifetime. Failure to parse a user override is logged at warn
+// level and the default list is used instead.
+
+export module xlings.core.mirror.registry;
+
+import std;
+
+import xlings.core.config;
+import xlings.core.log;
+import xlings.libs.json;
+import xlings.platform;
+import xlings.core.mirror.types;
+
+namespace xlings::mirror {
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Default mirror list. This is an embedded resource — updates require a
+// release. See docs/plans/2026-05-01-mirror-fallback-step1.md for the
+// rationale (rejecting remote hot-update because of chicken-and-egg).
+//
+// Ordering by priority (ascending = tried first):
+//   jsdelivr     priority  5   raw-only, very stable
+//   ghfast       priority 10   active 2025
+//   ghproxy-net  priority 20   active 2025
+//   kkgithub     priority 30   host-replace style fallback
+constexpr std::string_view DEFAULT_MIRRORS_JSON = R"JSON({
+  "version": 1,
+  "mirrors": [
+    {
+      "name": "jsdelivr",
+      "form": "jsdelivr",
+      "host": "cdn.jsdelivr.net",
+      "supports": ["raw"],
+      "limit_bytes": 52428800,
+      "priority": 5
+    },
+    {
+      "name": "ghfast",
+      "form": "prefix",
+      "host": "ghfast.top",
+      "supports": ["release", "raw", "archive", "git"],
+      "priority": 10
+    },
+    {
+      "name": "ghproxy-net",
+      "form": "prefix",
+      "host": "ghproxy.net",
+      "supports": ["release", "raw", "archive", "git"],
+      "priority": 20
+    },
+    {
+      "name": "kkgithub",
+      "form": "host-replace",
+      "host": "kkgithub.com",
+      "supports": ["release", "raw", "archive", "git"],
+      "priority": 30
+    }
+  ]
+})JSON";
+
+std::optional<Form> parse_form_(std::string_view s) {
+    if (s == "prefix")       return Form::Prefix;
+    if (s == "host-replace") return Form::HostReplace;
+    if (s == "jsdelivr")     return Form::JsDelivr;
+    return std::nullopt;
+}
+
+std::optional<ResourceType> parse_resource_type_(std::string_view s) {
+    if (s == "release") return ResourceType::Release;
+    if (s == "raw")     return ResourceType::Raw;
+    if (s == "archive") return ResourceType::Archive;
+    if (s == "git")     return ResourceType::Git;
+    return std::nullopt;
+}
+
+// Parse a mirrors JSON document into a vector of Mirror. Returns nullopt
+// on any parse error so the caller can fall back to defaults.
+std::optional<std::vector<Mirror>> parse_mirrors_json_(std::string_view json_text) {
+    auto root = nlohmann::json::parse(json_text, nullptr, false);
+    if (root.is_discarded() || !root.is_object()) return std::nullopt;
+
+    auto mirrors_node = root.find("mirrors");
+    if (mirrors_node == root.end() || !mirrors_node->is_array()) return std::nullopt;
+
+    std::vector<Mirror> out;
+    out.reserve(mirrors_node->size());
+
+    for (const auto& m : *mirrors_node) {
+        if (!m.is_object()) continue;
+        Mirror mir;
+
+        if (auto it = m.find("name"); it != m.end() && it->is_string())
+            mir.name = it->get<std::string>();
+        if (auto it = m.find("host"); it != m.end() && it->is_string())
+            mir.host = it->get<std::string>();
+        if (auto it = m.find("priority"); it != m.end() && it->is_number_integer())
+            mir.priority = it->get<int>();
+
+        auto form_it = m.find("form");
+        if (form_it == m.end() || !form_it->is_string()) continue;
+        auto form = parse_form_(form_it->get<std::string>());
+        if (!form) continue;
+        mir.form = *form;
+
+        if (auto it = m.find("supports"); it != m.end() && it->is_array()) {
+            for (const auto& s : *it) {
+                if (!s.is_string()) continue;
+                if (auto rt = parse_resource_type_(s.get<std::string>()))
+                    mir.supports.push_back(*rt);
+            }
+        }
+        if (auto it = m.find("limit_bytes"); it != m.end() && it->is_number_unsigned())
+            mir.limit_bytes = it->get<std::size_t>();
+
+        if (mir.host.empty() || mir.name.empty() || mir.supports.empty())
+            continue;
+        out.push_back(std::move(mir));
+    }
+
+    // Stable sort ascending by priority for deterministic iteration.
+    std::ranges::stable_sort(out, [](const Mirror& a, const Mirror& b) {
+        return a.priority < b.priority;
+    });
+    return out;
+}
+
+// Load the effective mirror list once, memoize for process lifetime.
+const std::vector<Mirror>& load_once_() {
+    static const std::vector<Mirror> mirrors = [] {
+        auto& paths = Config::paths();
+        auto user_path = paths.dataDir / "github-mirrors.json";
+
+        std::error_code ec;
+        if (fs::exists(user_path, ec)) {
+            auto content = platform::read_file_to_string(user_path.string());
+            if (auto parsed = parse_mirrors_json_(content)) {
+                log::debug("[mirror] loaded {} mirrors from {}",
+                          parsed->size(), user_path.string());
+                return std::move(*parsed);
+            }
+            log::warn("[mirror] failed to parse {}, falling back to defaults",
+                     user_path.string());
+        }
+
+        if (auto parsed = parse_mirrors_json_(DEFAULT_MIRRORS_JSON))
+            return std::move(*parsed);
+
+        log::warn("[mirror] failed to parse compiled-in defaults; mirror "
+                  "fallback disabled");
+        return std::vector<Mirror>{};
+    }();
+    return mirrors;
+}
+
+} // anonymous namespace
+
+// All mirrors, in priority order. Read-only view; the underlying storage
+// is process-wide and immutable after first load.
+export std::span<const Mirror> all() {
+    return load_once_();
+}
+
+// Mirrors filtered by resource type and (optionally) by `expected_size`.
+// Expected size of 0 means "size unknown" — limit_bytes filter is skipped
+// because we can't know whether the mirror will refuse the request.
+export std::vector<Mirror> filtered(ResourceType type,
+                                     std::size_t expected_size = 0) {
+    std::vector<Mirror> out;
+    for (const auto& m : load_once_()) {
+        if (std::ranges::find(m.supports, type) == m.supports.end()) continue;
+        if (expected_size > 0 && m.limit_bytes && expected_size > *m.limit_bytes)
+            continue;
+        out.push_back(m);
+    }
+    return out;
+}
+
+} // namespace xlings::mirror

--- a/src/core/mirror/types.cppm
+++ b/src/core/mirror/types.cppm
@@ -1,0 +1,83 @@
+// xlings.core.mirror.types — data types for the mirror fallback subsystem.
+//
+// All enums and structs live here. Keep this partition pure-data so the
+// other partitions (forms / registry / expand) can depend on it without
+// pulling in JSON parsing or platform code.
+
+export module xlings.core.mirror.types;
+
+import std;
+
+export namespace xlings::mirror {
+
+// What kind of asset a URL is requesting. Drives mirror filtering — not
+// every mirror handles every asset class (e.g. jsDelivr is raw-only).
+enum class ResourceType {
+    Release,    // GitHub release tarball / asset binary
+    Raw,        // raw.githubusercontent.com text/binary
+    Archive,    // /archive/<ref>.tar.gz or codeload.github.com
+    Git,        // git clone — caller MUST set this explicitly; URL alone
+                // can't disambiguate git from web view
+    Unknown,    // not a GitHub-family URL we know how to mirror
+};
+
+// URL-rewriting strategy. Each form is a pure function from
+// (original URL, mirror.host) → mirrored URL. See forms.cppm.
+enum class Form {
+    // Prefix strategy: prepend mirror host as proxy, original URL kept intact.
+    //   in:  https://github.com/x/y/releases/download/v1/asset.tar.gz
+    //   out: https://ghfast.top/https://github.com/x/y/releases/download/v1/asset.tar.gz
+    Prefix,
+
+    // Host-replace strategy: replace github.com / raw.githubusercontent.com
+    // with the mirror host, rewriting paths where needed.
+    //   in:  https://github.com/x/y/releases/download/v1/asset.tar.gz
+    //   out: https://kkgithub.com/x/y/releases/download/v1/asset.tar.gz
+    //   in:  https://raw.githubusercontent.com/x/y/main/file.txt
+    //   out: https://kkgithub.com/x/y/raw/main/file.txt
+    HostReplace,
+
+    // jsDelivr CDN strategy: only valid for raw.githubusercontent.com URLs;
+    // rewrites to jsDelivr's gh/ path syntax.
+    //   in:  https://raw.githubusercontent.com/x/y/<ref>/path/file
+    //   out: https://cdn.jsdelivr.net/gh/x/y@<ref>/path/file
+    JsDelivr,
+};
+
+// Process-wide policy for fallback behavior. Resolved once at first use
+// from env XLINGS_MIRROR_FALLBACK > .xlings.json mirror_fallback > Auto.
+enum class Mode {
+    Auto,    // default: try original first, then fall back through mirrors
+    Off,     // strict: only the original URL is returned (CI / debugging)
+    Force,   // skip the original URL, try mirrors first (heavily restricted networks)
+};
+
+// One entry in the mirror list. Loaded from compiled-in JSON or from
+// ~/.xlings/data/github-mirrors.json. Field names mirror the JSON schema.
+struct Mirror {
+    std::string name;             // identifier for logs/debug, e.g. "ghfast"
+    std::string host;             // mirror hostname, e.g. "ghfast.top"
+    Form        form;
+    std::vector<ResourceType> supports;
+    int         priority = 100;   // ascending; lower = tried first
+    std::optional<std::size_t> limit_bytes;  // per-file size cap (jsDelivr 50 MB)
+};
+
+// Per-call options passed to expand(). All fields optional with sensible
+// defaults so the typical caller can just write `mirror::expand(url)`.
+struct ExpandOptions {
+    // Asset class hint. If unset, expand() will run classify() on the URL.
+    // git clone callers MUST set this to ResourceType::Git — URL alone
+    // can't tell us whether a github.com/x/y URL is being cloned or fetched.
+    std::optional<ResourceType> type;
+
+    // Per-call mode override. Defaults to current_mode() (process-wide).
+    // Tests use this to force a specific mode without touching globals.
+    std::optional<Mode> mode;
+
+    // Known file size in bytes. Used to filter mirrors with limit_bytes
+    // smaller than the request (e.g. jsDelivr's 50 MB cap). 0 = unknown.
+    std::size_t expected_size = 0;
+};
+
+} // namespace xlings::mirror

--- a/src/core/xim/downloader.cppm
+++ b/src/core/xim/downloader.cppm
@@ -11,6 +11,7 @@ import xlings.platform;
 import xlings.core.config;
 import xlings.libs.tinyhttps;
 import xlings.runtime.cancellation;
+import xlings.core.mirror;
 // Re-export extract_archive so existing importers (installer) keep working.
 export import xlings.core.xim.extract;
 
@@ -21,14 +22,44 @@ bool is_git_url(const std::string& url) {
     return url.ends_with(".git");
 }
 
-// Clone a git repository
+// Derive the destination directory name from a git URL, e.g.
+// "https://github.com/user/repo.git" -> "repo" (or task.name fallback).
+std::string git_dest_repo_name_(const std::string& url, const std::string& fallback) {
+    std::string repoName;
+    auto lastSlash = url.rfind('/');
+    if (lastSlash != std::string::npos) {
+        repoName = url.substr(lastSlash + 1);
+        if (repoName.ends_with(".git"))
+            repoName = repoName.substr(0, repoName.size() - 4);
+    }
+    return repoName.empty() ? fallback : repoName;
+}
+
+// Build the ordered list of git clone URLs to try: primary + author-
+// declared fallbacks + mirror expansions. Mirror::expand handles the
+// Mode::Off / non-GitHub passthrough cases internally.
+std::vector<std::string> git_candidate_urls_(const DownloadTask& task) {
+    std::vector<std::string> urls;
+    urls.push_back(task.url);
+    for (auto& fb : task.fallbackUrls) urls.push_back(fb);
+
+    auto mirrored = mirror::expand(task.url, {.type = mirror::ResourceType::Git});
+    for (auto& u : mirrored) {
+        if (std::ranges::find(urls, u) == urls.end())
+            urls.push_back(std::move(u));
+    }
+    return urls;
+}
+
+// Clone a git repository, trying the primary URL then mirror fallbacks.
+// Each attempt that fails has its partial clone directory removed before
+// the next URL is tried.
 DownloadResult git_clone_one(const DownloadTask& task) {
     namespace fs = std::filesystem;
 
     DownloadResult result;
     result.name = task.name;
 
-    // Ensure dest directory exists
     std::error_code ec;
     fs::create_directories(task.destDir, ec);
     if (ec) {
@@ -37,22 +68,13 @@ DownloadResult git_clone_one(const DownloadTask& task) {
         return result;
     }
 
-    // Derive directory name from URL: "https://github.com/user/repo.git" -> "repo"
-    std::string url = task.url;
-    std::string repoName;
-    auto lastSlash = url.rfind('/');
-    if (lastSlash != std::string::npos) {
-        repoName = url.substr(lastSlash + 1);
-        if (repoName.ends_with(".git")) {
-            repoName = repoName.substr(0, repoName.size() - 4);
-        }
-    }
-    if (repoName.empty()) repoName = task.name;
-
+    auto repoName = git_dest_repo_name_(task.url, task.name);
     auto destDir = task.destDir / repoName;
     result.localFile = destDir;
 
-    // If already cloned, pull latest
+    // If already cloned, pull latest. Pull is single-URL by design — we
+    // don't switch remotes here. Pull failure removes and re-clones,
+    // which then goes through the URL-list fallback path below.
     if (fs::exists(destDir / ".git")) {
         log::debug("already cloned {}, pulling latest...", task.name);
         auto cmd = std::format("git -C \"{}\" pull --ff-only", destDir.string());
@@ -61,22 +83,31 @@ DownloadResult git_clone_one(const DownloadTask& task) {
             result.success = true;
             return result;
         }
-        // Pull failed, remove and re-clone
         log::warn("pull failed for {}, re-cloning...", task.name);
         fs::remove_all(destDir, ec);
     }
 
-    log::debug("cloning {} from {}", task.name, url);
-    auto cmd = std::format(
-        "git clone --depth 1 --recursive --quiet \"{}\" \"{}\"",
-        url, destDir.string());
-    auto rc = platform::exec(cmd);
-    if (rc != 0) {
-        result.error = std::format("git clone failed (rc={})", rc);
-        return result;
+    auto urls = git_candidate_urls_(task);
+    for (std::size_t i = 0; i < urls.size(); ++i) {
+        const auto& url = urls[i];
+        log::debug("cloning {} attempt {}/{}: {}",
+                   task.name, i + 1, urls.size(), url);
+        auto cmd = std::format(
+            "git clone --depth 1 --recursive --quiet \"{}\" \"{}\"",
+            url, destDir.string());
+        auto rc = platform::exec(cmd);
+        if (rc == 0) {
+            if (i > 0)
+                log::info("[mirror] git clone fallback succeeded via {}", url);
+            result.success = true;
+            return result;
+        }
+        // Clean partial clone before next attempt.
+        ec.clear();
+        fs::remove_all(destDir, ec);
     }
 
-    result.success = true;
+    result.error = std::format("all git clone URLs failed for {}", task.name);
     return result;
 }
 
@@ -98,30 +129,47 @@ DownloadResult download_one(const DownloadTask& task,
         return result;
     }
 
-    // Git clone for .git URLs
+    // Git clone for .git URLs. The non-cancellable path delegates to
+    // git_clone_one which already handles mirror fallback; the cancellable
+    // path needs the same fallback wiring inline because it uses
+    // spawn_command/wait_or_kill instead of blocking exec.
     if (is_git_url(task.url)) {
-        // When cancellable, run git clone as subprocess for kill support
         if (cancel) {
             namespace fs = std::filesystem;
-            std::string repoName;
-            auto lastSlashGit = task.url.rfind('/');
-            if (lastSlashGit != std::string::npos) {
-                repoName = task.url.substr(lastSlashGit + 1);
-                if (repoName.ends_with(".git"))
-                    repoName = repoName.substr(0, repoName.size() - 4);
-            }
-            if (repoName.empty()) repoName = task.name;
+            auto repoName = git_dest_repo_name_(task.url, task.name);
             auto destDir = task.destDir / repoName;
             result.localFile = destDir;
-            auto cmd = std::format("git clone --depth 1 --recursive --quiet \"{}\" \"{}\"",
-                                   task.url, destDir.string());
-            auto h = platform::spawn_command(cmd);
-            if (h.pid <= 0) { result.error = "failed to spawn git"; return result; }
-            auto [code, output] = platform::wait_or_kill(
-                h, cancel, std::chrono::minutes{10});
-            if (cancel->is_paused() || cancel->is_cancelled()) { result.error = "cancelled"; return result; }
-            result.success = (code == 0);
-            if (!result.success) result.error = output;
+
+            auto urls = git_candidate_urls_(task);
+            std::string lastError;
+            for (std::size_t i = 0; i < urls.size(); ++i) {
+                const auto& url = urls[i];
+                log::debug("cloning {} (cancellable) attempt {}/{}: {}",
+                           task.name, i + 1, urls.size(), url);
+                auto cmd = std::format(
+                    "git clone --depth 1 --recursive --quiet \"{}\" \"{}\"",
+                    url, destDir.string());
+                auto h = platform::spawn_command(cmd);
+                if (h.pid <= 0) { lastError = "failed to spawn git"; continue; }
+                auto [code, output] = platform::wait_or_kill(
+                    h, cancel, std::chrono::minutes{10});
+                if (cancel->is_paused() || cancel->is_cancelled()) {
+                    result.error = "cancelled";
+                    return result;
+                }
+                if (code == 0) {
+                    if (i > 0)
+                        log::info("[mirror] git clone fallback succeeded via {}", url);
+                    result.success = true;
+                    return result;
+                }
+                lastError = output;
+                std::error_code ec2;
+                fs::remove_all(destDir, ec2);
+            }
+            result.error = lastError.empty()
+                ? std::format("all git clone URLs failed for {}", task.name)
+                : lastError;
             return result;
         }
         return git_clone_one(task);
@@ -154,10 +202,21 @@ DownloadResult download_one(const DownloadTask& task,
         }
     }
 
-    // Build ordered list of URLs to try (primary + fallbacks)
+    // Build ordered list of URLs to try:
+    //   1. primary URL (as-is)
+    //   2. package-author-declared fallback URLs (already mirror-selected
+    //      by upstream resolver)
+    //   3. github mirror fallbacks (only appended if URL is github.com/
+    //      raw.githubusercontent.com/etc and mirror mode != Off)
     std::vector<std::string> urls;
     urls.push_back(url);
     for (auto& fb : task.fallbackUrls) urls.push_back(fb);
+
+    auto mirrored = mirror::expand(url);
+    for (auto& u : mirrored) {
+        if (std::ranges::find(urls, u) == urls.end())
+            urls.push_back(std::move(u));
+    }
 
     // Use in-process tinyhttps for all downloads (streaming progress).
     // When a CancellationToken is available, wire isCancelled so ESC aborts.

--- a/src/core/xim/repo.cppm
+++ b/src/core/xim/repo.cppm
@@ -8,6 +8,7 @@ import xlings.libs.json;
 import xlings.core.log;
 import xlings.platform;
 import xlings.core.config;
+import xlings.core.mirror;
 
 export namespace xlings::xim {
 
@@ -165,15 +166,29 @@ bool sync_repo(const std::filesystem::path& localDir,
     namespace fs = std::filesystem;
 
     if (!fs::exists(localDir / ".git")) {
-        log::debug("cloning index repo: {}", url);
-        auto cmd = std::format("git clone --depth 1 --quiet \"{}\" \"{}\"",
-                               url, localDir.string());
-        auto [rc, output] = platform::run_command_capture(cmd);
-        if (rc != 0) {
-            log::error("git clone failed: {}", output);
-            return false;
+        // Build mirror fallback list for the index repo URL. Mirror::expand
+        // returns just [url] when mirror_fallback=off or url is non-github.
+        auto urls = mirror::expand(url, {.type = mirror::ResourceType::Git});
+        if (urls.empty()) urls.push_back(url);
+
+        std::string lastErr;
+        for (std::size_t i = 0; i < urls.size(); ++i) {
+            log::debug("cloning index repo attempt {}/{}: {}",
+                       i + 1, urls.size(), urls[i]);
+            auto cmd = std::format("git clone --depth 1 --quiet \"{}\" \"{}\"",
+                                   urls[i], localDir.string());
+            auto [rc, output] = platform::run_command_capture(cmd);
+            if (rc == 0) {
+                if (i > 0)
+                    log::info("[mirror] index repo fallback succeeded via {}", urls[i]);
+                return true;
+            }
+            lastErr = output;
+            std::error_code ec2;
+            fs::remove_all(localDir, ec2);
         }
-        return true;
+        log::error("all index repo clone URLs failed: {}", lastErr);
+        return false;
     }
 
     // Check throttle: skip if pulled within 7 days (unless forced)

--- a/tests/e2e/mirror_fallback_test.sh
+++ b/tests/e2e/mirror_fallback_test.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# E2E: verify the github mirror fallback wiring.
+#
+# Strategy: instead of mocking http servers (which is fragile under CI
+# port allocation), inspect the verbose log. xlings emits a
+# "[mirror] ..." log line whenever fallback succeeds, and the debug-level
+# attempt log enumerates each URL in the candidate list. We can read
+# those to prove:
+#   1. With XLINGS_MIRROR_FALLBACK=off  → only the original URL is in
+#      the attempt list (1 candidate).
+#   2. With XLINGS_MIRROR_FALLBACK=auto → multiple candidates appear
+#      including a known mirror host (ghfast / kkgithub / etc).
+#
+# We run this against a github URL that DOES NOT NEED to reach the
+# network — the candidate-list construction happens before any network
+# I/O, and we abort with cancellation before the HTTP request fires by
+# pointing at a non-existent localhost port.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/mirror_fallback"
+LOG="$RUNTIME_DIR/run.log"
+
+case "$(uname -s)" in
+  Darwin) BIN_SRC="$ROOT_DIR/build/macosx/arm64/release/xlings" ;;
+  Linux)  BIN_SRC="$ROOT_DIR/build/linux/x86_64/release/xlings" ;;
+  *) echo "mirror_fallback_test.sh only supports Linux/macOS" >&2; exit 1 ;;
+esac
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+log()  { echo "[mirror-e2e] $*"; }
+
+[[ -x "$BIN_SRC" ]] || fail "built xlings binary not found at $BIN_SRC"
+
+# --- Setup portable home ---
+rm -rf "$RUNTIME_DIR"
+mkdir -p "$RUNTIME_DIR/portable/bin" "$RUNTIME_DIR/portable/data"
+cp "$BIN_SRC" "$RUNTIME_DIR/portable/bin/xlings"
+
+cat > "$RUNTIME_DIR/portable/.xlings.json" <<EOF
+{
+  "version": "0.4.8",
+  "mirror": "GLOBAL",
+  "activeSubos": "default",
+  "subos": { "default": { "dir": "" } }
+}
+EOF
+
+XLINGS_HOME="$RUNTIME_DIR/portable" \
+  "$RUNTIME_DIR/portable/bin/xlings" self init >/dev/null 2>&1 \
+  || fail "self init failed"
+
+# ──────────────────────────────────────────────────────────────────
+# Scenario 1: XLINGS_MIRROR_FALLBACK=off
+#   Trigger an index-repo clone that will fail. The candidate list
+#   should contain ONLY the original URL.
+# ──────────────────────────────────────────────────────────────────
+log "S1: XLINGS_MIRROR_FALLBACK=off → single-URL candidate list"
+
+# Point xim-indexrepos at a URL that doesn't exist; we don't care about
+# the clone succeeding — we only inspect the attempt log. We must
+# rewrite the JSON before each scenario because sync_all_repos prunes
+# failed entries on save.
+mkdir -p "$RUNTIME_DIR/portable/data/xim-index-repos"
+write_indexrepos() {
+  cat > "$RUNTIME_DIR/portable/data/xim-index-repos/xim-indexrepos.json" <<EOF
+{ "test-repo": "$1" }
+EOF
+}
+
+GH_BAD_URL="https://github.com/d2learn/this-repo-deliberately-does-not-exist-xlings-mirror-test.git"
+
+write_indexrepos "$GH_BAD_URL"
+
+set +e
+XLINGS_HOME="$RUNTIME_DIR/portable" XLINGS_MIRROR_FALLBACK=off \
+  XLINGS_NON_INTERACTIVE=1 \
+  "$RUNTIME_DIR/portable/bin/xlings" --verbose update >"$LOG" 2>&1
+rc=$?
+set -e
+
+# --verbose enables debug, so "cloning index repo attempt N/M" must appear.
+attempts_off=$(grep -cE 'cloning index repo attempt [0-9]+/[0-9]+:' "$LOG" || true)
+total_off=$(grep -oE 'attempt [0-9]+/[0-9]+:' "$LOG" | head -1 | grep -oE '/[0-9]+' | tr -d '/' || true)
+log "  → $attempts_off attempt log lines, total candidates declared: ${total_off:-0}"
+[[ -n "$total_off" ]] || fail "S1: no 'attempt' log lines found in --verbose output"
+[[ "$total_off" == "1" ]] || \
+  fail "S1: expected exactly 1 candidate with mirror_fallback=off, got $total_off"
+
+# ──────────────────────────────────────────────────────────────────
+# Scenario 2: XLINGS_MIRROR_FALLBACK=auto (default)
+#   The same broken URL should now produce multiple candidates,
+#   one per registered mirror that supports git.
+# ──────────────────────────────────────────────────────────────────
+log "S2: XLINGS_MIRROR_FALLBACK=auto → multi-URL candidate list"
+write_indexrepos "$GH_BAD_URL"
+
+set +e
+XLINGS_HOME="$RUNTIME_DIR/portable" XLINGS_MIRROR_FALLBACK=auto \
+  XLINGS_NON_INTERACTIVE=1 \
+  "$RUNTIME_DIR/portable/bin/xlings" --verbose update >"$LOG" 2>&1
+rc=$?
+set -e
+
+total_auto=$(grep -oE 'attempt [0-9]+/[0-9]+:' "$LOG" | head -1 | grep -oE '/[0-9]+' | tr -d '/' || true)
+log "  → total candidates declared: ${total_auto:-0}"
+[[ -n "$total_auto" ]] || fail "S2: no 'attempt' log lines in --verbose output"
+[[ "$total_auto" -gt 1 ]] || \
+  fail "S2: expected >1 candidate with mirror_fallback=auto, got $total_auto"
+
+# At least one candidate must reference a known mirror host. We don't
+# assert on a specific name — the registry might rotate priority — but
+# at least one of the built-in mirrors should be present.
+if ! grep -qE '(ghfast\.top|ghproxy\.net|kkgithub\.com|cdn\.jsdelivr\.net)' "$LOG"; then
+  fail "S2: no built-in mirror host appeared in candidate list"
+fi
+log "  → built-in mirror host found in candidate list"
+
+# ──────────────────────────────────────────────────────────────────
+# Scenario 3: gitee URL is NOT expanded
+#   Non-GitHub URLs must pass through unmodified.
+# ──────────────────────────────────────────────────────────────────
+log "S3: gitee URL → passthrough (1 candidate)"
+write_indexrepos "https://gitee.com/d2learn/this-repo-deliberately-does-not-exist-xlings-mirror-test.git"
+
+set +e
+XLINGS_HOME="$RUNTIME_DIR/portable" XLINGS_MIRROR_FALLBACK=auto \
+  XLINGS_NON_INTERACTIVE=1 \
+  "$RUNTIME_DIR/portable/bin/xlings" --verbose update >"$LOG" 2>&1
+rc=$?
+set -e
+
+total_gitee=$(grep -oE 'attempt [0-9]+/[0-9]+:' "$LOG" | head -1 | grep -oE '/[0-9]+' | tr -d '/' || true)
+log "  → total candidates for gitee URL: ${total_gitee:-0}"
+[[ "$total_gitee" == "1" ]] || \
+  fail "S3: gitee URL should not be mirror-expanded, got $total_gitee candidates"
+
+# ──────────────────────────────────────────────────────────────────
+# Scenario 4: user-supplied github-mirrors.json fully replaces defaults
+# ──────────────────────────────────────────────────────────────────
+log "S4: user-supplied github-mirrors.json overrides defaults"
+
+cat > "$RUNTIME_DIR/portable/data/github-mirrors.json" <<EOF
+{
+  "version": 1,
+  "mirrors": [
+    {
+      "name": "user-only-mirror",
+      "form": "prefix",
+      "host": "user-only.example.invalid",
+      "supports": ["release", "raw", "archive", "git"],
+      "priority": 1
+    }
+  ]
+}
+EOF
+
+write_indexrepos "$GH_BAD_URL"
+
+set +e
+XLINGS_HOME="$RUNTIME_DIR/portable" XLINGS_MIRROR_FALLBACK=auto \
+  XLINGS_NON_INTERACTIVE=1 \
+  "$RUNTIME_DIR/portable/bin/xlings" --verbose update >"$LOG" 2>&1
+set -e
+
+total_user=$(grep -oE 'attempt [0-9]+/[0-9]+:' "$LOG" | head -1 | grep -oE '/[0-9]+' | tr -d '/' || true)
+log "  → total candidates with user-only override: ${total_user:-0}"
+# Expect exactly 2: original + the single user-defined mirror.
+[[ "$total_user" == "2" ]] || \
+  fail "S4: user override should yield 2 candidates (orig + 1 mirror), got $total_user"
+grep -q "user-only.example.invalid" "$LOG" \
+  || fail "S4: user-only mirror host not in candidate list"
+# Verify the built-in mirrors are NOT in the list — full replacement.
+if grep -qE '(ghfast\.top|ghproxy\.net|kkgithub\.com)' "$LOG"; then
+  fail "S4: built-in mirror leaked through despite user override"
+fi
+log "  → built-in defaults correctly fully replaced"
+
+log "PASS: mirror fallback wiring verified across off/auto/non-github/user-override"

--- a/tests/unit/test_mirror.cpp
+++ b/tests/unit/test_mirror.cpp
@@ -1,0 +1,289 @@
+// Unit tests for the xlings.core.mirror module. Covers:
+//   - URL classification heuristic
+//   - Three URL-rewriting forms (prefix / host-replace / jsdelivr)
+//   - expand() across modes (Auto / Off / Force) and resource types
+//   - registry filtering by type and size
+//   - Same-priority shuffle behavior
+
+#include <gtest/gtest.h>
+
+import std;
+import xlings.core.mirror;
+
+using namespace xlings::mirror;
+namespace fs = std::filesystem;
+
+namespace {
+
+// Helper: any item in the list whose URL starts with the given prefix.
+bool any_starts_with(const std::vector<std::string>& urls, std::string_view prefix) {
+    return std::ranges::any_of(urls, [&](const auto& u) {
+        return u.starts_with(prefix);
+    });
+}
+
+} // namespace
+
+// ============================================================
+// classify()
+// ============================================================
+
+TEST(MirrorClassify, ReleaseAsset) {
+    EXPECT_EQ(classify("https://github.com/owner/repo/releases/download/v1.0/asset.tar.gz"),
+              ResourceType::Release);
+}
+
+TEST(MirrorClassify, ObjectsHostIsRelease) {
+    EXPECT_EQ(classify("https://objects.githubusercontent.com/..."),
+              ResourceType::Release);
+}
+
+TEST(MirrorClassify, RawHost) {
+    EXPECT_EQ(classify("https://raw.githubusercontent.com/owner/repo/main/file.txt"),
+              ResourceType::Raw);
+}
+
+TEST(MirrorClassify, ArchiveByPath) {
+    EXPECT_EQ(classify("https://github.com/owner/repo/archive/v1.tar.gz"),
+              ResourceType::Archive);
+}
+
+TEST(MirrorClassify, CodeloadIsArchive) {
+    EXPECT_EQ(classify("https://codeload.github.com/owner/repo/tar.gz/refs/heads/main"),
+              ResourceType::Archive);
+}
+
+TEST(MirrorClassify, GitDotGitSuffix) {
+    EXPECT_EQ(classify("https://github.com/owner/repo.git"),
+              ResourceType::Git);
+}
+
+TEST(MirrorClassify, BareGithubIsUnknown) {
+    // Without a /releases/, /archive/, or .git suffix, the URL is ambiguous.
+    EXPECT_EQ(classify("https://github.com/owner/repo"),
+              ResourceType::Unknown);
+}
+
+TEST(MirrorClassify, NonGithubIsUnknown) {
+    EXPECT_EQ(classify("https://gitee.com/owner/repo"), ResourceType::Unknown);
+    EXPECT_EQ(classify("https://example.com/foo.tar.gz"), ResourceType::Unknown);
+}
+
+// ============================================================
+// is_github_url()
+// ============================================================
+
+TEST(MirrorIsGithub, ClassifiesGithubFamily) {
+    EXPECT_TRUE(is_github_url("https://github.com/x/y"));
+    EXPECT_TRUE(is_github_url("https://raw.githubusercontent.com/x/y/main/f"));
+    EXPECT_TRUE(is_github_url("https://codeload.github.com/x/y/tar/v1"));
+    EXPECT_TRUE(is_github_url("https://objects.githubusercontent.com/abc"));
+    EXPECT_FALSE(is_github_url("https://gitee.com/x/y"));
+    EXPECT_FALSE(is_github_url("https://example.com"));
+    EXPECT_FALSE(is_github_url(""));
+}
+
+// ============================================================
+// expand() — Off mode
+// ============================================================
+
+TEST(MirrorExpand, OffModeReturnsOnlyOriginal) {
+    auto urls = expand("https://github.com/x/y/releases/download/v1/asset.tar.gz",
+                       {.type = ResourceType::Release, .mode = Mode::Off});
+    ASSERT_EQ(urls.size(), 1u);
+    EXPECT_EQ(urls[0], "https://github.com/x/y/releases/download/v1/asset.tar.gz");
+}
+
+// ============================================================
+// expand() — Auto mode
+// ============================================================
+
+TEST(MirrorExpand, AutoModeOriginalIsFirst) {
+    auto urls = expand("https://github.com/x/y/releases/download/v1/asset.tar.gz",
+                       {.type = ResourceType::Release, .mode = Mode::Auto});
+    ASSERT_FALSE(urls.empty());
+    EXPECT_EQ(urls[0], "https://github.com/x/y/releases/download/v1/asset.tar.gz");
+    EXPECT_GT(urls.size(), 1u) << "Auto mode should produce mirror fallbacks";
+}
+
+TEST(MirrorExpand, AutoModeProducesPrefixMirror) {
+    auto urls = expand("https://github.com/x/y/releases/download/v1/asset.tar.gz",
+                       {.type = ResourceType::Release, .mode = Mode::Auto});
+    EXPECT_TRUE(any_starts_with(urls, "https://ghfast.top/"));
+}
+
+TEST(MirrorExpand, AutoModeProducesHostReplaceMirror) {
+    auto urls = expand("https://github.com/x/y/releases/download/v1/asset.tar.gz",
+                       {.type = ResourceType::Release, .mode = Mode::Auto});
+    EXPECT_TRUE(any_starts_with(urls, "https://kkgithub.com/"));
+}
+
+TEST(MirrorExpand, RawUrlGetsJsdelivrMirror) {
+    auto urls = expand("https://raw.githubusercontent.com/x/y/main/file.txt",
+                       {.type = ResourceType::Raw, .mode = Mode::Auto});
+    EXPECT_TRUE(any_starts_with(urls, "https://cdn.jsdelivr.net/gh/"));
+}
+
+TEST(MirrorExpand, GitTypeGetsGitMirrors) {
+    auto urls = expand("https://github.com/x/y.git",
+                       {.type = ResourceType::Git, .mode = Mode::Auto});
+    // jsdelivr does NOT support git; only prefix + host-replace mirrors.
+    EXPECT_FALSE(any_starts_with(urls, "https://cdn.jsdelivr.net/"));
+    EXPECT_TRUE(any_starts_with(urls, "https://ghfast.top/"));
+}
+
+TEST(MirrorExpand, GitTypeFiltersOutJsdelivr) {
+    // Even for a raw-shaped URL, if caller says it's git, jsdelivr is excluded
+    // (jsdelivr doesn't handle git).
+    auto urls = expand("https://github.com/x/y",
+                       {.type = ResourceType::Git, .mode = Mode::Auto});
+    EXPECT_FALSE(any_starts_with(urls, "https://cdn.jsdelivr.net/"));
+}
+
+// ============================================================
+// expand() — Force mode
+// ============================================================
+
+TEST(MirrorExpand, ForceModeSkipsOriginal) {
+    auto urls = expand("https://github.com/x/y/releases/download/v1/asset.tar.gz",
+                       {.type = ResourceType::Release, .mode = Mode::Force});
+    EXPECT_FALSE(urls.empty());
+    EXPECT_NE(urls[0], "https://github.com/x/y/releases/download/v1/asset.tar.gz");
+}
+
+// ============================================================
+// expand() — non-GitHub passthrough
+// ============================================================
+
+TEST(MirrorExpand, GiteeUrlIsNotExpanded) {
+    auto urls = expand("https://gitee.com/owner/repo/releases/download/v1/asset.tar.gz",
+                       {.mode = Mode::Auto});
+    ASSERT_EQ(urls.size(), 1u);
+    EXPECT_EQ(urls[0],
+              "https://gitee.com/owner/repo/releases/download/v1/asset.tar.gz");
+}
+
+TEST(MirrorExpand, CustomHostIsNotExpanded) {
+    auto urls = expand("https://internal.corp.com/foo.tar.gz",
+                       {.mode = Mode::Auto});
+    ASSERT_EQ(urls.size(), 1u);
+}
+
+TEST(MirrorExpand, EmptyUrlReturnsEmpty) {
+    auto urls = expand("", {.mode = Mode::Auto});
+    EXPECT_TRUE(urls.empty());
+}
+
+// ============================================================
+// expand() — Unknown type doesn't expand
+// ============================================================
+
+TEST(MirrorExpand, UnknownTypeReturnsOnlyOriginal) {
+    // Bare github.com URL with no hint → classify returns Unknown.
+    auto urls = expand("https://github.com/x/y", {.mode = Mode::Auto});
+    ASSERT_EQ(urls.size(), 1u);
+    EXPECT_EQ(urls[0], "https://github.com/x/y");
+}
+
+// ============================================================
+// expand() — file size filtering
+// ============================================================
+
+TEST(MirrorExpand, LargeFileFiltersOutJsdelivr) {
+    // jsdelivr has limit_bytes = 50 MB. A 60 MB raw file should not include it.
+    auto urls = expand("https://raw.githubusercontent.com/x/y/main/big.bin",
+                       {.type = ResourceType::Raw,
+                        .mode = Mode::Auto,
+                        .expected_size = 60u * 1024u * 1024u});
+    EXPECT_FALSE(any_starts_with(urls, "https://cdn.jsdelivr.net/"));
+}
+
+TEST(MirrorExpand, SmallFileIncludesJsdelivr) {
+    // 1 MB file is well under jsdelivr's 50 MB cap.
+    auto urls = expand("https://raw.githubusercontent.com/x/y/main/small.txt",
+                       {.type = ResourceType::Raw,
+                        .mode = Mode::Auto,
+                        .expected_size = 1024u * 1024u});
+    EXPECT_TRUE(any_starts_with(urls, "https://cdn.jsdelivr.net/"));
+}
+
+TEST(MirrorExpand, UnknownSizeIncludesAllMirrors) {
+    // expected_size = 0 means "unknown" — we must not filter by limit_bytes.
+    auto urls = expand("https://raw.githubusercontent.com/x/y/main/file.txt",
+                       {.type = ResourceType::Raw,
+                        .mode = Mode::Auto,
+                        .expected_size = 0});
+    EXPECT_TRUE(any_starts_with(urls, "https://cdn.jsdelivr.net/"));
+}
+
+// ============================================================
+// expand() — host-replace path rewriting for raw URLs
+// ============================================================
+
+TEST(MirrorExpand, HostReplaceRewritesRawPath) {
+    auto urls = expand("https://raw.githubusercontent.com/x/y/main/path/file.txt",
+                       {.type = ResourceType::Raw, .mode = Mode::Auto});
+    // kkgithub host-replace must inject "/raw/" between repo and ref.
+    auto kk_it = std::ranges::find_if(urls, [](const auto& u) {
+        return u.starts_with("https://kkgithub.com/");
+    });
+    ASSERT_NE(kk_it, urls.end()) << "kkgithub mirror missing";
+    EXPECT_EQ(*kk_it, "https://kkgithub.com/x/y/raw/main/path/file.txt");
+}
+
+TEST(MirrorExpand, JsdelivrRewriteShape) {
+    auto urls = expand("https://raw.githubusercontent.com/x/y/main/path/file.txt",
+                       {.type = ResourceType::Raw, .mode = Mode::Auto});
+    auto js_it = std::ranges::find_if(urls, [](const auto& u) {
+        return u.starts_with("https://cdn.jsdelivr.net/");
+    });
+    ASSERT_NE(js_it, urls.end());
+    EXPECT_EQ(*js_it, "https://cdn.jsdelivr.net/gh/x/y@main/path/file.txt");
+}
+
+TEST(MirrorExpand, PrefixRewriteShape) {
+    auto urls = expand("https://github.com/x/y/releases/download/v1/asset.tar.gz",
+                       {.type = ResourceType::Release, .mode = Mode::Auto});
+    auto pref_it = std::ranges::find_if(urls, [](const auto& u) {
+        return u.starts_with("https://ghfast.top/");
+    });
+    ASSERT_NE(pref_it, urls.end());
+    EXPECT_EQ(*pref_it,
+              "https://ghfast.top/https://github.com/x/y/releases/download/v1/asset.tar.gz");
+}
+
+// ============================================================
+// expand() — no duplicates
+// ============================================================
+
+TEST(MirrorExpand, NoDuplicateUrls) {
+    auto urls = expand("https://github.com/x/y/releases/download/v1/asset.tar.gz",
+                       {.type = ResourceType::Release, .mode = Mode::Auto});
+    std::set<std::string> uniq(urls.begin(), urls.end());
+    EXPECT_EQ(uniq.size(), urls.size()) << "expand() returned duplicate URLs";
+}
+
+// ============================================================
+// expand() — defaults (no opts) classify automatically
+// ============================================================
+
+TEST(MirrorExpand, AutoClassifiesReleaseUrl) {
+    set_mode(Mode::Auto);
+    auto urls = expand("https://github.com/x/y/releases/download/v1/asset.tar.gz");
+    ASSERT_FALSE(urls.empty());
+    EXPECT_EQ(urls[0], "https://github.com/x/y/releases/download/v1/asset.tar.gz");
+    EXPECT_GT(urls.size(), 1u);
+}
+
+// ============================================================
+// Mode setter (test affordance)
+// ============================================================
+
+TEST(MirrorMode, SetModeAffectsCurrentMode) {
+    auto saved = current_mode();
+    set_mode(Mode::Off);
+    EXPECT_EQ(current_mode(), Mode::Off);
+    set_mode(Mode::Force);
+    EXPECT_EQ(current_mode(), Mode::Force);
+    set_mode(saved);
+}


### PR DESCRIPTION
## Summary

Adds a failure-driven GitHub URL fallback mechanism covering all three resource classes xlings downloads:

- **HTTP** — release tarballs, raw files, archives (via `tinyhttps`)
- **Git clone** — source-build packages (in `xim/downloader.cppm`)
- **Index repos** — `xim-pkgindex` and sub-indexes (in `xim/repo.cppm`)

The original URL is always tried first. Mirror URLs are only attempted when the primary fails. Happy path: zero overhead. Restricted-network path: automatic recovery through ghfast / ghproxy.net / kkgithub / jsDelivr.

## Design

Full plan in `docs/plans/2026-05-01-mirror-fallback-step1.md`. Key choices:

- **One module, four partitions**: `xlings.core.mirror` mirrors the `xself` umbrella+partition pattern. Future Step 2 (mid-flight throughput race) can be added as `mirror/race.cppm` without touching existing files.
- **Embedded default mirror list** (raw string literal in `mirror/registry.cppm`). Updates require a release — chicken-and-egg ruled out remote hot-update.
- **User override** at `~/.xlings/data/github-mirrors.json` fully replaces the defaults.
- **Three URL-rewriting forms**: `prefix` (ghproxy-style), `host-replace` (kkgithub), `jsdelivr` (raw-only CDN with size cap).
- **Mode resolution**: env `XLINGS_MIRROR_FALLBACK={off|auto|force}` > `~/.xlings.json` `mirror_fallback` > Auto.
- **Non-GitHub URLs pass through** — gitee, custom hosts, etc. are never proxied.

## What changed

- New module: `src/core/mirror.cppm` + `src/core/mirror/{types,forms,registry,expand}.cppm`
- Integrations: `xim/downloader.cppm` (HTTP + 2× git paths), `xim/repo.cppm` (index sync)
- Tests: 30 unit tests (`tests/unit/test_mirror.cpp`), 4-scenario e2e (`tests/e2e/mirror_fallback_test.sh`), wired into Linux + macOS CI

## Commits

- `ebd78c3` — `feat(mirror): add core mirror module + unit tests` (declarative only, no behavior change)
- `187e911` — `feat(mirror): wire fallback into HTTP / git / index download paths` (the actual hook-in)

## Test plan

- [x] 219/219 unit tests pass locally (30 new mirror tests + 0 regressions)
- [x] mirror_fallback_test.sh: all 4 scenarios pass (off / auto / gitee passthrough / user override)
- [x] Regression: shim_link / cli_short_alias_removal / self_doctor / xlings_self_replace / index_cache / sub_index_search all green
- [ ] CI: Linux + macOS + Windows builds + full e2e

## Out of scope (deferred)

- Step 2: mid-flight throughput monitoring + speculative race
- Step 3: cross-process mirror health stats, `xlings mirror` CLI subcommand
- gitee one-party `xim-pkgindex` mirror — independent ops task