### PR TITLE
release: 0.4.9 — mirror fallback + script-shim fix + CI self-host

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.8";
+    static constexpr std::string_view VERSION = "0.4.9";
     static constexpr std::string_view REPO = "https://github.com/d2learn/xlings";
 };
 


### PR DESCRIPTION
## Summary

Bumps `VERSION` from `0.4.8` to `0.4.9`. Highlights since 0.4.8:

- **#241** — Drop short-command aliases (`xim`/`xvm`/`xself`/`xsubos`/`xinstall`). Single canonical `xlings` entry point. Legacy shim cleanup auto-heals on first 0.4.9 use.
- **#242** — GitHub mirror fallback (Step 1). Failure-driven retry through ghfast / ghproxy.net / kkgithub / jsDelivr. Zero overhead on happy path. Opt-out via `XLINGS_MIRROR_FALLBACK=off`.
- **#244** — Fix `type=script` packages (e.g. `xim:xpkg-helper`) failing to create their shim on Unix under the canonical bootstrap layout.
- **#245** — CI self-host via `/.xlings.json`. Repo declares its own build deps; CI installs via `xlings install -y`. New `projectScope: false` flag prevents the file from activating project mode at the repo root.

## What this PR contains

- Single line: `VERSION = "0.4.8"` → `VERSION = "0.4.9"` in `src/core/config.cppm`.

All four substantive PRs are already on main and CI-verified. This is just the version bump so `release.yml` produces 0.4.9 artifacts when triggered.

## Test plan

- [x] CI passes (single-line change; trivial)
- After merge: trigger `release.yml` to produce v0.4.9 release artifacts