### PR TITLE
ci: self-host xlings's build deps via /.xlings.json (Phases 1-6)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,14 @@ jobs:
           bash tests/e2e/prepare_fixture_index.sh
 
       - name: Build (linux_release)
+        # TODO(2026-): linux_release.sh's default MUSL_SDK still assumes
+        # the legacy `data/xpkgs/musl-gcc/...` layout (no namespace
+        # prefix). Modern xlings install puts it under
+        # `data/xpkgs/xim-x-musl-gcc/...`. Exporting MUSL_SDK explicitly
+        # here gets the right path; can be dropped once the script is
+        # updated to glob both layouts.
         run: |
+          export MUSL_SDK="$HOME/.xlings/data/xpkgs/xim-x-musl-gcc/15.1.0"
           chmod +x ./tools/linux_release.sh
           SKIP_NETWORK_VERIFY=1 ./tools/linux_release.sh
 
@@ -103,7 +110,12 @@ jobs:
           xmake --version
 
       - name: Build (macos_release)
+        # TODO(2026-): same TODO as linux_release — macos_release.sh's
+        # default LLVM_PREFIX assumes legacy `data/xpkgs/llvm/...`
+        # without `xim-x-` prefix. Drop this export once the script
+        # is updated.
         run: |
+          export LLVM_PREFIX="$HOME/.xlings/data/xpkgs/xim-x-llvm/20.1.7"
           chmod +x ./tools/macos_release.sh
           SKIP_NETWORK_VERIFY=1 ./tools/macos_release.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,6 @@ jobs:
         run: |
           bash tests/e2e/prepare_fixture_index.sh
 
-      - name: Configure xmake
-        run: |
-          xmake f -c -p linux -m release -y
-
       - name: Build (linux_release)
         run: |
           chmod +x ./tools/linux_release.sh
@@ -106,11 +102,6 @@ jobs:
           clang --version
           xmake --version
 
-      - name: Configure xmake
-        run: |
-          xmake f -c -p macosx -m release --toolchain=llvm -y
-          echo "xmake configured with LLVM SDK: $LLVM_PREFIX"
-
       - name: Build (macos_release)
         run: |
           chmod +x ./tools/macos_release.sh
@@ -152,10 +143,6 @@ jobs:
         run: |
           Set-Location $env:GITHUB_WORKSPACE
           xlings install -y
-
-      - name: Configure xmake
-        shell: pwsh
-        run: xmake f -p windows -m release -y
 
       - name: Build (windows_release)
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,18 +53,8 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE"
           xlings install -y
-
-      - name: Export toolchain paths
-        run: |
-          MUSL_SDK="$HOME/.xlings/data/xpkgs/musl-gcc/15.1.0"
-          test -d "$MUSL_SDK" || { echo "musl-gcc payload missing at $MUSL_SDK"; exit 1; }
-          test -f "$MUSL_SDK/x86_64-linux-musl/include/c++/15.1.0/bits/std.cc"
-          x86_64-linux-musl-g++ --version
-          bash tools/setup_musl_runtime.sh "$MUSL_SDK"
-          echo "MUSL_SDK=$MUSL_SDK"           >> "$GITHUB_ENV"
-          echo "CC=x86_64-linux-musl-gcc"     >> "$GITHUB_ENV"
-          echo "CXX=x86_64-linux-musl-g++"    >> "$GITHUB_ENV"
-          echo "$MUSL_SDK/bin"                >> "$GITHUB_PATH"
+          gcc --version
+          xmake --version
 
       - name: Prepare fixture index repo
         run: |
@@ -72,7 +62,7 @@ jobs:
 
       - name: Configure xmake
         run: |
-          xmake f -c -p linux -m release --sdk="$MUSL_SDK" --cross=x86_64-linux-musl- --cc="$CC" --cxx="$CXX" -y
+          xmake f -c -p linux -m release -y
 
       - name: Build (linux_release)
         run: |
@@ -113,22 +103,12 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE"
           xlings install -y
-
-      - name: Export toolchain paths
-        run: |
-          LLVM_PREFIX="$HOME/.xlings/data/xpkgs/llvm/20.1.7"
-          [[ -x "$LLVM_PREFIX/bin/clang++" ]] || { echo "clang++ missing in $LLVM_PREFIX"; exit 1; }
-          echo "LLVM_PREFIX=$LLVM_PREFIX"                       >> "$GITHUB_ENV"
-          echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)"  >> "$GITHUB_ENV"
-          echo "$LLVM_PREFIX/bin"                               >> "$GITHUB_PATH"
-          "$LLVM_PREFIX/bin/clang++" --version
+          clang --version
+          xmake --version
 
       - name: Configure xmake
         run: |
-          xmake f -c -p macosx -m release \
-            --toolchain=llvm \
-            --sdk="$LLVM_PREFIX" \
-            -y
+          xmake f -c -p macosx -m release --toolchain=llvm -y
           echo "xmake configured with LLVM SDK: $LLVM_PREFIX"
 
       - name: Build (macos_release)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,14 @@ on:
 
 env:
   GIT_TERMINAL_PROMPT: 0
-  BOOTSTRAP_XLINGS_VERSION: v0.4.2
-  BOOTSTRAP_LLVM_VERSION: 20.1.7
-  XMAKE_VERSION: v3.0.7
+  # CI runs on github.com; force GLOBAL mirror so xim doesn't try gitee
+  # endpoints (which need auth and aren't reachable in CI).
+  XLINGS_RELEASE_MIRROR: GLOBAL
+  # Pinned bootstrap xlings used to read /.xlings.json and install all
+  # build dependencies (xmake, cmake, ninja, musl-gcc on Linux, llvm on
+  # macOS). Bump this in a dedicated PR after verifying the target
+  # release is healthy.
+  BOOTSTRAP_XLINGS_VERSION: v0.4.8
 
 jobs:
   build-linux:
@@ -26,38 +31,40 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y curl git build-essential
 
-      - name: Install xmake (bundled v3.0.7)
-        run: |
-          XMAKE_URL="https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-bundle-v3.0.7.linux.x86_64"
-          curl -fsSL -o xmake.bin "$XMAKE_URL" -H "Accept: application/octet-stream"
-          chmod +x xmake.bin
-          mkdir -p xmake/bin
-          mv xmake.bin xmake/bin/xmake
-          echo "PATH=$GITHUB_WORKSPACE/xmake/bin:$PATH" >> "$GITHUB_ENV"
-          export PATH="$GITHUB_WORKSPACE/xmake/bin:$PATH"
-          xmake --version
-
-      - name: Install Xlings
+      - name: Install bootstrap xlings (pinned ${{ env.BOOTSTRAP_XLINGS_VERSION }})
         env:
           XLINGS_NON_INTERACTIVE: 1
+          XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
           curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
-          echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
-          echo "PATH=$HOME/.xlings/subos/current/bin:$PATH" >> "$GITHUB_ENV"
+          echo "XLINGS_HOME=$HOME/.xlings"           >> "$GITHUB_ENV"
+          echo "$HOME/.xlings/subos/current/bin"     >> "$GITHUB_PATH"
+          echo "$HOME/.xlings/bin"                   >> "$GITHUB_PATH"
 
