### PR TITLE
fix(release): bypass shim + add -y so 0.4.9 release.yml succeeds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,14 +61,20 @@ jobs:
           bash tests/e2e/prepare_fixture_index.sh
 
       - name: Build (linux_release)
-        # TODO(2026-): linux_release.sh's default MUSL_SDK still assumes
-        # the legacy `data/xpkgs/musl-gcc/...` layout (no namespace
-        # prefix). Modern xlings install puts it under
-        # `data/xpkgs/xim-x-musl-gcc/...`. Exporting MUSL_SDK explicitly
-        # here gets the right path; can be dropped once the script is
-        # updated to glob both layouts.
+        # TODO(2026-): two workarounds, both removable once bootstrap
+        # xlings 0.4.9 propagates everywhere:
+        #   1. linux_release.sh's default MUSL_SDK assumes the legacy
+        #      `data/xpkgs/musl-gcc/...` layout; modern xlings install
+        #      uses `data/xpkgs/xim-x-musl-gcc/...`. Override here.
+        #   2. CC / CXX must be ABSOLUTE PATHS to bypass xlings shim
+        #      dispatch (same shim-vs-real-binary issue documented in
+        #      xlings-ci-linux.yml). Without this, xrepo subprocess
+        #      can't resolve the shim and reports "compiler does not
+        #      support c++ module".
         run: |
           export MUSL_SDK="$HOME/.xlings/data/xpkgs/xim-x-musl-gcc/15.1.0"
+          export CC="$MUSL_SDK/bin/x86_64-linux-musl-gcc"
+          export CXX="$MUSL_SDK/bin/x86_64-linux-musl-g++"
           chmod +x ./tools/linux_release.sh
           SKIP_NETWORK_VERIFY=1 ./tools/linux_release.sh
 

--- a/tools/linux_release.sh
+++ b/tools/linux_release.sh
@@ -56,7 +56,7 @@ else
   fail "musl-gcc sdk not found at $MUSL_SDK (Linux release requires musl-gcc@15.1.0 for fully static binary)"
 fi
 xmake clean -q 2>/dev/null || true
-xmake build xlings 2>&1 || fail "xmake build failed"
+xmake build -y xlings 2>&1 || fail "xmake build failed"
 
 BIN_SRC="build/linux/${ARCH}/release/xlings"
 [[ -f "$BIN_SRC" ]] || fail "C++ binary not found at $BIN_SRC"

--- a/tools/macos_release.sh
+++ b/tools/macos_release.sh
@@ -48,7 +48,7 @@ if [[ -n "$LLVM_PREFIX_DEFAULT" && -x "$LLVM_PREFIX_DEFAULT/bin/clang++" ]]; the
     || fail "xmake configure with llvm failed"
 fi
 xmake clean -q 2>/dev/null || true
-xmake build xlings 2>&1 || fail "xmake build failed"
+xmake build -y xlings 2>&1 || fail "xmake build failed"
 
 BIN_SRC="build/macosx/${ARCH}/release/xlings"
 [[ -f "$BIN_SRC" ]] || fail "C++ binary not found at $BIN_SRC"

--- a/tools/windows_release.ps1
+++ b/tools/windows_release.ps1
@@ -33,7 +33,7 @@ Set-Location $PROJECT_DIR
 Info "Version: $VERSION  |  Arch: $ARCH"
 Info "Building C++ binary..."
 xmake clean -q 2>$null
-xmake build xlings
+xmake build -y xlings
 if ($LASTEXITCODE -ne 0) { Fail "xmake build failed" }
 
 $BIN_SRC = "build\windows\x64\release\xlings.exe"


### PR DESCRIPTION
## Summary

First v0.4.9 release.yml run (`25200185313`) failed: build-linux + build-windows. Two issues fixed here:

1. **Shim-bypass for Linux**: `linux_release.sh` ran \`xmake f --cc=\$CC --cxx=\$CXX\` with bare shim names. xrepo's spawned subprocess can't dispatch the shim out of project context → "compiler does not support c++ module" (same root cause as PR #245's CI fix). Fix: `release.yml` now exports `CC`/`CXX` as absolute paths into the SDK before invoking `linux_release.sh`.

2. **`xmake build -y` in all 3 release scripts**: was prompting interactively for xrepo deps install on Windows, hanging, then aborting. Fix: pass `-y` so deps auto-install.

## Test plan

- [x] CI passes (only changes affect CI artifacts when invoked through `linux_release.sh` etc — main CI runs separately and was unaffected previously)
- After merge: re-trigger `release.yml` to produce v0.4.9 artifacts