### PR TITLE
fix(release): add missing xmake f to windows_release.ps1

### DIFF
--- a/tools/windows_release.ps1
+++ b/tools/windows_release.ps1
@@ -33,6 +33,11 @@ Set-Location $PROJECT_DIR
 Info "Version: $VERSION  |  Arch: $ARCH"
 Info "Building C++ binary..."
 xmake clean -q 2>$null
+# `xmake f` is required so xmake resolves+installs xrepo deps (ftxui /
+# cmdline / ...) before the `xmake build` step touches sources. The
+# Linux + macOS release scripts have an equivalent step.
+xmake f -p windows -m release -y
+if ($LASTEXITCODE -ne 0) { Fail "xmake configure failed" }
 xmake build -y xlings
 if ($LASTEXITCODE -ne 0) { Fail "xmake build failed" }
 


### PR DESCRIPTION
## Summary

0.4.9 release run #2 failed on Windows with \`fatal error C1083: Cannot open include file: 'ftxui/component/event.hpp'\`. Root cause: \`tools/windows_release.ps1\` was calling \`xmake build\` directly with no prior \`xmake f\` configure step, so xrepo dependencies (ftxui / cmdline / etc) never got installed.

The Linux + macOS counterparts already had this step. Bringing Windows symmetric.

## Test plan

- [x] script change is local (no source / module changes)
- After merge: re-trigger release.yml; expect all 3 platforms to succeed and v0.4.9 release to publish