### PR TITLE
fix(script): create auto-shim under canonical bootstrap layout on Unix

### DIFF
--- a/src/core/xim/libxpkg/types/script.cppm
+++ b/src/core/xim/libxpkg/types/script.cppm
@@ -53,9 +53,15 @@ bool default_config(const PlanNode& node,
     auto xlings_bin = paths.homeDir / "bin" / "xlings.exe";
     constexpr std::string_view shim_ext = ".exe";
 #else
-    auto xlings_bin = paths.homeDir / "xlings";
+    auto xlings_bin = paths.homeDir / "bin" / "xlings";
     constexpr std::string_view shim_ext = "";
 #endif
+    // Bootstrap-layout fallback: pre-`self init` the binary may live
+    // directly at <homeDir>/xlings before being moved under bin/.
+    // Matches the resolution used in xvm/commands.cppm and xself/doctor.cppm.
+    if (!std::filesystem::exists(xlings_bin))
+        xlings_bin = paths.homeDir / ("xlings" + std::string(shim_ext));
+
     if (std::filesystem::exists(xlings_bin)) {
         std::string shim_name = node.name;
         if (!shim_ext.empty() && !shim_name.ends_with(shim_ext))

--- a/tests/e2e/script_type_install_test.sh
+++ b/tests/e2e/script_type_install_test.sh
@@ -81,4 +81,36 @@ echo "$REMOVE_OUT"
 [[ ! -d "$INSTALL_DIR" ]] \
   || fail "install_dir not removed after uninstall"
 
+# ── 13. Regression scenario: canonical bootstrap layout ──
+# `write_home_config` places the binary at <home>/xlings (legacy bootstrap
+# layout). Real-world `xlings self install` puts it at <home>/bin/xlings
+# (canonical). The script default_config used to look only at the legacy
+# path on Unix, silently skipping shim creation in the canonical layout.
+# This scenario re-runs the install with the binary ONLY at the canonical
+# location to pin that fix.
+log "Regression: install with canonical <home>/bin/xlings layout"
+rm -rf "$HOME_DIR"
+mkdir -p "$HOME_DIR/bin" "$HOME_DIR/subos/default/bin"
+cp "$(find_xlings_bin)" "$HOME_DIR/bin/xlings"
+[[ ! -f "$HOME_DIR/xlings" ]] || \
+  fail "regression setup: legacy bootstrap path must be absent"
+
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$FIXTURE_INDEX_DIR" }
+  ]
+}
+EOF
+
+env XLINGS_HOME="$HOME_DIR" "$HOME_DIR/bin/xlings" --verbose self init >/dev/null 2>&1
+env XLINGS_HOME="$HOME_DIR" "$HOME_DIR/bin/xlings" --verbose install xpkg-helper -y >/dev/null 2>&1 \
+  || fail "regression: xpkg-helper install failed under canonical layout"
+
+[[ -e "$HOME_DIR/subos/default/bin/xpkg-helper" ]] \
+  || fail "regression: shim not created under canonical layout (the bug fixed by this PR)"
+
+log "Regression PASS: canonical layout shim creation works"
+
 log "PASS: script-type package install/shim/uninstall flow"


### PR DESCRIPTION
## Summary

`script::default_config` was checking `<homeDir>/xlings` (legacy bootstrap layout) on Unix to decide whether to create the auto-shim for `type="script"` packages. Real installs put the binary at `<homeDir>/bin/xlings` (canonical layout), so the check silently failed and **the shim was never created on Linux/macOS**.

Symptom: `xlings install xim:xpkg-helper@0.0.1` finishes cleanly, the `.lua` lands in `xpkgs/`, the xvm DB and workspace are updated — but `<subos>/default/bin/xpkg-helper` is missing, so invoking the package fails with "command not found".

The Windows branch was correct (`<homeDir>/bin/xlings.exe`), so this only affected Linux/macOS.

## Fix

Prefer canonical `<homeDir>/bin/xlings`, fall back to `<homeDir>/xlings` only for the bootstrap layout. Matches the resolver pattern already used in `src/core/xvm/commands.cppm:236-241` and `src/core/xself/doctor.cppm:65-72`.

```diff
-    auto xlings_bin = paths.homeDir / "xlings";
+    auto xlings_bin = paths.homeDir / "bin" / "xlings";
+    if (!std::filesystem::exists(xlings_bin))
+        xlings_bin = paths.homeDir / ("xlings" + std::string(shim_ext));
```

## Why the existing e2e didn't catch this

`tests/e2e/project_test_lib.sh:62` (`write_home_config`) places the binary at `<home>/xlings` — the legacy bootstrap layout that the buggy code happens to find. This PR adds a regression scenario (step 13) at the end of `script_type_install_test.sh` that:

1. Wipes `$HOME_DIR`
2. Sets up only the canonical layout (`$HOME_DIR/bin/xlings`, no legacy file at `$HOME_DIR/xlings`)
3. Runs `xlings install xpkg-helper -y`
4. Asserts `$HOME_DIR/subos/default/bin/xpkg-helper` exists

This new scenario **fails on the buggy code** and **passes after the fix**, so the bug can't silently come back.

## User workaround on 0.4.8 (without this fix)

`xlings self doctor --fix` detects the missing-shim invariant (workspace has the package, but `<binDir>/<name>` is absent) and recreates the shim from the bootstrap.

## Test plan

- [x] 189/189 unit tests pass locally
- [x] `tests/e2e/script_type_install_test.sh`: 12 original + 1 new regression scenario, all pass
- [x] Regression sweep: `shim_link_test.sh`, `self_doctor_test.sh` still green
- [ ] CI: Linux + macOS + Windows builds + full e2e