-      - name: Install musl-gcc 15.1
+      - name: Cache xlings package payloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.xlings/data/xpkgs
+          key: xlings-deps-${{ runner.os }}-${{ hashFiles('.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          restore-keys: |
+            xlings-deps-${{ runner.os }}-
+
+      - name: Install build dependencies (xmake / cmake / ninja / musl-gcc)
         run: |
-          MUSL_SDK=$HOME/.xlings/data/xpkgs/musl-gcc/15.1.0
-          mkdir -p "$MUSL_SDK"
-          curl -fSL# https://github.com/xlings-res/musl-gcc/releases/download/15.1.0/musl-gcc-15.1.0-linux-x86_64.tar.gz | tar xz -C "$MUSL_SDK" --strip-components=1
-          echo "MUSL_SDK=$MUSL_SDK" >> "$GITHUB_ENV"
-          echo "CC=x86_64-linux-musl-gcc" >> "$GITHUB_ENV"
-          echo "CXX=x86_64-linux-musl-g++" >> "$GITHUB_ENV"
-          echo "PATH=$MUSL_SDK/bin:$PATH" >> "$GITHUB_ENV"
-          export PATH="$MUSL_SDK/bin:$PATH"
+          cd "$GITHUB_WORKSPACE"
+          xlings install -y
+
+      - name: Export toolchain paths
+        run: |
+          MUSL_SDK="$HOME/.xlings/data/xpkgs/musl-gcc/15.1.0"
+          test -d "$MUSL_SDK" || { echo "musl-gcc payload missing at $MUSL_SDK"; exit 1; }
           test -f "$MUSL_SDK/x86_64-linux-musl/include/c++/15.1.0/bits/std.cc"
           x86_64-linux-musl-g++ --version
           bash tools/setup_musl_runtime.sh "$MUSL_SDK"
+          echo "MUSL_SDK=$MUSL_SDK"           >> "$GITHUB_ENV"
+          echo "CC=x86_64-linux-musl-gcc"     >> "$GITHUB_ENV"
+          echo "CXX=x86_64-linux-musl-g++"    >> "$GITHUB_ENV"
+          echo "$MUSL_SDK/bin"                >> "$GITHUB_PATH"
 
       - name: Prepare fixture index repo
         run: |
@@ -84,49 +91,40 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install xmake
-        uses: xmake-io/github-action-setup-xmake@v1
+      - name: Install bootstrap xlings (pinned ${{ env.BOOTSTRAP_XLINGS_VERSION }})
+        env:
+          XLINGS_NON_INTERACTIVE: 1
+          XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+          echo "XLINGS_HOME=$HOME/.xlings"           >> "$GITHUB_ENV"
+          echo "$HOME/.xlings/subos/current/bin"     >> "$GITHUB_PATH"
+          echo "$HOME/.xlings/bin"                   >> "$GITHUB_PATH"
+
+      - name: Cache xlings package payloads
+        uses: actions/cache@v4
         with:
-          xmake-version: ${{ env.XMAKE_VERSION }}
+          path: ~/.xlings/data/xpkgs
+          key: xlings-deps-${{ runner.os }}-${{ hashFiles('.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          restore-keys: |
+            xlings-deps-${{ runner.os }}-
 
-      - name: Bootstrap legacy xlings
+      - name: Install build dependencies (xmake / cmake / ninja / llvm)
         run: |
-          PKG_VERSION="${BOOTSTRAP_XLINGS_VERSION#v}"
-          ARCHIVE="xlings-${PKG_VERSION}-macosx-arm64.tar.gz"
-          DOWNLOAD_URL="https://github.com/d2learn/xlings/releases/download/${BOOTSTRAP_XLINGS_VERSION}/${ARCHIVE}"
-          BOOTSTRAP_ROOT="$RUNNER_TEMP/bootstrap-xlings"
-          rm -rf "$BOOTSTRAP_ROOT"
-          mkdir -p "$BOOTSTRAP_ROOT"
-          curl -fsSL -o "$BOOTSTRAP_ROOT/$ARCHIVE" "$DOWNLOAD_URL"
-          tar -xzf "$BOOTSTRAP_ROOT/$ARCHIVE" -C "$BOOTSTRAP_ROOT"
-          BOOTSTRAP_HOME="$(find "$BOOTSTRAP_ROOT" -mindepth 1 -maxdepth 1 -type d -name 'xlings-*' | head -1)"
-          [[ -n "$BOOTSTRAP_HOME" ]] || { echo "bootstrap xlings package not found"; exit 1; }
-          xattr -cr "$BOOTSTRAP_HOME" 2>/dev/null || true
-          echo "BOOTSTRAP_XLINGS_HOME=$BOOTSTRAP_HOME" >> "$GITHUB_ENV"
+          cd "$GITHUB_WORKSPACE"
+          xlings install -y
 
-      - name: Install LLVM toolchain with legacy xlings
+      - name: Export toolchain paths
         run: |
-          export XLINGS_HOME="$HOME/.xlings"
-          rm -rf "$XLINGS_HOME"
-          "$BOOTSTRAP_XLINGS_HOME/bin/xlings" self init
-          "$BOOTSTRAP_XLINGS_HOME/bin/xlings" install llvm@"$BOOTSTRAP_LLVM_VERSION" -y
-          ACTUAL_LLVM_PREFIX="$(find "$XLINGS_HOME/data/xpkgs" -path "*/${BOOTSTRAP_LLVM_VERSION}" -type d | head -1)"
-          [[ -n "$ACTUAL_LLVM_PREFIX" ]] || { echo "installed llvm toolchain not found"; exit 1; }
-          LLVM_ALIAS_ROOT="$XLINGS_HOME/data/xpkgs/local-x-llvm"
-          mkdir -p "$LLVM_ALIAS_ROOT"
-          rm -rf "$LLVM_ALIAS_ROOT/$BOOTSTRAP_LLVM_VERSION"
-          ln -s "$ACTUAL_LLVM_PREFIX" "$LLVM_ALIAS_ROOT/$BOOTSTRAP_LLVM_VERSION"
-          LLVM_PREFIX="$LLVM_ALIAS_ROOT/$BOOTSTRAP_LLVM_VERSION"
+          LLVM_PREFIX="$HOME/.xlings/data/xpkgs/llvm/20.1.7"
           [[ -x "$LLVM_PREFIX/bin/clang++" ]] || { echo "clang++ missing in $LLVM_PREFIX"; exit 1; }
-          echo "LLVM_PREFIX=$LLVM_PREFIX" >> "$GITHUB_ENV"
-          echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> "$GITHUB_ENV"
-          echo "$LLVM_PREFIX/bin" >> "$GITHUB_PATH"
-          echo "Configured LLVM toolchain path: $LLVM_PREFIX"
+          echo "LLVM_PREFIX=$LLVM_PREFIX"                       >> "$GITHUB_ENV"
+          echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)"  >> "$GITHUB_ENV"
+          echo "$LLVM_PREFIX/bin"                               >> "$GITHUB_PATH"
+          "$LLVM_PREFIX/bin/clang++" --version
 
       - name: Configure xmake
         run: |
-          # Temporary workaround: configure xmake with the explicit SDK path
-          # from the bootstrap-installed LLVM toolchain on the GitHub runner.
           xmake f -c -p macosx -m release \
             --toolchain=llvm \
             --sdk="$LLVM_PREFIX" \
@@ -150,12 +148,33 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install xmake
-        uses: xmake-io/github-action-setup-xmake@v1
+      - name: Install bootstrap xlings (pinned ${{ env.BOOTSTRAP_XLINGS_VERSION }})
+        shell: pwsh
+        env:
+          XLINGS_NON_INTERACTIVE: '1'
+          XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
+        run: |
+          irm https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.ps1 | iex
+          "XLINGS_HOME=$env:USERPROFILE\.xlings"            >> $env:GITHUB_ENV
+          "$env:USERPROFILE\.xlings\subos\current\bin"      >> $env:GITHUB_PATH
+          "$env:USERPROFILE\.xlings\bin"                    >> $env:GITHUB_PATH
+
+      - name: Cache xlings package payloads
+        uses: actions/cache@v4
         with:
-          xmake-version: latest
+          path: ~\.xlings\data\xpkgs
+          key: xlings-deps-${{ runner.os }}-${{ hashFiles('.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          restore-keys: |
+            xlings-deps-${{ runner.os }}-
+
+      - name: Install build dependencies (xmake / cmake / ninja)
+        shell: pwsh
+        run: |
+          Set-Location $env:GITHUB_WORKSPACE
+          xlings install -y
 
       - name: Configure xmake
+        shell: pwsh
         run: xmake f -p windows -m release -y
 
       - name: Build (windows_release)

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build and run unit tests
         run: |
-          xmake build -vV xlings_tests
+          xmake build -vv xlings_tests
           xmake run xlings_tests
 
       # ── Phase 2: Build via Release Script ───────────────────────

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build and run unit tests
         run: |
-          xmake build -vv xlings_tests
+          xmake build -y -vv xlings_tests
           xmake run xlings_tests
 
       # ── Phase 2: Build via Release Script ───────────────────────

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -67,15 +67,11 @@ jobs:
         run: |
           bash tests/e2e/prepare_fixture_index.sh
 
-      - name: Configure xmake
-        run: |
-          xmake f -c -p linux -m release -y
-
       # ── Phase 1.5: Unit Tests ────────────────────────────────────
 
       - name: Build and run unit tests
         run: |
-          xmake build xlings_tests
+          xmake build -vV xlings_tests
           xmake run xlings_tests
 
       # ── Phase 2: Build via Release Script ───────────────────────

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -53,18 +53,15 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE"
           xlings install -y
-
-      - name: Export toolchain paths
-        run: |
-          MUSL_SDK="$HOME/.xlings/data/xpkgs/musl-gcc/15.1.0"
-          test -d "$MUSL_SDK" || { echo "musl-gcc payload missing at $MUSL_SDK"; exit 1; }
-          test -f "$MUSL_SDK/x86_64-linux-musl/include/c++/15.1.0/bits/std.cc"
-          x86_64-linux-musl-g++ --version
-          bash tools/setup_musl_runtime.sh "$MUSL_SDK"
-          echo "MUSL_SDK=$MUSL_SDK"           >> "$GITHUB_ENV"
-          echo "CC=x86_64-linux-musl-gcc"     >> "$GITHUB_ENV"
-          echo "CXX=x86_64-linux-musl-g++"    >> "$GITHUB_ENV"
-          echo "$MUSL_SDK/bin"                >> "$GITHUB_PATH"
+          # Sanity: musl-gcc registers `gcc`/`g++`/`cc` flavor shims that
+          # resolve to x86_64-linux-musl-gcc with --dynamic-linker / rpath
+          # flags baked in, so xmake auto-picks the toolchain via PATH —
+          # no --sdk / --cross / CC / CXX needed.
+          gcc --version
+          g++ --version
+          xmake --version
+          cmake --version
+          ninja --version
 
       - name: Prepare fixture index repo
         run: |
@@ -72,7 +69,7 @@ jobs:
 
       - name: Configure xmake
         run: |
-          xmake f -c -p linux -m release --sdk="$MUSL_SDK" --cross=x86_64-linux-musl- --cc="$CC" --cxx="$CXX" -y
+          xmake f -c -p linux -m release -y
 
       # ── Phase 1.5: Unit Tests ────────────────────────────────────
 

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -68,25 +68,28 @@ jobs:
           bash tests/e2e/prepare_fixture_index.sh
 
       - name: Configure xmake
-        # TODO(2026-): the explicit `--sdk=...` here works around an xmake
-        # quirk: when an xrepo dependency (e.g. mcpplibs-xpkg) uses
-        # `import std`, the xrepo subprocess does its own `xmake f` and
-        # does NOT inherit the parent's PATH-based toolchain. Without
-        # `--sdk` it can't locate `<sdk>/x86_64-linux-musl/include/c++/
-        # <ver>/bits/std.cc`, falls back to a deprecated `-fmodules-ts`
-        # check that fails on GCC 15, and reports the misleading
-        # "compiler(gcc): does not support c++ module" error.
-        # See https://github.com/xmake-io/xmake/issues — likely needs
-        # an upstream fix to propagate SDK info into xrepo build env.
-        # When fixed, drop --sdk / --cross / --cc / --cxx and rely on
-        # the musl-gcc-flavor `gcc`/`g++` shims on PATH.
+        # TODO(2026-): we pass --cc / --cxx as ABSOLUTE PATHS to the
+        # real musl-gcc binaries (not the shim names) to bypass xlings'
+        # shim dispatch. xmake's xrepo install spawns subprocesses with
+        # cwd at <pkg-cache>/.../source.tmp, where the shim's project
+        # search can't find the project workspace; the shim then
+        # falls back to the GLOBAL xvm DB which has no musl-gcc entries
+        # (bootstrap xlings 0.4.8 doesn't recognize `projectScope:
+        # false` yet, so it registered musl-gcc to project scope at
+        # install time). Result: shim returns "no version set" in
+        # subprocess context, xmake misinterprets as "compiler doesn't
+        # support flag X", build fails. Absolute paths sidestep the
+        # whole shim dispatch chain.
+        # When the bootstrap xlings is bumped to a release that knows
+        # `projectScope: false` (or musl-gcc is registered globally),
+        # we can revert to bare `--cc=x86_64-linux-musl-gcc`.
         run: |
           MUSL_SDK="$HOME/.xlings/data/xpkgs/xim-x-musl-gcc/15.1.0"
           xmake f -c -p linux -m release \
             --sdk="$MUSL_SDK" \
             --cross=x86_64-linux-musl- \
-            --cc=x86_64-linux-musl-gcc \
-            --cxx=x86_64-linux-musl-g++ \
+            --cc="$MUSL_SDK/bin/x86_64-linux-musl-gcc" \
+            --cxx="$MUSL_SDK/bin/x86_64-linux-musl-g++" \
             -y -vv
 
       # ── Phase 1.5: Unit Tests ────────────────────────────────────

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -11,6 +11,10 @@ env:
   # CI runs on github.com; force GLOBAL mirror so xim doesn't try gitee
   # endpoints (which need auth and aren't reachable in CI).
   XLINGS_RELEASE_MIRROR: GLOBAL
+  # Pinned bootstrap xlings used to read /.xlings.json and install all
+  # build dependencies. Bump this in a dedicated PR after verifying the
+  # target release is healthy.
+  BOOTSTRAP_XLINGS_VERSION: v0.4.8
 
 jobs:
   build-and-test:
@@ -20,45 +24,47 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # ── Phase 1: Configure Environment ──────────────────────────
+      # ── Phase 1: Configure Environment via xlings ─────────────────
 
       - name: Install system deps
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y curl git build-essential
 
-      - name: Install xmake (bundled v3.0.7)
-        run: |
-          XMAKE_URL="https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-bundle-v3.0.7.linux.x86_64"
-          curl -fsSL -o xmake.bin "$XMAKE_URL" -H "Accept: application/octet-stream"
-          chmod +x xmake.bin
-          mkdir -p xmake/bin
-          mv xmake.bin xmake/bin/xmake
-          echo "PATH=$GITHUB_WORKSPACE/xmake/bin:$PATH" >> "$GITHUB_ENV"
-          export PATH="$GITHUB_WORKSPACE/xmake/bin:$PATH"
-          xmake --version
-
-      - name: Install Xlings
+      - name: Install bootstrap xlings (pinned ${{ env.BOOTSTRAP_XLINGS_VERSION }})
         env:
           XLINGS_NON_INTERACTIVE: 1
+          XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
           curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
-          echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
-          echo "PATH=$HOME/.xlings/subos/current/bin:$PATH" >> "$GITHUB_ENV"
+          echo "XLINGS_HOME=$HOME/.xlings"           >> "$GITHUB_ENV"
+          echo "$HOME/.xlings/subos/current/bin"     >> "$GITHUB_PATH"
+          echo "$HOME/.xlings/bin"                   >> "$GITHUB_PATH"
 
-      - name: Install musl-gcc 15.1
+      - name: Cache xlings package payloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.xlings/data/xpkgs
+          key: xlings-deps-${{ runner.os }}-${{ hashFiles('.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          restore-keys: |
+            xlings-deps-${{ runner.os }}-
+
+      - name: Install build dependencies (xmake / cmake / ninja / musl-gcc)
         run: |
-          MUSL_SDK=$HOME/.xlings/data/xpkgs/musl-gcc/15.1.0
-          mkdir -p "$MUSL_SDK"
-          curl -fSL# https://github.com/xlings-res/musl-gcc/releases/download/15.1.0/musl-gcc-15.1.0-linux-x86_64.tar.gz | tar xz -C "$MUSL_SDK" --strip-components=1
-          echo "MUSL_SDK=$MUSL_SDK" >> "$GITHUB_ENV"
-          echo "CC=x86_64-linux-musl-gcc" >> "$GITHUB_ENV"
-          echo "CXX=x86_64-linux-musl-g++" >> "$GITHUB_ENV"
-          echo "PATH=$MUSL_SDK/bin:$PATH" >> "$GITHUB_ENV"
-          export PATH="$MUSL_SDK/bin:$PATH"
+          cd "$GITHUB_WORKSPACE"
+          xlings install -y
+
+      - name: Export toolchain paths
+        run: |
+          MUSL_SDK="$HOME/.xlings/data/xpkgs/musl-gcc/15.1.0"
+          test -d "$MUSL_SDK" || { echo "musl-gcc payload missing at $MUSL_SDK"; exit 1; }
           test -f "$MUSL_SDK/x86_64-linux-musl/include/c++/15.1.0/bits/std.cc"
           x86_64-linux-musl-g++ --version
           bash tools/setup_musl_runtime.sh "$MUSL_SDK"
+          echo "MUSL_SDK=$MUSL_SDK"           >> "$GITHUB_ENV"
+          echo "CC=x86_64-linux-musl-gcc"     >> "$GITHUB_ENV"
+          echo "CXX=x86_64-linux-musl-g++"    >> "$GITHUB_ENV"
+          echo "$MUSL_SDK/bin"                >> "$GITHUB_PATH"
 
       - name: Prepare fixture index repo
         run: |

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -67,6 +67,10 @@ jobs:
         run: |
           bash tests/e2e/prepare_fixture_index.sh
 
+      - name: Configure xmake
+        run: |
+          xmake f -p linux -m release -y -vv
+
       # ── Phase 1.5: Unit Tests ────────────────────────────────────
 
       - name: Build and run unit tests

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -68,8 +68,26 @@ jobs:
           bash tests/e2e/prepare_fixture_index.sh
 
       - name: Configure xmake
+        # TODO(2026-): the explicit `--sdk=...` here works around an xmake
+        # quirk: when an xrepo dependency (e.g. mcpplibs-xpkg) uses
+        # `import std`, the xrepo subprocess does its own `xmake f` and
+        # does NOT inherit the parent's PATH-based toolchain. Without
+        # `--sdk` it can't locate `<sdk>/x86_64-linux-musl/include/c++/
+        # <ver>/bits/std.cc`, falls back to a deprecated `-fmodules-ts`
+        # check that fails on GCC 15, and reports the misleading
+        # "compiler(gcc): does not support c++ module" error.
+        # See https://github.com/xmake-io/xmake/issues — likely needs
+        # an upstream fix to propagate SDK info into xrepo build env.
+        # When fixed, drop --sdk / --cross / --cc / --cxx and rely on
+        # the musl-gcc-flavor `gcc`/`g++` shims on PATH.
         run: |
-          xmake f -p linux -m release -y -vv
+          MUSL_SDK="$HOME/.xlings/data/xpkgs/xim-x-musl-gcc/15.1.0"
+          xmake f -c -p linux -m release \
+            --sdk="$MUSL_SDK" \
+            --cross=x86_64-linux-musl- \
+            --cc=x86_64-linux-musl-gcc \
+            --cxx=x86_64-linux-musl-g++ \
+            -y -vv
 
       # ── Phase 1.5: Unit Tests ────────────────────────────────────
 

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -102,7 +102,12 @@ jobs:
       # ── Phase 2: Build via Release Script ───────────────────────
 
       - name: Build (linux_release)
+        # TODO: linux_release.sh's default MUSL_SDK assumes the legacy
+        # `data/xpkgs/musl-gcc/...` layout (no namespace prefix); modern
+        # xlings install puts it under `data/xpkgs/xim-x-musl-gcc/...`.
+        # Drop this export once the script globs both layouts.
         run: |
+          export MUSL_SDK="$HOME/.xlings/data/xpkgs/xim-x-musl-gcc/15.1.0"
           chmod +x ./tools/linux_release.sh
           SKIP_NETWORK_VERIFY=1 ./tools/linux_release.sh
 

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -9,12 +9,13 @@ on:
 env:
   GIT_TERMINAL_PROMPT: 0
   MACOSX_DEPLOYMENT_TARGET: "11.0"
-  BOOTSTRAP_XLINGS_VERSION: v0.4.2
-  BOOTSTRAP_LLVM_VERSION: 20.1.7
-  XMAKE_VERSION: v3.0.7
   # CI runs on github.com; force GLOBAL mirror so xim doesn't try gitee
   # endpoints (which need auth and aren't reachable in CI).
   XLINGS_RELEASE_MIRROR: GLOBAL
+  # Pinned bootstrap xlings used to read /.xlings.json and install xmake,
+  # cmake, ninja, and the macOS LLVM toolchain. Bump in a dedicated PR
+  # after verifying the target release is healthy.
+  BOOTSTRAP_XLINGS_VERSION: v0.4.8
 
 jobs:
   build-and-test:
@@ -24,57 +25,46 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # ── Phase 1: Configure Environment ──────────────────────────
+      # ── Phase 1: Configure Environment via xlings ─────────────────
 
-      - name: Install xmake
-        uses: xmake-io/github-action-setup-xmake@v1
+      - name: Install bootstrap xlings (pinned ${{ env.BOOTSTRAP_XLINGS_VERSION }})
+        env:
+          XLINGS_NON_INTERACTIVE: 1
+          XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+          echo "XLINGS_HOME=$HOME/.xlings"           >> "$GITHUB_ENV"
+          echo "$HOME/.xlings/subos/current/bin"     >> "$GITHUB_PATH"
+          echo "$HOME/.xlings/bin"                   >> "$GITHUB_PATH"
+
+      - name: Cache xlings package payloads
+        uses: actions/cache@v4
         with:
-          xmake-version: ${{ env.XMAKE_VERSION }}
+          path: ~/.xlings/data/xpkgs
+          key: xlings-deps-${{ runner.os }}-${{ hashFiles('.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          restore-keys: |
+            xlings-deps-${{ runner.os }}-
 
-      - name: Bootstrap legacy xlings
+      - name: Install build dependencies (xmake / cmake / ninja / llvm)
         run: |
-          PKG_VERSION="${BOOTSTRAP_XLINGS_VERSION#v}"
-          ARCHIVE="xlings-${PKG_VERSION}-macosx-arm64.tar.gz"
-          DOWNLOAD_URL="https://github.com/d2learn/xlings/releases/download/${BOOTSTRAP_XLINGS_VERSION}/${ARCHIVE}"
-          BOOTSTRAP_ROOT="$RUNNER_TEMP/bootstrap-xlings"
-          rm -rf "$BOOTSTRAP_ROOT"
-          mkdir -p "$BOOTSTRAP_ROOT"
-          curl -fsSL -o "$BOOTSTRAP_ROOT/$ARCHIVE" "$DOWNLOAD_URL"
-          tar -xzf "$BOOTSTRAP_ROOT/$ARCHIVE" -C "$BOOTSTRAP_ROOT"
-          BOOTSTRAP_HOME="$(find "$BOOTSTRAP_ROOT" -mindepth 1 -maxdepth 1 -type d -name 'xlings-*' | head -1)"
-          [[ -n "$BOOTSTRAP_HOME" ]] || { echo "bootstrap xlings package not found"; exit 1; }
-          xattr -cr "$BOOTSTRAP_HOME" 2>/dev/null || true
-          echo "BOOTSTRAP_XLINGS_HOME=$BOOTSTRAP_HOME" >> "$GITHUB_ENV"
+          cd "$GITHUB_WORKSPACE"
+          xlings install -y
 
-      - name: Install LLVM toolchain with legacy xlings
+      - name: Export toolchain paths
         run: |
-          export XLINGS_HOME="$HOME/.xlings"
-          rm -rf "$XLINGS_HOME"
-          "$BOOTSTRAP_XLINGS_HOME/bin/xlings" self init
-          "$BOOTSTRAP_XLINGS_HOME/bin/xlings" install llvm@"$BOOTSTRAP_LLVM_VERSION" -y
-          ACTUAL_LLVM_PREFIX="$(find "$XLINGS_HOME/data/xpkgs" -path "*/${BOOTSTRAP_LLVM_VERSION}" -type d | head -1)"
-          [[ -n "$ACTUAL_LLVM_PREFIX" ]] || { echo "installed llvm toolchain not found"; exit 1; }
-          LLVM_ALIAS_ROOT="$XLINGS_HOME/data/xpkgs/local-x-llvm"
-          mkdir -p "$LLVM_ALIAS_ROOT"
-          rm -rf "$LLVM_ALIAS_ROOT/$BOOTSTRAP_LLVM_VERSION"
-          ln -s "$ACTUAL_LLVM_PREFIX" "$LLVM_ALIAS_ROOT/$BOOTSTRAP_LLVM_VERSION"
-          LLVM_PREFIX="$LLVM_ALIAS_ROOT/$BOOTSTRAP_LLVM_VERSION"
+          LLVM_PREFIX="$HOME/.xlings/data/xpkgs/llvm/20.1.7"
           [[ -x "$LLVM_PREFIX/bin/clang++" ]] || { echo "clang++ missing in $LLVM_PREFIX"; exit 1; }
-          echo "LLVM_PREFIX=$LLVM_PREFIX" >> "$GITHUB_ENV"
-          echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> "$GITHUB_ENV"
-          echo "$LLVM_PREFIX/bin" >> "$GITHUB_PATH"
-          echo "Configured LLVM toolchain path: $LLVM_PREFIX"
+          echo "LLVM_PREFIX=$LLVM_PREFIX"                       >> "$GITHUB_ENV"
+          echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)"  >> "$GITHUB_ENV"
+          echo "$LLVM_PREFIX/bin"                               >> "$GITHUB_PATH"
           "$LLVM_PREFIX/bin/clang++" --version
 
       - name: Prepare fixture index repo
         run: |
-          rm -rf tests/fixtures/xim-pkgindex
-          git clone --depth 1 https://github.com/d2learn/xim-pkgindex.git tests/fixtures/xim-pkgindex
+          bash tests/e2e/prepare_fixture_index.sh
 
       - name: Configure xmake
         run: |
-          # Temporary workaround: configure xmake with the explicit SDK path
-          # from the bootstrap-installed LLVM toolchain on the GitHub runner.
           xmake f -c -p macosx -m release \
             --toolchain=llvm \
             --sdk="$LLVM_PREFIX" \
@@ -95,10 +85,6 @@ jobs:
         run: |
           chmod +x ./tools/macos_release.sh
           SKIP_NETWORK_VERIFY=1 ./tools/macos_release.sh
-
-      - name: Prepare fixture index repo
-        run: |
-          bash tests/e2e/prepare_fixture_index.sh
 
       - name: "E2E-01: Bootstrap Home (portable + installed)"
         run: |

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build and run unit tests
         run: |
-          xmake build -vV xlings_tests
+          xmake build -vv xlings_tests
           xmake run xlings_tests
 
       # ── Phase 2: Build via Release Script ───────────────────────

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -63,8 +63,19 @@ jobs:
           bash tests/e2e/prepare_fixture_index.sh
 
       - name: Configure xmake
+        # TODO(2026-): the explicit `--sdk=...` here works around an xmake
+        # quirk: xrepo subprocesses don't inherit toolchain SDK info, so
+        # any xrepo dep using `import std` (mcpplibs-xpkg etc) can't
+        # resolve std modules without --sdk pointing at the LLVM payload.
+        # When the upstream issue is fixed, drop --sdk and rely on
+        # `clang`/`clang++` from `xlings install`-installed shims on PATH.
         run: |
-          xmake f -p macosx -m release --toolchain=llvm --target_minver=11.0 -y -vv
+          LLVM_PREFIX="$HOME/.xlings/data/xpkgs/xim-x-llvm/20.1.7"
+          xmake f -c -p macosx -m release \
+            --toolchain=llvm \
+            --sdk="$LLVM_PREFIX" \
+            --target_minver=11.0 \
+            -y -vv
 
       # ── Phase 1.5: Unit Tests ────────────────────────────────────
 

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build and run unit tests
         run: |
-          xmake build -vv xlings_tests
+          xmake build -y -vv xlings_tests
           xmake run xlings_tests
 
       # ── Phase 2: Build via Release Script ───────────────────────

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -62,6 +62,10 @@ jobs:
         run: |
           bash tests/e2e/prepare_fixture_index.sh
 
+      - name: Configure xmake
+        run: |
+          xmake f -p macosx -m release --toolchain=llvm --target_minver=11.0 -y -vv
+
       # ── Phase 1.5: Unit Tests ────────────────────────────────────
 
       - name: Build and run unit tests

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -49,15 +49,14 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE"
           xlings install -y
-
-      - name: Export toolchain paths
-        run: |
-          LLVM_PREFIX="$HOME/.xlings/data/xpkgs/llvm/20.1.7"
-          [[ -x "$LLVM_PREFIX/bin/clang++" ]] || { echo "clang++ missing in $LLVM_PREFIX"; exit 1; }
-          echo "LLVM_PREFIX=$LLVM_PREFIX"                       >> "$GITHUB_ENV"
-          echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)"  >> "$GITHUB_ENV"
-          echo "$LLVM_PREFIX/bin"                               >> "$GITHUB_PATH"
-          "$LLVM_PREFIX/bin/clang++" --version
+          # Sanity: llvm payload's clang/clang++ shims are now on PATH via
+          # the subos current/bin. No --sdk needed — xmake's `--toolchain=llvm`
+          # detects the LLVM clang on PATH and uses its bundled lib/include.
+          xmake --version
+          cmake --version
+          ninja --version
+          clang --version
+          clang++ --version
 
       - name: Prepare fixture index repo
         run: |
@@ -65,12 +64,7 @@ jobs:
 
       - name: Configure xmake
         run: |
-          xmake f -c -p macosx -m release \
-            --toolchain=llvm \
-            --sdk="$LLVM_PREFIX" \
-            --target_minver=11.0 \
-            -y
-          echo "xmake configured with LLVM SDK: $LLVM_PREFIX"
+          xmake f -c -p macosx -m release --toolchain=llvm --target_minver=11.0 -y
 
       # ── Phase 1.5: Unit Tests ────────────────────────────────────
 

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -63,17 +63,18 @@ jobs:
           bash tests/e2e/prepare_fixture_index.sh
 
       - name: Configure xmake
-        # TODO(2026-): the explicit `--sdk=...` here works around an xmake
-        # quirk: xrepo subprocesses don't inherit toolchain SDK info, so
-        # any xrepo dep using `import std` (mcpplibs-xpkg etc) can't
-        # resolve std modules without --sdk pointing at the LLVM payload.
-        # When the upstream issue is fixed, drop --sdk and rely on
-        # `clang`/`clang++` from `xlings install`-installed shims on PATH.
+        # TODO(2026-): same shim-bypass workaround as Linux — see the
+        # comment in xlings-ci-linux.yml. xrepo subprocesses lose
+        # project context, so we pass absolute paths to the real
+        # clang/clang++ inside the LLVM payload to bypass the xlings
+        # shim dispatch chain entirely.
         run: |
           LLVM_PREFIX="$HOME/.xlings/data/xpkgs/xim-x-llvm/20.1.7"
           xmake f -c -p macosx -m release \
             --toolchain=llvm \
             --sdk="$LLVM_PREFIX" \
+            --cc="$LLVM_PREFIX/bin/clang" \
+            --cxx="$LLVM_PREFIX/bin/clang++" \
             --target_minver=11.0 \
             -y -vv
 

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -62,15 +62,11 @@ jobs:
         run: |
           bash tests/e2e/prepare_fixture_index.sh
 
-      - name: Configure xmake
-        run: |
-          xmake f -c -p macosx -m release --toolchain=llvm --target_minver=11.0 -y
-
       # ── Phase 1.5: Unit Tests ────────────────────────────────────
 
       - name: Build and run unit tests
         run: |
-          xmake build xlings_tests
+          xmake build -vV xlings_tests
           xmake run xlings_tests
 
       # ── Phase 2: Build via Release Script ───────────────────────

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -56,16 +56,12 @@ jobs:
         run: |
           bash tests/e2e/prepare_fixture_index.sh
 
-      - name: Configure xmake
-        shell: pwsh
-        run: xmake f -p windows -m release -y
-
       # ── Phase 1.5: Unit Tests ────────────────────────────────────
 
       - name: Build and run unit tests
         shell: pwsh
         run: |
-          xmake build xlings_tests
+          xmake build -vV xlings_tests
           xmake run xlings_tests
 
       # ── Phase 2: Build via Release Script ───────────────────────

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -11,6 +11,10 @@ env:
   # CI runs on github.com; force GLOBAL mirror so xim doesn't try gitee
   # endpoints (which need auth and aren't reachable in CI).
   XLINGS_RELEASE_MIRROR: GLOBAL
+  # Pinned bootstrap xlings used to read /.xlings.json and install xmake
+  # / cmake / ninja. Windows uses MSVC from the runner image (no compiler
+  # in .xlings.json), so xmake's auto-detection still applies.
+  BOOTSTRAP_XLINGS_VERSION: v0.4.8
 
 jobs:
   build-and-test:
@@ -20,23 +24,46 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # ── Phase 1: Configure Environment ──────────────────────────
+      # ── Phase 1: Configure Environment via xlings ─────────────────
 
-      - name: Install xmake
-        uses: xmake-io/github-action-setup-xmake@v1
+      - name: Install bootstrap xlings (pinned ${{ env.BOOTSTRAP_XLINGS_VERSION }})
+        shell: pwsh
+        env:
+          XLINGS_NON_INTERACTIVE: '1'
+          XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
+        run: |
+          irm https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.ps1 | iex
+          "XLINGS_HOME=$env:USERPROFILE\.xlings"            >> $env:GITHUB_ENV
+          "$env:USERPROFILE\.xlings\subos\current\bin"      >> $env:GITHUB_PATH
+          "$env:USERPROFILE\.xlings\bin"                    >> $env:GITHUB_PATH
+
+      - name: Cache xlings package payloads
+        uses: actions/cache@v4
         with:
-          xmake-version: latest
+          path: ~\.xlings\data\xpkgs
+          key: xlings-deps-${{ runner.os }}-${{ hashFiles('.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          restore-keys: |
+            xlings-deps-${{ runner.os }}-
+
+      - name: Install build dependencies (xmake / cmake / ninja)
+        shell: pwsh
+        run: |
+          Set-Location $env:GITHUB_WORKSPACE
+          xlings install -y
 
       - name: Prepare fixture index repo
+        shell: bash
         run: |
           bash tests/e2e/prepare_fixture_index.sh
 
       - name: Configure xmake
+        shell: pwsh
         run: xmake f -p windows -m release -y
 
       # ── Phase 1.5: Unit Tests ────────────────────────────────────
 
       - name: Build and run unit tests
+        shell: pwsh
         run: |
           xmake build xlings_tests
           xmake run xlings_tests

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build and run unit tests
         shell: pwsh
         run: |
-          xmake build -vv xlings_tests
+          xmake build -y -vv xlings_tests
           xmake run xlings_tests
 
       # ── Phase 2: Build via Release Script ───────────────────────

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build and run unit tests
         shell: pwsh
         run: |
-          xmake build -vV xlings_tests
+          xmake build -vv xlings_tests
           xmake run xlings_tests
 
       # ── Phase 2: Build via Release Script ───────────────────────

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -56,6 +56,10 @@ jobs:
         run: |
           bash tests/e2e/prepare_fixture_index.sh
 
+      - name: Configure xmake
+        shell: pwsh
+        run: xmake f -p windows -m release -y -vv
+
       # ── Phase 1.5: Unit Tests ────────────────────────────────────
 
       - name: Build and run unit tests

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ bin/mdbook*
 # local dev sandbox
 .xlings-home-dev/
 .xlings-sandbox/
+/.xlings/

--- a/.xlings.json
+++ b/.xlings.json
@@ -1,5 +1,5 @@
 {
-  "$schema-comment": "Build dependencies for xlings itself. CI and contributors run `xlings install` from this directory to fetch all toolchains and build tools listed below. Windows uses the GitHub-runner-provided MSVC and declares no compiler here. See docs/plans/2026-05-01-ci-self-host-via-xlings-json.md.",
+  "$schema-comment": "Build dependencies for xlings itself. CI / release / contributors run `xlings install` from this directory; xmake then auto-detects the toolchain via PATH (musl-gcc registers `gcc`/`g++`/`cc` flavor shims that resolve to x86_64-linux-musl-gcc with the dynamic-linker / rpath flags baked in, so no --sdk / --cross is needed). Windows uses the GitHub-runner-provided MSVC and declares no compiler here. See docs/plans/2026-05-01-ci-self-host-via-xlings-json.md.",
   "projectScope": false,
   "mirror": "GLOBAL",
   "workspace": {

--- a/.xlings.json
+++ b/.xlings.json
@@ -1,0 +1,16 @@
+{
+  "$schema-comment": "Build dependencies for xlings itself. CI and contributors run `xlings install` from this directory to fetch all toolchains and build tools listed below. Windows uses the GitHub-runner-provided MSVC and declares no compiler here. See docs/plans/2026-05-01-ci-self-host-via-xlings-json.md.",
+  "projectScope": false,
+  "mirror": "GLOBAL",
+  "workspace": {
+    "xmake": "3.0.7",
+    "cmake": "4.0.2",
+    "ninja": "1.12.1",
+    "musl-gcc": {
+      "linux": "15.1.0"
+    },
+    "llvm": {
+      "macosx": "20.1.7"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -162,6 +162,28 @@ strategy to avoid repeatedly downloading the same package payloads.
 - [Adding New Packages](https://xlings.d2learn.org/en/documents/community/contribute/add-xpkg.html)
 - [Documentation Writing](https://xlings.d2learn.org/en/documents/community/contribute/documentation.html)
 
+### Building xlings from source
+
+The repo declares its own build dependencies (xmake / cmake / ninja and a
+platform-specific C++ toolchain) in [`.xlings.json`](.xlings.json), so you
+can install everything via xlings itself:
+
+```bash
+# 1. Install any recent xlings (one-liner) — see installation section above
+# 2. From the repo root:
+xlings install        # reads .xlings.json, installs xmake / cmake / ninja
+                      # + musl-gcc on Linux / llvm on macOS
+                      # (Windows uses the system MSVC)
+
+# 3. Configure + build (paths exported by step 2 satisfy xmake's expectations):
+xmake f -y
+xmake build           # main binary
+xmake build xlings_tests && xmake run xlings_tests
+```
+
+The same `.xlings.json` is consumed by GitHub Actions CI and the release
+pipeline, so a clean local build matches what CI runs.
+
 **👥Contributors**
 
 [![Star History Chart](https://api.star-history.com/svg?repos=d2learn/xlings,d2learn/xim-pkgindex&type=Date)](https://star-history.com/#d2learn/xlings&d2learn/xim-pkgindex&Date)

--- a/docs/plans/2026-05-01-ci-self-host-via-xlings-json.md
+++ b/docs/plans/2026-05-01-ci-self-host-via-xlings-json.md
@@ -1,0 +1,261 @@
+# CI Self-Host: Build xlings's Dependencies Via Its Own `.xlings.json`
+
+**Date**: 2026-05-01
+**Status**: planning
+**Owner**: TBD
+
+## Goal
+
+Replace the manually-scripted dependency-install steps in xlings's GitHub Actions workflows (CI + release) with a single declarative `.xlings.json` at the repo root, consumed by a pinned bootstrap xlings via `xlings install`. The CI gets simpler, dependency upgrades become a one-line edit, and xlings dogfoods itself.
+
+## Scope
+
+| In scope                                            | Out of scope                          |
+|-----------------------------------------------------|---------------------------------------|
+| New `.xlings.json` at repo root                     | Adding new packages to xim-pkgindex   |
+| Refactor `xlings-ci-{linux,macos,windows}.yml`      | Changing toolchain (Linux still musl-gcc, macOS still LLVM, Windows still MSVC) |
+| Refactor `release.yml` (3 build jobs)               | Refactoring the build itself (xmake commands stay the same) |
+| Pin bootstrap xlings to a known-good version (0.4.8)| Replacing xim-pkgindex source-of-truth |
+| Cache `~/.xlings/data/xpkgs` across runs            | Hot-update bootstrap version (keep it pinned) |
+
+## Resolved decisions
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| 1 | Windows toolchain | **MSVC stays default** | Native runner toolchain works; mingw via xlings is opt-in for users only |
+| 2 | Add cmake + ninja to deps? | **Yes — all platforms** | xmake invokes them when building/pulling third-party packages; future-proofing avoids surprise CI breakage |
+| 3 | Bootstrap xlings version | **Pinned to 0.4.8** | First release shipping `self doctor` + alias-removal + mirror config maturity. Pinned via `BOOTSTRAP_XLINGS_VERSION` env, can be bumped per-PR |
+| 4 | Apply to release.yml as well? | **Yes — same refactor** | release.yml duplicates the same env-setup; keeping it in sync prevents drift |
+| 5 | mirror config in .xlings.json | **`"mirror": "GLOBAL"`** | CI runs on github.com; gitee endpoints in some packages need auth and aren't reachable in Actions |
+
+## The `.xlings.json` (repo root, new file)
+
+```json
+{
+  "$schema-comment": "Build dependencies for xlings itself. CI and contributors run `xlings install` from the repo root to install everything below.",
+  "mirror": "GLOBAL",
+
+  "workspace": {
+    "xmake":  "3.0.7",
+    "cmake":  "4.0.2",
+    "ninja":  "1.12.1",
+
+    "musl-gcc": {
+      "linux":  "15.1.0"
+    },
+    "llvm": {
+      "macosx": "20.1.7"
+    }
+  }
+}
+```
+
+Notes:
+- `xmake`, `cmake`, `ninja` have no platform map → installed on all three OSes.
+- `musl-gcc` is keyed `linux` only; macOS and Windows skip it (no key for that OS = nothing installed).
+- `llvm` is keyed `macosx` only.
+- Windows declares no compiler in this file — uses MSVC from the GitHub runner image.
+- **`"projectScope": false`** opts the file out of project-mode activation. The `xlings install` no-args command still reads `workspace` from this file (the install code parses `.xlings.json` directly), but project subos / state writes / `XLINGS_PROJECT_DIR` env-export are all skipped. Without this, every `xlings` invocation from any subdir of the repo would walk up to this file and treat the repo root as a project root — polluting `<repo>/.xlings/.xlings.json` with state across runs. See `src/core/config.cppm:load_project_config_from_dir_` for the gate.
+
+## Bootstrap xlings (the chicken-and-egg solution)
+
+CI installs a known-good xlings via `quick_install.sh` pinned to a specific tag, then uses **that** xlings to read `.xlings.json` and install everything else.
+
+```yaml
+env:
+  BOOTSTRAP_XLINGS_VERSION: v0.4.8
+
+# ...
+- name: Install bootstrap xlings (pinned)
+  env:
+    XLINGS_NON_INTERACTIVE: 1
+    XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
+  run: |
+    curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+    echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
+    echo "$HOME/.xlings/bin" >> "$GITHUB_PATH"
+```
+
+Pre-condition: `quick_install.sh` must honor `XLINGS_VERSION` to install a specific version. **Verify before merging Phase 2** — if the script doesn't support pinning yet, add support as a small pre-PR. (Worst case: download the release tarball directly and run `self install`.)
+
+## Common CI step (the new shared template)
+
+After bootstrap, every workflow does:
+
+```yaml
+- name: Cache xlings packages
+  uses: actions/cache@v4
+  with:
+    path: |
+      ~/.xlings/data/xpkgs
+    key: xlings-deps-${{ runner.os }}-${{ hashFiles('.xlings.json') }}
+    restore-keys: |
+      xlings-deps-${{ runner.os }}-
+
+- name: Install build dependencies (declared in .xlings.json)
+  run: |
+    cd $GITHUB_WORKSPACE
+    xlings install -y      # reads ./.xlings.json, installs all deps under workspace
+```
+
+After this step, `xmake`, `cmake`, `ninja` are on PATH (via xlings shims under `~/.xlings/subos/current/bin`). For tools whose install path xmake needs explicitly (musl-gcc SDK root, llvm prefix), exports follow:
+
+```yaml
+# Linux only
+- name: Export toolchain paths
+  run: |
+    MUSL_SDK="$HOME/.xlings/data/xpkgs/musl-gcc/15.1.0"
+    test -d "$MUSL_SDK" || { echo "musl-gcc not installed"; exit 1; }
+    echo "MUSL_SDK=$MUSL_SDK" >> "$GITHUB_ENV"
+    echo "$MUSL_SDK/bin"    >> "$GITHUB_PATH"
+    echo "CC=x86_64-linux-musl-gcc"  >> "$GITHUB_ENV"
+    echo "CXX=x86_64-linux-musl-g++" >> "$GITHUB_ENV"
+    bash tools/setup_musl_runtime.sh "$MUSL_SDK"
+```
+
+Idea is to keep the xmake-configure + build steps unchanged so the diff is purely "drop the manual download in favor of declarative install".
+
+## Per-workflow diffs (skeleton)
+
+### `xlings-ci-linux.yml`
+
+**Removed**:
+- "Install xmake (bundled v3.0.7)" — replaced by xlings install
+- "Install musl-gcc 15.1" curl/tar — replaced by xlings install
+- "Install Xlings" (already used quick_install — repurpose to bootstrap pinned)
+
+**Added**:
+- Cache action keyed on `.xlings.json` hash
+- "Install build dependencies" runs `xlings install -y`
+- Compact "Export toolchain paths" using `$HOME/.xlings/data/xpkgs/musl-gcc/15.1.0` as the SDK root
+
+Net change: ~−15 lines.
+
+### `xlings-ci-macos.yml`
+
+**Removed**:
+- "Bootstrap legacy xlings" hand-rolled tarball download (lines 34-47)
+- "Install LLVM toolchain with legacy xlings" hand-rolled `install llvm@... -y` (lines 49-67)
+- The `xmake-io/github-action-setup-xmake` action
+
+**Added**:
+- Bootstrap pinned xlings via quick_install (same as Linux)
+- Cache action
+- `xlings install -y` reads `.xlings.json` → installs xmake + cmake + ninja + llvm
+
+The `LLVM_PREFIX` export is still needed for `xmake f --sdk=...`. Path: `$HOME/.xlings/data/xpkgs/llvm/20.1.7` (or whatever xlings-pkgindex stores).
+
+Net change: ~−25 lines.
+
+### `xlings-ci-windows.yml`
+
+**Removed**:
+- The `xmake-io/github-action-setup-xmake@v1 latest` action
+
+**Added**:
+- Bootstrap pinned xlings (Windows-flavored quick_install — verify it exists and works on PowerShell)
+- Cache action
+- `xlings install -y` reads `.xlings.json` → installs xmake + cmake + ninja
+
+MSVC remains auto-detected from the runner. No toolchain export needed.
+
+Net change: ~−5 lines.
+
+### `release.yml`
+
+Three jobs (`build-linux`, `build-macos`, `build-windows`), each currently duplicates the corresponding CI workflow's setup. Apply the same diffs:
+
+- Replace per-job manual downloads with bootstrap-xlings + xlings-install + cache.
+- Keep the release-specific steps (artifact upload, GitHub Release creation, etc.) untouched.
+
+Net change: ~−45 lines across the 3 jobs.
+
+## Caching: expected savings
+
+Cache stores `~/.xlings/data/xpkgs` (the actual binary payloads) plus the xlings DB.
+
+| Phase | Linux time | macOS time | Windows time |
+|-------|-----------|-----------|--------------|
+| Today's setup phase | ~90-120s | ~120-180s | ~30-60s |
+| New (cache hit, common case) | **~5-10s** | **~5-10s** | **~5-10s** |
+| New (cache miss, after `.xlings.json` change) | ~90-120s | ~120-180s | ~60-90s |
+
+Across PR + release CI runs per day, expect ~3-5 minutes/day savings, plus less variance.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Bootstrap 0.4.8 has a bug that breaks `xlings install` | Pin is exactly so we control the version. Bump bootstrap to 0.4.9 in a separate PR after verifying release |
+| `quick_install.sh` doesn't honor `XLINGS_VERSION` | Verify pre-Phase-2; if missing, add support as a tiny preliminary PR |
+| `XLINGS_RES` token (used by musl-gcc / cmake / ninja / llvm) resolves to gitee, unreachable in CI | `mirror: "GLOBAL"` + workflow `XLINGS_RELEASE_MIRROR: GLOBAL` env force github resolution. If any package only has gitee, that package needs a GLOBAL URL — independent xim-pkgindex PR |
+| Cache poisoning (a broken package gets cached) | Cache key includes `.xlings.json` hash; bumping any version invalidates. Manual cache-bust by appending a version comment to `.xlings.json` |
+| GitHub Actions rate-limits hit during quick_install | Bootstrap step retries 3× with exponential backoff. The release tarball download is small (<10 MB), well under typical limits |
+| musl-gcc tarball is ~600 MB; cache-miss runs may time out | Set `actions/cache` `enableCrossOsArchive` and `fail-on-cache-miss: false`; cap the install step at 10 min explicit timeout |
+| .xlings.json conflict with project consumers | This file is conceptually "xlings's own build config". Document at the top that it's for xlings devs, not the same as a consumer project |
+
+## Pre-flight checks (before Phase 2)
+
+Run these before refactoring CI to catch blockers early:
+
+1. **`quick_install.sh` version-pin support**: read `tools/other/quick_install.sh`; confirm it honors `XLINGS_VERSION` env. If not — add it (tiny PR).
+2. **musl-gcc / cmake / ninja / llvm GLOBAL URL resolution**: for each package, with `XLINGS_RELEASE_MIRROR=GLOBAL`, does the URL resolve to a publicly reachable github / gitcode endpoint? If any one is gitee-only, fix in xim-pkgindex first.
+3. **xmake on PATH after `xlings install`**: verify the shim approach works — `xmake --version` from a fresh CI runner after `xlings install -y` should print 3.0.7.
+4. **macOS LLVM payload path**: confirm `$HOME/.xlings/data/xpkgs/llvm/20.1.7/bin/clang++` exists after install (matches what current CI assumes).
+
+## Implementation phases
+
+Each phase is one PR. Each PR is independently reviewable + revertible.
+
+### Phase 1 — Add `.xlings.json` (non-breaking, this is the planning PR)
+
+- New file: `/.xlings.json` (above contents)
+- README contributor section: "To build xlings, install xlings (any recent version), then `xlings install` in this repo to fetch xmake / cmake / ninja / toolchains automatically."
+- No CI workflow changes
+- **Acceptance**: `xlings install` from repo root completes successfully on Linux + macOS + Windows for a contributor. CI is unchanged.
+
+### Phase 2 — Refactor `xlings-ci-linux.yml`
+
+- Remove: "Install xmake (bundled)", "Install musl-gcc 15.1" hand-rolled steps
+- Repurpose: existing "Install Xlings" → "Install bootstrap xlings (pinned 0.4.8)"
+- Add: cache action, "Install build dependencies", "Export toolchain paths"
+- **Acceptance**: PR CI runs end-to-end (build + all 18 e2e steps) with comparable or better timing. Cache miss + cache hit paths both validated.
+
+### Phase 3 — Refactor `xlings-ci-macos.yml`
+
+- Remove: "Bootstrap legacy xlings" + "Install LLVM toolchain with legacy xlings" + xmake action
+- Replace with the same template as Linux (bootstrap pinned + cache + xlings install)
+- Update toolchain export to use `$HOME/.xlings/data/xpkgs/llvm/20.1.7` as `LLVM_PREFIX`
+- **Acceptance**: Same as Phase 2 (Linux). The hand-rolled `LLVM_ALIAS_ROOT` symlinking can be dropped.
+
+### Phase 4 — Refactor `xlings-ci-windows.yml`
+
+- Remove: xmake action
+- Add: bootstrap pinned xlings (PowerShell flavored) + cache + xlings install
+- MSVC remains auto-detected
+- **Acceptance**: Same as Phase 2.
+
+### Phase 5 — Refactor `release.yml`
+
+- Same structural changes as Phases 2-4 across the three release jobs
+- Keep release-specific steps (tarball/zip artifacts, GitHub Release upload) intact
+- **Acceptance**: A test release run produces identical artifacts to a current release.
+
+### Phase 6 (optional) — Cleanup
+
+- Once all 4 workflows are using `.xlings.json`, delete `BOOTSTRAP_LLVM_VERSION` env (it's now read from `.xlings.json`'s llvm version)
+- Delete any orphaned env vars
+- Document the bootstrap-xlings bump procedure in `tools/`
+
+## Future-evolution markers
+
+This is **permanent infrastructure code** — no `COMPAT` markers needed. The `BOOTSTRAP_XLINGS_VERSION` is the only piece that will need periodic bumps; track those in commit history, not in a TODO/COMPAT scheme.
+
+When xlings adopts a `xlings.lock` (lockfile) mechanism, this `.xlings.json` would gain a paired `.xlings.lock` for reproducible CI, but that's a separate feature.
+
+## Out of scope (deferred to follow-up issues)
+
+- Self-doctor check that warns when the repo's `.xlings.json` declared deps don't match what's currently installed
+- Pre-commit hook that runs `xlings install --dry-run` to verify the file parses
+- A `tools/dev-bootstrap.sh` to install bootstrap xlings + run `xlings install` for one-step contributor onboarding
+- Lockfile generation

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -463,6 +463,30 @@ private:
                 // activation, project-state writes, and the project_dir
                 // env-export that downstream shims would otherwise pick
                 // up. Search continues upward as if this file weren't here.
+                //
+                // TODO(2026-): this flag is a workaround for the
+                // chicken-and-egg of "xlings's own repo wants to declare
+                // build deps via .xlings.json without becoming a
+                // managed xlings project". Cleaner long-term options:
+                //
+                //   1. Embrace project mode at the repo root: rewrite
+                //      tests / dev workflow to assume the xlings repo
+                //      IS a managed project; drop this flag entirely.
+                //   2. Add `xlings env` / `xlings config --pkgdir <name>`
+                //      so CI doesn't need to assume payload paths or
+                //      hand-export toolchain env vars at all — the
+                //      installed-subos PATH + xmake auto-detect already
+                //      cover it for the common case (see CI workflows
+                //      that drop --sdk/--cross thanks to musl-gcc's
+                //      gcc-flavor shims), but cross-compile / non-default
+                //      toolchain selections still need explicit values.
+                //   3. Split: keep `.xlings.json` for `xlings install`
+                //      workspace reads, but introduce a separate
+                //      schema-level marker (e.g. top-level
+                //      `"kind": "build-deps"`) checked here.
+                //
+                // Track these in a single follow-up issue once the CI
+                // self-host PR has soaked in.
                 if (json.contains("projectScope") &&
                     json["projectScope"].is_boolean() &&
                     !json["projectScope"].get<bool>()) {

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -455,6 +455,20 @@ private:
             auto content = platform::read_file_to_string(cfg.string());
             auto json = nlohmann::json::parse(content, nullptr, false);
             if (!json.is_discarded()) {
+                // Build-deps-only files (e.g. xlings's own repo-root
+                // /.xlings.json declaring CI dependencies) opt out of
+                // project mode by setting `"projectScope": false`. This
+                // lets `xlings install` from the repo root still read
+                // the `workspace` field, but skips project-subos
+                // activation, project-state writes, and the project_dir
+                // env-export that downstream shims would otherwise pick
+                // up. Search continues upward as if this file weren't here.
+                if (json.contains("projectScope") &&
+                    json["projectScope"].is_boolean() &&
+                    !json["projectScope"].get<bool>()) {
+                    log::debug("config: skipping {} (projectScope=false)", cfg.string());
+                    return;
+                }
                 projectDir_ = dir;
                 hasProjectConfig_ = true;
                 // Export project dir so child processes (shims, os.execute)

--- a/tests/e2e/cli_short_alias_removal_test.sh
+++ b/tests/e2e/cli_short_alias_removal_test.sh
@@ -28,7 +28,7 @@ XLINGS_BIN="$(find_xlings_bin)"
 
 # Plain RUN — invoke as canonical `xlings`.
 RUN() {
-  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
 }
 
 # RUN_AS — invoke the binary via a temporary symlink whose basename is

--- a/tests/e2e/cli_target_compat_test.sh
+++ b/tests/e2e/cli_target_compat_test.sh
@@ -32,7 +32,7 @@ cleanup
 XLINGS_BIN="$(find_xlings_bin)"
 
 RUN() {
-  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
 }
 
 # Helper that runs RUN and captures stdout/stderr as $LAST_OUT.

--- a/tests/e2e/install_idempotent_test.sh
+++ b/tests/e2e/install_idempotent_test.sh
@@ -37,7 +37,7 @@ cleanup
 XLINGS_BIN="$(find_xlings_bin)"
 
 RUN() {
-  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
 }
 
 mkdir -p "$HOME_DIR"

--- a/tests/e2e/project_test_lib.sh
+++ b/tests/e2e/project_test_lib.sh
@@ -77,7 +77,32 @@ run_xlings() {
   local home_dir="$1"
   local workdir="$2"
   shift 2
-  env XLINGS_HOME="$home_dir" "$(find_xlings_bin)" --verbose "$@"
+  # Default: run from a neutral cwd outside the repo so an ancestor-
+  # search for `.xlings.json` (the repo now ships its own at /.xlings.json
+  # for CI self-host purposes) doesn't accidentally activate project mode
+  # for tests that don't want it. Project-context tests wrap call sites
+  # with `(cd "$SCENARIO_DIR" && run_xlings ...)`; we respect such
+  # explicit chdirs by skipping our own when cwd is already inside a
+  # scenario / fixture tree.
+  #
+  # We also `unset` XLINGS_PROJECT_DIR which xlings auto-exports whenever
+  # it loads a project config — it leaks into the test environment from
+  # any prior xlings invocation in the user's shell and would override
+  # our cwd-based isolation.
+  local cwd
+  cwd="$PWD"
+  if [[ "$cwd" == "$ROOT_DIR" ]]; then
+    # Caller didn't cd — they don't want project context. Use a neutral
+    # cwd so the spawned xlings doesn't pick up the repo's CI-self-host
+    # `.xlings.json`.
+    ( cd /tmp && env -u XLINGS_PROJECT_DIR XLINGS_HOME="$home_dir" \
+        "$(find_xlings_bin)" --verbose "$@" )
+  else
+    # Caller explicitly cd'd somewhere — respect it (project-context
+    # tests rely on the project search starting from cwd).
+    env -u XLINGS_PROJECT_DIR XLINGS_HOME="$home_dir" \
+      "$(find_xlings_bin)" --verbose "$@"
+  fi
 }
 
 platform_name() {

--- a/tests/e2e/remove_multi_version_test.sh
+++ b/tests/e2e/remove_multi_version_test.sh
@@ -38,7 +38,7 @@ cleanup  # start fresh
 XLINGS_BIN="$(find_xlings_bin)"
 
 RUN() {
-  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
 }
 
 mkdir -p "$HOME_DIR"

--- a/tests/e2e/self_doctor_test.sh
+++ b/tests/e2e/self_doctor_test.sh
@@ -36,7 +36,7 @@ cleanup
 XLINGS_BIN="$(find_xlings_bin)"
 
 RUN() {
-  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
 }
 
 mkdir -p "$HOME_DIR"

--- a/tests/e2e/subos_events_test.sh
+++ b/tests/e2e/subos_events_test.sh
@@ -31,7 +31,7 @@ cleanup
 XLINGS_BIN="$(find_xlings_bin)"
 
 RUN() {
-  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
 }
 
 mkdir -p "$HOME_DIR/subos/default/bin"

--- a/tests/e2e/update_package_test.sh
+++ b/tests/e2e/update_package_test.sh
@@ -28,7 +28,7 @@ cleanup
 XLINGS_BIN="$(find_xlings_bin)"
 
 RUN() {
-  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
 }
 
 mkdir -p "$HOME_DIR"

--- a/tests/e2e/xlings_self_replace_test.sh
+++ b/tests/e2e/xlings_self_replace_test.sh
@@ -35,7 +35,7 @@ cleanup
 XLINGS_BIN="$(find_xlings_bin)"
 
 RUN() {
-  env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
 }
 
 # Read the marker line from a "fake xlings" script: each version drops

--- a/tests/unit/test_interface_protocol.cpp
+++ b/tests/unit/test_interface_protocol.cpp
@@ -68,8 +68,15 @@ std::pair<std::string, int> run_xlings_(
     if (!xlings_home.empty()) {
 #ifdef _WIN32
         _putenv_s("XLINGS_HOME", xlings_home.c_str());
+        // XLINGS_PROJECT_DIR is auto-set by xlings whenever it loads a
+        // project config (config.cppm). It can leak in from the user's
+        // shell (e.g., running xlings in the repo before the test) and
+        // would override the `cd <neutral_cwd>` isolation below by
+        // forcing the spawned binary to use the leaked project root.
+        _putenv_s("XLINGS_PROJECT_DIR", "");
 #else
         ::setenv("XLINGS_HOME", xlings_home.c_str(), 1);
+        ::unsetenv("XLINGS_PROJECT_DIR");
 #endif
     }
 
@@ -96,6 +103,20 @@ std::pair<std::string, int> run_xlings_(
         cmd += " '" + a + "'";
 #endif
     }
+
+    // Run from a clean directory so the spawned xlings doesn't walk up
+    // and pick up an unrelated project-scope `.xlings.json` (e.g. the
+    // repo root's, which now ships its own `.xlings.json` for CI
+    // self-host purposes). The system temp dir typically has no
+    // ancestor `.xlings.json`, so project-scope detection cleanly
+    // returns "no project". XLINGS_HOME (set above) still routes the
+    // spawned binary to the sandbox global config.
+    auto neutral_cwd = std::filesystem::temp_directory_path().string();
+#ifdef _WIN32
+    cmd = "cd /D \"" + neutral_cwd + "\" && " + cmd;
+#else
+    cmd = "cd \"" + neutral_cwd + "\" && " + cmd;
+#endif
 #ifdef _WIN32
     cmd += " 2>NUL";
 #else


### PR DESCRIPTION
## Summary

Replaces the manually-scripted dependency-install steps across xlings's three CI workflows + release pipeline with a single declarative `/.xlings.json` at the repo root. CI now bootstraps a pinned xlings (v0.4.8) and runs `xlings install -y` to pull every dep. Cache action keyed on `.xlings.json` hash makes warm runs near-instant.

Implements Phases 1-6 from `docs/plans/2026-05-01-ci-self-host-via-xlings-json.md` as a single PR per request.

## What's declared

```json
{
  "projectScope": false,
  "mirror": "GLOBAL",
  "workspace": {
    "xmake":  "3.0.7",   "cmake":  "4.0.2",   "ninja":  "1.12.1",
    "musl-gcc": { "linux":  "15.1.0" },
    "llvm":     { "macosx": "20.1.7" }
  }
}
```

Windows omits a compiler — uses MSVC from the GitHub runner image (per request).

## Files

| File | Change |
|------|--------|
| `/.xlings.json` | NEW — declarative build deps |
| `.github/workflows/xlings-ci-linux.yml` | Replace bundle-download + musl-tar steps with bootstrap + xlings install + cache + export |
| `.github/workflows/xlings-ci-macos.yml` | Drop legacy-bootstrap-0.4.2 dance + LLVM_ALIAS_ROOT symlinks; replaced by the same pinned-0.4.8 + xlings install pattern as Linux |
| `.github/workflows/xlings-ci-windows.yml` | Same; Windows still uses MSVC |
| `.github/workflows/release.yml` | Same refactor across the 3 build jobs |
| `README.md` | Contributors section: `xlings install` from repo root replaces hand-rolled xmake/cmake/ninja install |
| `src/core/config.cppm` | NEW `"projectScope": false` marker — opts a `.xlings.json` out of project-mode activation while still letting `xlings install` read its workspace. Without this, every xlings invocation in the repo subtree would walk up to the build-deps file and treat the repo root as a project, polluting state |
| `tests/e2e/project_test_lib.sh` | `run_xlings` cd's to `/tmp` (when caller hasn't explicitly cd'd into a scenario) + unsets `XLINGS_PROJECT_DIR` — defense-in-depth so test helpers stay robust if the marker is ever bypassed |
| `tests/unit/test_interface_protocol.cpp` | Same hygiene for the unit-test xlings-spawn helper |
| 8 e2e tests using `env -i HOME=...` | Wrap the env-i invocation in `( cd /tmp && ... )` — same hygiene |
| `.gitignore` | Add `/.xlings/` — defensive |
| `docs/plans/2026-05-01-ci-self-host-via-xlings-json.md` | Full design |

## Bootstrap pinning

`BOOTSTRAP_XLINGS_VERSION: v0.4.8` env var across all workflows. Bumps go in a dedicated PR after verifying the target release is healthy.

## Caching

`actions/cache@v4` keyed on `${{ runner.os }}-${{ hashFiles('.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}`. Cache scope = `~/.xlings/data/xpkgs`. Expected savings: ~90s per CI run (Linux) when warm, ~120-180s on macOS where the LLVM tarball was the bottleneck.

## Pre-flight checks (all passed before refactor)

- ✅ `quick_install.sh:24` and `quick_install.ps1:6` honor `XLINGS_VERSION` env
- ✅ `XLINGS_RES` token resolves to `github.com/xlings-res` under `mirror=GLOBAL` (config.cppm:80)
- ✅ Local sweep: 219/219 unit tests + 20 e2e tests pass; `.xlings/` no longer auto-created at repo root

## Test plan

- [x] 219/219 unit tests pass locally (incl. test_interface_protocol fix)
- [x] 20+ e2e tests pass locally: `shim_link`, `cli_short_alias_removal`, `self_doctor`, `xlings_self_replace`, `mirror_fallback`, `index_cache`, `sub_index_search`, `sub_index_install`, `legacy_config`, `pkginfo_install_dir`, `remove_multi_version`, `cli_target_compat`, `script_type_install`, `project_e2e` (orchestrates 11 sub-tests), `install_idempotent`, `tui_utf8`, `bootstrap_home`
- [ ] CI: Linux + macOS + Windows builds + full e2e (this PR's full effect)

## Out of scope

- Bumping bootstrap to 0.4.9+ — separate PR after a healthy release
- Lockfile generation — separate feature