### PR TITLE
feat(xim): runtime / build deps split (libxpkg schema + resolver/installer kind propagation)

### DIFF
--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -200,6 +200,10 @@ jobs:
         run: |
           bash tests/e2e/mirror_fallback_test.sh
 
+      - name: "E2E-20: build/runtime deps split (kind=Build skip-activate + build_dep API)"
+        run: |
+          bash tests/e2e/build_deps_split_test.sh
+
       - name: Attach artifact
         uses: actions/upload-artifact@v4
         if: success()

--- a/docs/plans/2026-05-01-build-runtime-deps-split.md
+++ b/docs/plans/2026-05-01-build-runtime-deps-split.md
@@ -1,0 +1,316 @@
+# Build vs Runtime Deps Split
+
+**Date**: 2026-05-01
+**Status**: in implementation
+**Branch**: `feat/build-runtime-deps`
+**Cross-repo**: requires changes in both `mcpplibs/libxpkg` (schema/parser) and `d2learn/xlings` (consumer)
+
+## Goal
+
+Allow xlings packages to declare two distinct kinds of deps:
+
+- **`runtime`** — what the consumer **needs at run-time** after install. Activated in subos workspace, exposed via shim/PATH (program/script/config) or linked at consumer build (lib).
+- **`build`** — what the package needs **only while installing/building itself**. Filesystem-installed but not activated; the install hook accesses them via injected env / API and uses absolute paths.
+
+Why this matters:
+
+- Today, every dep declared by a package becomes part of the active workspace, polluting the user's tool versions even if the dep was only needed at install time.
+- Build-time tools (compilers, patchelf, code generators) are per-consumer concerns — different consumers can require different versions without conflict if treated as build-only.
+- This unblocks several real conflict scenarios (see `2026-05-01-semver-constraint-design.md` if/when written) where two packages want incompatible versions of the same tool *just for their own builds*.
+
+## Core design
+
+### Lua schema (in xim-pkgindex packages)
+
+New format:
+
+```lua
+package = {
+    name = "fancyapp",
+    type = "program",
+    deps = {
+        linux = {
+            runtime = { "openssl@^3.0", "ncurses" },
+            build   = { "gcc@13.5", "patchelf@0.18" }
+        }
+    }
+}
+```
+
+Backward-compatible legacy format (continues to work, fan-out to both kinds):
+
+```lua
+package = {
+    deps = {
+        linux = { "node", "npm" }   -- treated as runtime AND build
+    }
+}
+```
+
+**Fan-out rule**: when `deps[platform]` is a flat array, every entry is implicitly added to *both* `runtime` and `build`. This is a conservative default that preserves today's behavior. Packages that want the new ergonomics opt in by switching to the table form.
+
+### Lua install-hook API
+
+```lua
+function install()
+    -- absolute path to a build dep payload
+    local gcc = pkginfo.build_dep("gcc")
+    -- gcc.path    = "<xpkgs>/xim-x-gcc/13.5.0"
+    -- gcc.bin     = "<xpkgs>/xim-x-gcc/13.5.0/bin"
+    -- gcc.version = "13.5.0"
+
+    os.exec(gcc.bin .. "/gcc -O2 src/foo.c -o foo")
+end
+```
+
+Plus a convenience: build deps' bin/ directories are auto-prepended to `PATH` for the duration of the install hook, so legacy code like `os.exec("gcc ...")` Just Works and finds the right version.
+
+### xlings consumer behaviour
+
+| Phase | Build deps | Runtime deps |
+|-------|-----------|---------------|
+| Resolver | walked into plan with `kind=build` | walked into plan with `kind=runtime` |
+| Installer | downloaded + extracted to `xpkgs` only | downloaded + extracted + registered in xvm DB + workspace activated |
+| Workspace | NOT touched | active version updated |
+| Visible to user shell | ❌ | ✅ |
+| GC | refcount via consumer's `.build_deps_used.json`; cleaned by `xlings self clean` when no consumer references them | normal workspace removal |
+| Conflict resolution (see semver-constraint plan) | per-consumer private — never cross-conflict | per-package convergence required (subos isolation if not) |
+
+## Schema changes — `mcpplibs/libxpkg`
+
+### `src/xpkg.cppm`
+
+`XpmEntry` (or equivalent platform record) gains two vectors. Keep the existing `deps` field for backward serialization compat.
+
+```cpp
+struct XpmEntry {
+    // ... existing fields
+    std::vector<std::string> deps;          // legacy/effective-union (kept)
+    std::vector<std::string> runtime_deps;  // NEW
+    std::vector<std::string> build_deps;    // NEW
+};
+```
+
+Semantics:
+- Loader populates `runtime_deps`/`build_deps` from the lua source (table form), or fans out from the legacy array.
+- `deps` is set to the union (`runtime ∪ build`) so existing consumers reading `deps` keep working.
+
+### `src/xpkg-loader.cppm`
+
+Detect whether `deps[platform]` is array or table, dispatch to two helper paths. Roughly:
+
+```cpp
+if (lua_is_table_array(...)) {
+    auto v = parse_string_array(...);
+    entry.runtime_deps = v;
+    entry.build_deps = v;
+    entry.deps = v;
+} else {
+    entry.runtime_deps = parse_string_array(deps_table["runtime"]);
+    entry.build_deps   = parse_string_array(deps_table["build"]);
+    entry.deps = union(entry.runtime_deps, entry.build_deps);
+}
+```
+
+### `src/lua-stdlib/xim/libxpkg/pkginfo.lua`
+
+Add `pkginfo.build_dep(name)` returning `{path, bin, version}`. Implementation reads from `XLINGS_BUILDDEP_<NAME>_PATH` env vars that the C++ installer injects.
+
+## Consumer changes — `d2learn/xlings`
+
+### `src/core/xim/libxpkg/types/type.cppm`
+
+`PlanNode` gains `kind` discriminator + dep lists:
+
+```cpp
+enum class DepKind { Runtime, Build };
+
+struct PlanNode {
+    // ... existing fields
+    DepKind kind = DepKind::Runtime;        // how this node was reached in the dep graph
+    std::vector<std::string> runtime_deps;
+    std::vector<std::string> build_deps;
+};
+```
+
+### `src/core/xim/resolver.cppm`
+
+When walking dependencies of a node, partition them:
+
+```cpp
+// previous: for (auto& dep : pkg->xpm.deps[plat]) plan_add(dep, ...);
+for (auto& dep : pkg->xpm.runtime_deps[plat]) plan_add(dep, DepKind::Runtime);
+for (auto& dep : pkg->xpm.build_deps[plat])   plan_add(dep, DepKind::Build);
+```
+
+Build deps inherit `kind=build` even through transitive dependencies — once you're in the build subtree, you stay there.
+
+### `src/core/xim/installer.cppm`
+
+Topological install order honours `kind`:
+
+```cpp
+// install build_deps for X
+for (auto& bd : x.build_deps_resolved) {
+    install_payload(bd);            // unpack to xpkgs/, no DB / workspace updates
+    bump_build_dep_refcount(bd, x); // x is now an "owner"
+}
+
+// run X's install hook with build deps on PATH + env
+auto env = inherit_current_env();
+for (auto& bd : x.build_deps_resolved) {
+    env["PATH"]                                       = bd.bin + ":" + env["PATH"];
+    env["XLINGS_BUILDDEP_" + upper(bd.name) + "_PATH"] = bd.path;
+}
+exec_install_hook(x, env);
+
+// register X in xvm DB + workspace (runtime side only)
+xvm::add_version(x.name, x.version, ...);
+update_workspace(...);
+```
+
+### `src/core/xim/commands.cppm`
+
+`xlings info <pkg>` displays:
+
+```
+Runtime deps: openssl@^3.0, ncurses
+Build deps:   gcc@13.5, patchelf@0.18
+```
+
+### `src/core/xvm/db.cppm`
+
+Refcount tracking for build deps. Each consumer's install dir grows a `build_deps_used.json`:
+
+```json
+{ "gcc": "13.5.0", "patchelf": "0.18.0" }
+```
+
+`xlings self clean` walks this to determine GC eligibility.
+
+## Local joint debugging via xmake.lua
+
+Cross-repo iteration is awkward — every libxpkg change normally requires a release. Workaround: xlings's `xmake.lua` accepts a flag to point at a local libxpkg checkout instead of fetching from xrepo.
+
+```lua
+-- xmake.lua
+option("local_libxpkg")
+    set_default("")
+    set_description("Path to a local mcpplibs/libxpkg checkout for dev")
+option_end()
+
+if has_config("local_libxpkg") and get_config("local_libxpkg") ~= "" then
+    -- Use a private xrepo source pointing at local path
+    add_requireconfs("mcpplibs-xpkg",
+        { override = true,
+          version  = "dev",
+          configs  = { sourcedir = get_config("local_libxpkg") } })
+else
+    add_requires("mcpplibs-xpkg 0.0.32")
+end
+```
+
+Dev workflow:
+
+```bash
+# Iterate on libxpkg
+cd ~/workspace/github/mcpplibs/libxpkg && vim src/xpkg.cppm
+
+# Build xlings against local libxpkg
+cd ~/workspace/github/openxlings/xlings
+xmake f --local_libxpkg=/home/speak/workspace/github/mcpplibs/libxpkg ...
+xmake build
+```
+
+(Exact xmake API may need tweaking — see implementation phase.)
+
+## Test plan
+
+### Unit (libxpkg)
+
+- Parse legacy array form → both vectors populated (fan-out)
+- Parse new table form (only `runtime`) → `build_deps` empty
+- Parse new table form (only `build`) → `runtime_deps` empty
+- Parse mixed → both populated correctly
+
+### Unit (xlings)
+
+- Resolver: `kind=Runtime` and `kind=Build` distinction propagates
+- Installer: hook gets `XLINGS_BUILDDEP_*_PATH` env vars and modified PATH
+- xvm DB: build deps don't enter workspace
+
+### E2E (in isolated XLINGS_HOME)
+
+Fixture package `bdfix` with:
+- `runtime = { "needed-at-runtime@1.0" }`
+- `build = { "compiler-mock@2.0" }`
+
+After install:
+1. ✅ `<xpkgs>/needed-at-runtime/1.0/` exists
+2. ✅ `<xpkgs>/compiler-mock/2.0/` exists
+3. ✅ `<subos>/bin/needed-at-runtime` shim exists (active)
+4. ❌ `<subos>/bin/compiler-mock` shim does NOT exist (build-only)
+5. ✅ `bdfix` install hook successfully invoked compiler-mock via injected PATH/env
+
+## Files
+
+```
+NEW:
+  docs/plans/2026-05-01-build-runtime-deps-split.md   (this file)
+  tests/e2e/build_deps_split_test.sh                   (e2e fixture-driven)
+
+MODIFIED (mcpplibs/libxpkg, separate repo):
+  src/xpkg.cppm                                        (~10 LOC)
+  src/xpkg-loader.cppm                                 (~30 LOC)
+  src/lua-stdlib/xim/libxpkg/pkginfo.lua               (~25 LOC)
+  tests/...                                            (~40 LOC)
+
+MODIFIED (d2learn/xlings):
+  src/core/xim/libxpkg/types/type.cppm                 (~5 LOC)
+  src/core/xim/resolver.cppm                           (~25 LOC)
+  src/core/xim/installer.cppm                          (~60 LOC)
+  src/core/xim/commands.cppm                           (~15 LOC)
+  src/core/xvm/db.cppm                                 (~15 LOC)
+  xmake.lua                                            (~10 LOC, local-override)
+  tests/unit/test_main.cpp                             (~40 LOC, new asserts)
+```
+
+## Phases
+
+### Phase A — libxpkg: schema + parser + lua API
+1. Edit `xpkg.cppm` (add fields)
+2. Edit `xpkg-loader.cppm` (legacy fan-out + table form)
+3. Edit `pkginfo.lua` (build_dep API)
+4. Tests
+5. ⚠️ Don't release yet — wait for Phase B integration
+
+### Phase B — xlings: integration (parallel-able with A's later half)
+1. Add `local_libxpkg` xmake option
+2. Edit `type.cppm`, `resolver.cppm`, `installer.cppm`, `commands.cppm`, `db.cppm`
+3. Tests (unit + e2e)
+4. Build against local libxpkg
+
+### Phase C — xim-pkgindex migration (optional, post-merge)
+- musl-gcc: patchelf as `build`
+- llvm: ninja, cmake as `build`
+- fromsource packages: compilers as `build`
+- One PR per package, optional, low priority.
+
+### Out of scope (this PR)
+- Lockfile (`xlings.lock`)
+- `--override-constraint`
+- semver constraint full grammar (`^`, `~` etc) — that's a separate PR
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Legacy `deps` array gets installed twice (once as runtime, once as build) | Identical artifacts, idempotent install — no actual problem; just a small redundancy log. Documented |
+| Build deps' bin on PATH leaks beyond install hook | Scope env mutation to the hook subprocess; restore after exit |
+| User unintentionally relies on a build dep being on PATH (because it used to be) | Migration of pkgindex packages is opt-in; legacy fan-out preserves old behaviour for unmigrated packages |
+| `xlings remove` of a build-dep leaves dangling consumer references | `self clean` reads `build_deps_used.json` to detect; if user manually removes, refcount layer reports orphans |
+| Cross-repo sync (libxpkg version bump) | `local_libxpkg` xmake option enables dev-time iteration without round-tripping through release |
+
+## Removal / cleanup notes
+
+This is permanent feature, not transitional. No `COMPAT` markers needed. The legacy fan-out stays indefinitely as backward-compat with old pkgindex entries.

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -591,14 +591,30 @@ int cmd_info(const std::string& target, EventStream& stream) {
         addField(fieldsJson, "versions", verStr);
     }
 
-    auto depsIt = pkg->xpm.deps.find(platform);
-    if (depsIt != pkg->xpm.deps.end() && !depsIt->second.empty()) {
-        std::string depStr;
-        for (auto& d : depsIt->second) {
-            if (!depStr.empty()) depStr += " ";
-            depStr += d;
+    auto join_deps = [](const std::vector<std::string>& v) {
+        std::string s;
+        for (auto& d : v) {
+            if (!s.empty()) s += " ";
+            s += d;
         }
-        addField(fieldsJson, "deps", depStr);
+        return s;
+    };
+    auto rtIt = pkg->xpm.runtime_deps.find(platform);
+    auto bdIt = pkg->xpm.build_deps.find(platform);
+    bool hasRuntime = (rtIt != pkg->xpm.runtime_deps.end() && !rtIt->second.empty());
+    bool hasBuild   = (bdIt != pkg->xpm.build_deps.end()   && !bdIt->second.empty());
+    if (hasRuntime || hasBuild) {
+        // Show split form when either is non-empty. The legacy `deps`
+        // field was always the union, so omit it to avoid duplication
+        // when a package only declares the array form (loader fans
+        // legacy → both kinds, so listing all three would triple-print).
+        if (hasRuntime) addField(fieldsJson, "runtime deps", join_deps(rtIt->second));
+        if (hasBuild)   addField(fieldsJson, "build deps",   join_deps(bdIt->second));
+    } else {
+        auto depsIt = pkg->xpm.deps.find(platform);
+        if (depsIt != pkg->xpm.deps.end() && !depsIt->second.empty()) {
+            addField(fieldsJson, "deps", join_deps(depsIt->second));
+        }
     }
 
     addField(fieldsJson, "installed", match->installed ? "yes" : "no", match->installed);

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -741,6 +741,36 @@ public:
     explicit Installer(IndexManager& index) : index_(&index) {}
     explicit Installer(PackageCatalog& catalog) : catalog_(&catalog) {}
 
+    // Resolve a build_deps entry (e.g. "gcc", "ns:gcc@15") to its
+    // payload directory inside xpkgs/<store>/<version>. Plan is in topo
+    // order, so by the time a Runtime node runs its install hook all of
+    // its build_deps already have their payloads laid down on disk.
+    static std::filesystem::path
+    locate_dep_install_dir_(const InstallPlan& plan,
+                            const std::filesystem::path& dataDir,
+                            std::string_view depRef) {
+        auto at = depRef.find('@');
+        auto baseRef = (at == std::string_view::npos) ? depRef
+                                                       : depRef.substr(0, at);
+        auto colon = baseRef.find(':');
+        std::string ns = (colon == std::string_view::npos)
+            ? std::string{}
+            : std::string(baseRef.substr(0, colon));
+        std::string bare = (colon == std::string_view::npos)
+            ? std::string(baseRef)
+            : std::string(baseRef.substr(colon + 1));
+        for (auto& n : plan.nodes) {
+            bool match = (n.name == bare)
+                       || (n.canonicalName == baseRef)
+                       || (n.rawName == depRef);
+            if (!ns.empty()) match = match && (n.namespaceName == ns);
+            if (!match) continue;
+            auto root = n.storeRoot.empty() ? (dataDir / "xpkgs") : n.storeRoot;
+            return root / detail_::effective_store_name_(n) / n.version;
+        }
+        return {};
+    }
+
     // Execute an install plan.
     // useAfterInstall: when true, force the installed program version to
     // become the active one even if another version is currently active.
@@ -1020,8 +1050,59 @@ public:
                     ? dlIt->second.localFile.parent_path()
                     : detail_::runtime_dir_(node, dataDir); // fallback to runtime dir
                 detail_::ScopedCurrentDir_ installCwd(hookCwd);
+
+                // Inject XLINGS_BUILDDEP_<UPPER>_PATH for every build_dep
+                // declared by this node, and prepend their bin/ dirs to
+                // PATH for the duration of the hook. The hook (and any
+                // subprocess it spawns) sees both forms; xpkg-side
+                // pkginfo.build_dep() picks the env path first.
+                std::string oldPath = std::getenv("PATH") ? std::getenv("PATH") : "";
+                std::vector<std::string> setEnvKeys;
+                std::string newPath = oldPath;
+                for (auto& bd : node.build_deps) {
+                    auto bdDir = locate_dep_install_dir_(plan, dataDir, bd);
+                    if (bdDir.empty()) {
+                        log::debug("[{}] build_dep '{}' not found in plan",
+                                   node.name, bd);
+                        continue;
+                    }
+                    std::string nameOnly = bd;
+                    if (auto a = nameOnly.find('@'); a != std::string::npos)
+                        nameOnly.resize(a);
+                    if (auto c = nameOnly.find(':'); c != std::string::npos)
+                        nameOnly = nameOnly.substr(c + 1);
+                    std::string upper;
+                    upper.reserve(nameOnly.size());
+                    for (char c : nameOnly) {
+                        upper += std::isalnum(static_cast<unsigned char>(c))
+                            ? static_cast<char>(std::toupper(static_cast<unsigned char>(c)))
+                            : '_';
+                    }
+                    auto envKey = "XLINGS_BUILDDEP_" + upper + "_PATH";
+                    platform::set_env_variable(envKey, bdDir.string());
+                    setEnvKeys.push_back(envKey);
+                    auto bdBin = (bdDir / "bin").string();
+                    if (std::filesystem::exists(bdDir / "bin")) {
+                        newPath = bdBin + std::string(1, platform::PATH_SEPARATOR) + newPath;
+                    }
+                    log::debug("[{}] build_dep {} -> {} (env {})",
+                               node.name, bd, bdDir.string(), envKey);
+                }
+                if (!setEnvKeys.empty()) {
+                    platform::set_env_variable("PATH", newPath);
+                }
+
                 auto hookResult = executor.run_hook(
                     mcpplibs::xpkg::HookType::Install, ctx);
+
+                // Restore env regardless of hook outcome
+                if (!setEnvKeys.empty()) {
+                    platform::set_env_variable("PATH", oldPath);
+                    for (auto& k : setEnvKeys) {
+                        platform::set_env_variable(k, "");
+                    }
+                }
+
                 if (!hookResult.success) {
                     log::error("install hook failed for {}: {}",
                                node.name, hookResult.error);
@@ -1091,7 +1172,14 @@ public:
                 }
             }
 
-            if (!executor.has_hook(mcpplibs::xpkg::HookType::Config) && node.pkgType == 1 /* Script */) {
+            if (node.kind == DepKind::Build) {
+                // Build-only deps: payload is on disk and resolvable via
+                // pkginfo.build_dep() / XLINGS_BUILDDEP_*_PATH. We skip
+                // config hook + xvm operations entirely so the dep does
+                // NOT take over a workspace slot or get a PATH shim.
+                log::debug("[{}] kind=Build: skipping config hook / workspace activation",
+                           node.name);
+            } else if (!executor.has_hook(mcpplibs::xpkg::HookType::Config) && node.pkgType == 1 /* Script */) {
                 if (!script::default_config(node, dataDir)) {
                     if (onStatus) {
                         onStatus({ node.name, InstallPhase::Failed, 0.0f,

--- a/src/core/xim/libxpkg/types/type.cppm
+++ b/src/core/xim/libxpkg/types/type.cppm
@@ -29,6 +29,11 @@ struct InstallStatus {
     std::string message;
 };
 
+// How a node was reached in the dep graph. Determines whether the
+// installer activates it in the subos workspace (Runtime) or merely
+// places it in the xpkgs store for the consumer's install hook (Build).
+enum class DepKind { Runtime, Build };
+
 // A node in the dependency-resolved install plan
 struct PlanNode {
     std::string rawName;
@@ -39,7 +44,19 @@ struct PlanNode {
     std::string repoName;
     std::filesystem::path pkgFile;
     std::filesystem::path storeRoot;
+    // Effective union of runtime + build deps (kept for legacy callers
+    // that don't yet distinguish; populated by resolver as `runtime ∪
+    // build`).
     std::vector<std::string> deps;
+    // The two kinds, populated when the package's xpm declares them
+    // separately. For legacy packages where only `deps` is present in
+    // the schema, both lists are equal to `deps` (loader-side fan-out).
+    std::vector<std::string> runtime_deps;
+    std::vector<std::string> build_deps;
+    // How this node was added to the plan: Build = a transitive
+    // build-only dep of some other node; Runtime = part of a consumer's
+    // active workspace contract. Build nodes skip workspace activation.
+    DepKind kind { DepKind::Runtime };
     bool alreadyInstalled { false };
     bool isSystemPM { false };
     PackageScope scope { PackageScope::Global };

--- a/src/core/xim/resolver.cppm
+++ b/src/core/xim/resolver.cppm
@@ -42,9 +42,13 @@ resolve(IndexManager& index,
     std::unordered_map<std::string, Color_> color;
     std::unordered_map<std::string, PlanNode> nodeMap;
 
-    // Recursive DFS to expand dependencies
-    std::function<bool(const std::string&, std::vector<std::string>&)> expand =
-        [&](const std::string& target, std::vector<std::string>& path) -> bool {
+    // Recursive DFS to expand dependencies. `kind` propagates from
+    // parent: a Runtime parent's runtime_deps stay Runtime; a Runtime
+    // parent's build_deps become Build; once a subtree is Build, every
+    // transitive dep stays Build (it's only present to serve the build
+    // of an upstream consumer, not the user's active workspace).
+    std::function<bool(const std::string&, std::vector<std::string>&, DepKind)> expand =
+        [&](const std::string& target, std::vector<std::string>& path, DepKind kind) -> bool {
 
         auto [baseName, versionHint] = parse_target_(target);
 
@@ -119,6 +123,7 @@ resolve(IndexManager& index,
         node.name = name;
         node.pkgFile = entry->path;
         node.alreadyInstalled = entry->installed;
+        node.kind = kind;
 
         if (pkg) {
             node.pkgType = static_cast<int>(pkg->type);
@@ -145,15 +150,35 @@ resolve(IndexManager& index,
             }
             key = node_key_(name, node.version);
 
-            // Get deps for this platform
+            // Populate runtime_deps and build_deps separately. Loader
+            // fan-out guarantees: legacy `deps = { ... }` array form is
+            // mirrored into both vectors; new table form `deps = {
+            // runtime = ..., build = ... }` is split. So reading the two
+            // separately is always safe.
+            auto rtIt = pkg->xpm.runtime_deps.find(platform);
+            if (rtIt != pkg->xpm.runtime_deps.end())
+                node.runtime_deps = rtIt->second;
+            auto bdIt = pkg->xpm.build_deps.find(platform);
+            if (bdIt != pkg->xpm.build_deps.end())
+                node.build_deps = bdIt->second;
+
+            // The legacy `deps` field is the union (loader-side) — keep
+            // populating it so existing topo-sort code paths that read
+            // `node.deps` keep working until they're migrated.
             auto depsIt = pkg->xpm.deps.find(platform);
-            if (depsIt != pkg->xpm.deps.end()) {
-                node.deps = depsIt->second;
-                for (auto& dep : node.deps) {
-                    if (!expand(dep, path)) {
-                        // Continue collecting errors
-                    }
-                }
+            if (depsIt != pkg->xpm.deps.end()) node.deps = depsIt->second;
+
+            // Walk the two kinds. Build subtrees stay Build (the dep is
+            // only being installed to satisfy an upstream consumer's
+            // install hook); Runtime parents fork their build_deps to
+            // Build but keep runtime_deps as Runtime.
+            DepKind rt_kind = (kind == DepKind::Build) ? DepKind::Build
+                                                       : DepKind::Runtime;
+            for (auto& dep : node.runtime_deps) {
+                if (!expand(dep, path, rt_kind)) { /* keep collecting */ }
+            }
+            for (auto& dep : node.build_deps) {
+                if (!expand(dep, path, DepKind::Build)) { /* keep collecting */ }
             }
         } else {
             log::warn("failed to load package {}: {}", name, pkg.error());
@@ -165,10 +190,13 @@ resolve(IndexManager& index,
         return true;
     };
 
-    // Process all targets
+    // Process all targets. Top-level user-requested targets are
+    // Runtime by definition — the user is asking xlings to make this
+    // package active in their workspace. Build-only entry points
+    // currently aren't exposed at the CLI level.
     for (auto& target : targets) {
         std::vector<std::string> path;
-        expand(target, path);
+        expand(target, path, DepKind::Runtime);
     }
 
     if (plan.has_errors()) {
@@ -238,8 +266,9 @@ resolve(PackageCatalog& catalog,
     std::unordered_map<std::string, Color_> color;
     std::unordered_map<std::string, PlanNode> nodeMap;
 
-    std::function<bool(const std::string&, std::vector<std::string>&)> expand =
-        [&](const std::string& target, std::vector<std::string>& path) -> bool {
+    // See the IndexManager overload above for `kind` propagation rules.
+    std::function<bool(const std::string&, std::vector<std::string>&, DepKind)> expand =
+        [&](const std::string& target, std::vector<std::string>& path, DepKind kind) -> bool {
         auto resolved = catalog.resolve_target(target, platform);
         if (!resolved) {
             plan.errors.push_back(resolved.error());
@@ -258,6 +287,15 @@ resolve(PackageCatalog& catalog,
                 plan.errors.push_back(std::format("cyclic dependency detected: {}", cycle));
                 return false;
             }
+            // Already processed. If we're encountering this node via a
+            // Runtime walk this time but it was first seen as Build,
+            // upgrade its kind so the installer activates it. Build does
+            // NOT downgrade Runtime — Runtime always wins.
+            if (kind == DepKind::Runtime) {
+                auto nit = nodeMap.find(key);
+                if (nit != nodeMap.end() && nit->second.kind == DepKind::Build)
+                    nit->second.kind = DepKind::Runtime;
+            }
             return true;
         }
 
@@ -275,18 +313,26 @@ resolve(PackageCatalog& catalog,
         node.storeRoot = match.storeRoot;
         node.scope = match.scope;
         node.alreadyInstalled = match.installed;
+        node.kind = kind;
 
         auto pkg = catalog.load_package(match);
         if (pkg) {
             node.pkgType = static_cast<int>(pkg->type);
+
+            auto rtIt = pkg->xpm.runtime_deps.find(platform);
+            if (rtIt != pkg->xpm.runtime_deps.end()) node.runtime_deps = rtIt->second;
+            auto bdIt = pkg->xpm.build_deps.find(platform);
+            if (bdIt != pkg->xpm.build_deps.end()) node.build_deps = bdIt->second;
             auto depsIt = pkg->xpm.deps.find(platform);
-            if (depsIt != pkg->xpm.deps.end()) {
-                node.deps = depsIt->second;
-                for (auto& dep : node.deps) {
-                    if (!expand(dep, path)) {
-                        // keep collecting all dependency errors
-                    }
-                }
+            if (depsIt != pkg->xpm.deps.end()) node.deps = depsIt->second;
+
+            DepKind rt_kind = (kind == DepKind::Build) ? DepKind::Build
+                                                       : DepKind::Runtime;
+            for (auto& dep : node.runtime_deps) {
+                if (!expand(dep, path, rt_kind)) { /* keep collecting */ }
+            }
+            for (auto& dep : node.build_deps) {
+                if (!expand(dep, path, DepKind::Build)) { /* keep collecting */ }
             }
         } else {
             log::warn("failed to load package {}: {}", key, pkg.error());
@@ -300,7 +346,7 @@ resolve(PackageCatalog& catalog,
 
     for (auto& target : targets) {
         std::vector<std::string> path;
-        expand(target, path);
+        expand(target, path, DepKind::Runtime);
     }
 
     if (plan.has_errors()) {

--- a/tests/e2e/build_deps_split_test.sh
+++ b/tests/e2e/build_deps_split_test.sh
@@ -21,33 +21,51 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
 
 require_fixture_index
 
-# The cloned xim-pkgindex doesn't ship our private bdtool/rttool/bdconsumer
-# fixtures (they're test-only schemas exercising the build_deps split). Copy
-# them into the index pkgs/ tree for this run, then remove on EXIT.
+# Use a private LOCAL_INDEX_DIR (not the shared $FIXTURE_INDEX_DIR) because
+# `xlings install` internally calls sync_all_repos when the catalog isn't
+# loaded yet — that runs `git fetch + reset --hard` against the index repo
+# and would clobber any fixture .lua we drop in. Following the same pattern
+# as remove_multi_version_test.sh / xlings_self_replace_test.sh: clone-copy
+# the shared fixture into a runtime-private directory, neutralise its
+# sub-index repos to skip GitHub fetches, and inject the test-only fixtures
+# there. The .xlings.json points "xim" at LOCAL_INDEX_DIR — sync sees it
+# as a non-git path and leaves it alone.
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/build_deps_split"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
 SCENARIO_FIXTURES="$ROOT_DIR/tests/e2e/fixtures/build_deps_split"
-INSTALLED_FIXTURES=(
-    "$FIXTURE_INDEX_DIR/pkgs/b/bdtool.lua"
-    "$FIXTURE_INDEX_DIR/pkgs/b/bdconsumer.lua"
-    "$FIXTURE_INDEX_DIR/pkgs/r/rttool.lua"
-)
-mkdir -p "$FIXTURE_INDEX_DIR/pkgs/b" "$FIXTURE_INDEX_DIR/pkgs/r"
-cp "$SCENARIO_FIXTURES/bdtool.lua"     "$FIXTURE_INDEX_DIR/pkgs/b/bdtool.lua"
-cp "$SCENARIO_FIXTURES/bdconsumer.lua" "$FIXTURE_INDEX_DIR/pkgs/b/bdconsumer.lua"
-cp "$SCENARIO_FIXTURES/rttool.lua"     "$FIXTURE_INDEX_DIR/pkgs/r/rttool.lua"
 
-HOME_DIR="$(runtime_home_dir build_deps_split_home)"
-cleanup() {
-    rm -rf "$HOME_DIR"
-    for f in "${INSTALLED_FIXTURES[@]}"; do rm -f "$f"; done
-}
+cleanup() { rm -rf "$RUNTIME_DIR"; }
 trap cleanup EXIT
 cleanup
 
-# Index cache stores absolute paths from prior runs — wipe.
-rm -f "$FIXTURE_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$HOME_DIR/subos/default/bin"
 
-write_home_config "$HOME_DIR" "GLOBAL"
-run_xlings "$HOME_DIR" "$ROOT_DIR" self init
+# Private copy of the shared fixture index, neutralise sub-index repos.
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+
+# Inject the test fixtures into the private index.
+mkdir -p "$LOCAL_INDEX_DIR/pkgs/b" "$LOCAL_INDEX_DIR/pkgs/r"
+cp "$SCENARIO_FIXTURES/bdtool.lua"     "$LOCAL_INDEX_DIR/pkgs/b/bdtool.lua"
+cp "$SCENARIO_FIXTURES/bdconsumer.lua" "$LOCAL_INDEX_DIR/pkgs/b/bdconsumer.lua"
+cp "$SCENARIO_FIXTURES/rttool.lua"     "$LOCAL_INDEX_DIR/pkgs/r/rttool.lua"
+
+# Seed XLINGS_HOME pointing at the private (neutralised + injected) index.
+cp "$(find_xlings_bin)" "$HOME_DIR/xlings"
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
+EOF
+
+run_xlings "$HOME_DIR" "$ROOT_DIR" self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
 
 log "Installing bdconsumer (runtime_dep=rttool, build_dep=bdtool) ..."
 INSTALL_OUT="$(run_xlings "$HOME_DIR" "$ROOT_DIR" install bdconsumer -y 2>&1)" || {

--- a/tests/e2e/build_deps_split_test.sh
+++ b/tests/e2e/build_deps_split_test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# E2E test: runtime/build deps split.
+#
+# Validates that:
+#   1. The new schema `deps = { runtime = ..., build = ... }` is parsed
+#      and propagated through resolve → install correctly.
+#   2. Runtime deps activate in the workspace (PATH shim, xvm version).
+#   3. Build deps land in xpkgs but are NOT activated (no shim, no
+#      workspace mutation) — they exist only to support the consumer's
+#      install hook.
+#   4. The consumer's install hook sees XLINGS_BUILDDEP_<NAME>_PATH env
+#      vars pointing at the build-dep payload directories, and the
+#      build dep's bin/ is on PATH for the hook subprocess.
+#   5. pkginfo.build_dep() returns the same install_dir / bin / version
+#      from inside the consumer's install hook.
+#
+# Fixtures: tests/fixtures/xim-pkgindex/pkgs/{b,r}/{bdtool,rttool,bdconsumer}.lua
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+# The cloned xim-pkgindex doesn't ship our private bdtool/rttool/bdconsumer
+# fixtures (they're test-only schemas exercising the build_deps split). Copy
+# them into the index pkgs/ tree for this run, then remove on EXIT.
+SCENARIO_FIXTURES="$ROOT_DIR/tests/e2e/fixtures/build_deps_split"
+INSTALLED_FIXTURES=(
+    "$FIXTURE_INDEX_DIR/pkgs/b/bdtool.lua"
+    "$FIXTURE_INDEX_DIR/pkgs/b/bdconsumer.lua"
+    "$FIXTURE_INDEX_DIR/pkgs/r/rttool.lua"
+)
+mkdir -p "$FIXTURE_INDEX_DIR/pkgs/b" "$FIXTURE_INDEX_DIR/pkgs/r"
+cp "$SCENARIO_FIXTURES/bdtool.lua"     "$FIXTURE_INDEX_DIR/pkgs/b/bdtool.lua"
+cp "$SCENARIO_FIXTURES/bdconsumer.lua" "$FIXTURE_INDEX_DIR/pkgs/b/bdconsumer.lua"
+cp "$SCENARIO_FIXTURES/rttool.lua"     "$FIXTURE_INDEX_DIR/pkgs/r/rttool.lua"
+
+HOME_DIR="$(runtime_home_dir build_deps_split_home)"
+cleanup() {
+    rm -rf "$HOME_DIR"
+    for f in "${INSTALLED_FIXTURES[@]}"; do rm -f "$f"; done
+}
+trap cleanup EXIT
+cleanup
+
+# Index cache stores absolute paths from prior runs — wipe.
+rm -f "$FIXTURE_INDEX_DIR/.xlings-index-cache.json"
+
+write_home_config "$HOME_DIR" "GLOBAL"
+run_xlings "$HOME_DIR" "$ROOT_DIR" self init
+
+log "Installing bdconsumer (runtime_dep=rttool, build_dep=bdtool) ..."
+INSTALL_OUT="$(run_xlings "$HOME_DIR" "$ROOT_DIR" install bdconsumer -y 2>&1)" || {
+    echo "$INSTALL_OUT"
+    fail "xlings install bdconsumer failed"
+}
+echo "$INSTALL_OUT"
+
+CONSUMER_DIR="$HOME_DIR/data/xpkgs/xim-x-bdconsumer/1.0.0"
+BDTOOL_DIR="$HOME_DIR/data/xpkgs/xim-x-bdtool/1.0.0"
+RTTOOL_DIR="$HOME_DIR/data/xpkgs/xim-x-rttool/1.0.0"
+BIN_DIR="$HOME_DIR/subos/default/bin"
+
+# 1. All three payloads laid down on disk.
+[[ -d "$CONSUMER_DIR" ]] || fail "bdconsumer payload missing at $CONSUMER_DIR"
+[[ -d "$BDTOOL_DIR"   ]] || fail "bdtool payload missing at $BDTOOL_DIR"
+[[ -d "$RTTOOL_DIR"   ]] || fail "rttool payload missing at $RTTOOL_DIR"
+
+# 2. Runtime dep is activated: shim exists.
+[[ -e "$BIN_DIR/rttool" ]] \
+    || fail "rttool shim missing — runtime dep must activate in workspace"
+
+# 3. Build dep is NOT activated: no shim, no workspace entry.
+if [[ -e "$BIN_DIR/bdtool" ]]; then
+    fail "bdtool shim should NOT exist — build deps must not pollute workspace PATH"
+fi
+if grep -q '"bdtool"' "$HOME_DIR/.xlings.json" 2>/dev/null; then
+    log ".xlings.json contains 'bdtool' — checking it's only payload metadata, not workspace"
+    if python3 -c "
+import json, sys
+d = json.load(open('$HOME_DIR/.xlings.json'))
+ws = d.get('workspace', {})
+sys.exit(0 if 'bdtool' not in ws else 1)
+"; then
+        log "  ok: bdtool is referenced but not in workspace map"
+    else
+        fail "bdtool should NOT appear in workspace map"
+    fi
+fi
+
+# 4. Consumer's install hook captured the env var.
+CAPTURED="$CONSUMER_DIR/captured_env.txt"
+[[ -f "$CAPTURED" ]] || fail "captured_env.txt missing — install hook didn't run?"
+log "captured env:"; sed 's/^/  /' "$CAPTURED"
+EXPECTED="BDTOOL_PATH=$BDTOOL_DIR"
+grep -qxF "$EXPECTED" "$CAPTURED" \
+    || fail "expected '$EXPECTED' in captured_env.txt; got: $(cat "$CAPTURED")"
+
+# RTTOOL env should be empty: runtime deps are activated via workspace,
+# not via the build-dep env-var pathway.
+if grep -q "^RTTOOL_ENV=$" "$CAPTURED"; then
+    log "  ok: RTTOOL env var was empty (runtime deps don't use build-dep injection)"
+else
+    fail "RTTOOL env should be empty — runtime deps must not use XLINGS_BUILDDEP_*"
+fi
+
+# 5. bdtool was reachable on PATH during the install hook.
+BDTOOL_OUT="$CONSUMER_DIR/bdtool_output.txt"
+[[ -f "$BDTOOL_OUT" ]] || fail "bdtool_output.txt missing"
+log "bdtool output during install: $(cat "$BDTOOL_OUT")"
+grep -q "bdtool-1.0.0" "$BDTOOL_OUT" \
+    || fail "bdtool was not reachable on PATH during install hook"
+
+# 6. pkginfo.build_dep() returns expected fields.
+API="$CONSUMER_DIR/build_dep_api.txt"
+[[ -f "$API" ]] || fail "build_dep_api.txt missing"
+log "pkginfo.build_dep('bdtool') ->"; sed 's/^/  /' "$API"
+grep -qxF "path=$BDTOOL_DIR" "$API" \
+    || fail "pkginfo.build_dep().path mismatch — got: $(grep '^path=' "$API")"
+grep -qxF "bin=$BDTOOL_DIR/bin" "$API" \
+    || fail "pkginfo.build_dep().bin mismatch — got: $(grep '^bin=' "$API")"
+grep -qxF "version=1.0.0" "$API" \
+    || fail "pkginfo.build_dep().version should be 1.0.0"
+
+log "PASS: build_deps split (runtime activated, build is install-time only, env vars + Lua API both work)"

--- a/tests/e2e/fixtures/build_deps_split/bdconsumer.lua
+++ b/tests/e2e/fixtures/build_deps_split/bdconsumer.lua
@@ -1,0 +1,99 @@
+-- Fixture: bdconsumer — exercises the build/runtime deps split. Its
+-- xpm.linux.deps uses the new table form { runtime = ..., build = ... }
+-- so the loader exercises the split-form path and the resolver
+-- exercises kind-aware DepKind propagation.
+--
+-- The install hook captures whether xlings injected the build-dep env
+-- vars and whether the build dep was reachable on PATH. The e2e test
+-- (tests/e2e/build_deps_split_test.sh) reads these capture files to
+-- verify both behaviours.
+package = {
+    spec = "1",
+    name = "bdconsumer",
+    description = "Fixture: package with both runtime and build deps",
+    licenses = {"MIT"},
+    type = "package",
+    repo = "https://example.com/bdconsumer",
+    archs = {"x86_64"},
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            deps = {
+                runtime = { "rttool" },
+                build   = { "bdtool" },
+            },
+            ["latest"] = { ref = "1.0.0" },
+            ["1.0.0"]  = {},
+        },
+        macosx = {
+            deps = {
+                runtime = { "rttool" },
+                build   = { "bdtool" },
+            },
+            ["latest"] = { ref = "1.0.0" },
+            ["1.0.0"]  = {},
+        },
+        windows = {
+            deps = {
+                runtime = { "rttool" },
+                build   = { "bdtool" },
+            },
+            ["latest"] = { ref = "1.0.0" },
+            ["1.0.0"]  = {},
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.mkdir(dir)
+
+    -- 1. Capture XLINGS_BUILDDEP_*_PATH env vars: the installer should
+    --    set BDTOOL for the build dep but NOT RTTOOL (runtime deps are
+    --    activated via the workspace, not the env-var pathway).
+    local bdpath = os.getenv("XLINGS_BUILDDEP_BDTOOL_PATH") or ""
+    local rt_env = os.getenv("XLINGS_BUILDDEP_RTTOOL_PATH") or ""
+    local f = io.open(path.join(dir, "captured_env.txt"), "w")
+    f:write("BDTOOL_PATH=" .. bdpath .. "\n")
+    f:write("RTTOOL_ENV=" .. rt_env .. "\n")
+    f:close()
+
+    -- 2. Try to invoke `bdtool` via PATH. The installer should have
+    --    prepended the build dep's bin/ directory to PATH for the
+    --    duration of this hook, so the bare-name call must resolve.
+    local h = io.popen("bdtool 2>&1")
+    if h then
+        local out = h:read("*a") or ""
+        h:close()
+        local f2 = io.open(path.join(dir, "bdtool_output.txt"), "w")
+        if f2 then f2:write(out); f2:close() end
+    end
+
+    -- 3. Use pkginfo.build_dep() — the high-level Lua API for build deps
+    local info = pkginfo.build_dep("bdtool")
+    local f3 = io.open(path.join(dir, "build_dep_api.txt"), "w")
+    if info then
+        f3:write("path=" .. (info.path or "") .. "\n")
+        f3:write("bin="  .. (info.bin  or "") .. "\n")
+        f3:write("version=" .. (info.version or "") .. "\n")
+    else
+        f3:write("nil\n")
+    end
+    f3:close()
+
+    return true
+end
+
+function config()
+    xvm.add("bdconsumer", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("bdconsumer")
+    return true
+end

--- a/tests/e2e/fixtures/build_deps_split/bdtool.lua
+++ b/tests/e2e/fixtures/build_deps_split/bdtool.lua
@@ -1,0 +1,51 @@
+-- Fixture: bdtool — a fake "build-time-only" dep used by the
+-- build_deps_split_test.sh e2e test. Has no download URL; the install
+-- hook lays down a placeholder bin/bdtool script entirely from Lua so
+-- the test runs offline. Used by bdconsumer as a `build` dep.
+package = {
+    spec = "1",
+    name = "bdtool",
+    description = "Fixture: build-only dep tool",
+    licenses = {"MIT"},
+    type = "package",
+    repo = "https://example.com/bdtool",
+    archs = {"x86_64"},
+    xvm_enable = true,
+
+    xpm = {
+        linux   = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+        macosx  = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+        windows = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.mkdir(path.join(dir, "bin"))
+    local bin_path = path.join(dir, "bin", "bdtool")
+    local f = io.open(bin_path, "w")
+    if not f then return false end
+    f:write("#!/bin/sh\necho 'bdtool-1.0.0'\n")
+    f:close()
+    os.execute("chmod 755 '" .. bin_path .. "'")
+    return true
+end
+
+-- Note: config() will be SKIPPED entirely when this package is reached
+-- via a Build-kind walk (xlings >= 0.5.x). It is still defined here so
+-- direct `xlings install bdtool` (Runtime-kind, top-level user request)
+-- registers a workspace shim like any normal package — proving the
+-- "Build-kind suppresses workspace activation" path is the only place
+-- the suppression happens, not the package itself.
+function config()
+    xvm.add("bdtool", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+
+function uninstall()
+    xvm.remove("bdtool")
+    return true
+end

--- a/tests/e2e/fixtures/build_deps_split/rttool.lua
+++ b/tests/e2e/fixtures/build_deps_split/rttool.lua
@@ -1,0 +1,45 @@
+-- Fixture: rttool — runtime-kind dep used by build_deps_split_test.sh.
+-- Same shape as bdtool but pulled in via bdconsumer's `runtime` deps,
+-- so the installer is expected to register it in the workspace and
+-- create a PATH shim.
+package = {
+    spec = "1",
+    name = "rttool",
+    description = "Fixture: runtime dep tool",
+    licenses = {"MIT"},
+    type = "package",
+    repo = "https://example.com/rttool",
+    archs = {"x86_64"},
+    xvm_enable = true,
+
+    xpm = {
+        linux   = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+        macosx  = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+        windows = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.mkdir(path.join(dir, "bin"))
+    local bin_path = path.join(dir, "bin", "rttool")
+    local f = io.open(bin_path, "w")
+    if not f then return false end
+    f:write("#!/bin/sh\necho 'rttool-1.0.0'\n")
+    f:close()
+    os.execute("chmod 755 '" .. bin_path .. "'")
+    return true
+end
+
+function config()
+    xvm.add("rttool", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+
+function uninstall()
+    xvm.remove("rttool")
+    return true
+end

--- a/xmake.lua
+++ b/xmake.lua
@@ -9,10 +9,33 @@ end
 
 add_repositories("mcpplibs-index https://github.com/mcpplibs/mcpplibs-index.git")
 
+-- Local-libxpkg override for cross-repo joint debugging.
+-- Usage:
+--   xmake f --local_libxpkg=/path/to/mcpplibs/libxpkg ...
+-- When set, we treat the local checkout as the source of mcpplibs-xpkg
+-- instead of fetching from the released xrepo package. Useful while
+-- iterating on libxpkg + xlings together (e.g., schema split for
+-- build/runtime deps). Empty string (default) → use released package.
+option("local_libxpkg")
+    set_default("")
+    set_showmenu(true)
+    set_description("Path to local mcpplibs/libxpkg checkout for dev builds")
+option_end()
+
 add_requires("cmdline 0.0.2")
 add_requires("ftxui 6.1.9")
 add_requires("mcpplibs-capi-lua")
-add_requires("mcpplibs-xpkg 0.0.31")
+-- mcpplibs-xpkg: prefer a local source checkout for joint debugging
+-- when --local_libxpkg=/path/to/libxpkg is set. We pull the upstream
+-- xmake.lua targets in via `includes()` so the consumer's build sees
+-- our edits without going through xrepo's package cache (which keys
+-- by released-version hash and ignores in-flight source changes).
+-- Otherwise fall back to the released package from xrepo.
+if has_config("local_libxpkg") and get_config("local_libxpkg") ~= "" then
+    includes(path.join(get_config("local_libxpkg"), "xmake.lua"))
+else
+    add_requires("mcpplibs-xpkg 0.0.31")
+end
 add_requires("gtest 1.15.2")
 add_requires("mcpplibs-tinyhttps 0.2.0")
 -- libarchive's compression backends. Force `system = false` so xmake
@@ -34,7 +57,13 @@ target("xlings")
     add_files("src/**.cppm")
     add_includedirs("src/libs/json")
     add_packages("cmdline", "ftxui", "mcpplibs-capi-lua")
-    add_packages("mcpplibs-xpkg")
+    if has_config("local_libxpkg") and get_config("local_libxpkg") ~= "" then
+        add_deps("mcpplibs-xpkg", "mcpplibs-xpkg-loader",
+                 "mcpplibs-xpkg-index", "mcpplibs-xpkg-lua-stdlib",
+                 "mcpplibs-xpkg-executor")
+    else
+        add_packages("mcpplibs-xpkg")
+    end
     add_packages("mcpplibs-tinyhttps", "libarchive")
     set_policy("build.c++.modules", true)
 
@@ -61,7 +90,13 @@ target("xlings_tests")
     add_files("src/**.cppm")
     add_includedirs("src/libs/json")
     add_packages("cmdline", "ftxui", "mcpplibs-capi-lua", "gtest")
-    add_packages("mcpplibs-xpkg")
+    if has_config("local_libxpkg") and get_config("local_libxpkg") ~= "" then
+        add_deps("mcpplibs-xpkg", "mcpplibs-xpkg-loader",
+                 "mcpplibs-xpkg-index", "mcpplibs-xpkg-lua-stdlib",
+                 "mcpplibs-xpkg-executor")
+    else
+        add_packages("mcpplibs-xpkg")
+    end
     add_packages("mcpplibs-tinyhttps", "libarchive")
     set_policy("build.c++.modules", true)
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -34,7 +34,7 @@ add_requires("mcpplibs-capi-lua")
 if has_config("local_libxpkg") and get_config("local_libxpkg") ~= "" then
     includes(path.join(get_config("local_libxpkg"), "xmake.lua"))
 else
-    add_requires("mcpplibs-xpkg 0.0.31")
+    add_requires("mcpplibs-xpkg 0.0.32")
 end
 add_requires("gtest 1.15.2")
 add_requires("mcpplibs-tinyhttps 0.2.0")


### PR DESCRIPTION
## Summary

- libxpkg ([mcpplibs/libxpkg#... TBD](https://github.com/mcpplibs/libxpkg/commit/3954f3d)): schema gains `runtime_deps` + `build_deps`. Loader fan-out keeps legacy `deps = {...}` array form working unchanged; new `deps = { runtime = ..., build = ... }` table form keeps the two lists separate. `pkginfo.build_dep(name)` Lua API resolves a build-time dep's payload at hook time via injected env or xpkgs scan. **8/8 LoaderTest pass** (incl. 2 new fixtures for both shapes).
- xlings: PlanNode gains `kind` (Runtime/Build) + per-kind dep lists. Resolver propagates kind through DFS — Runtime parent forks build_deps to Build, Build subtree stays Build, "Runtime wins" upgrade on second encounter so user-requested packages always activate. Installer skips `run_config_hook_` for kind=Build (no shim, no workspace mutation, no version DB add) so build deps land in xpkgs/ but never pollute the user's PATH. For Runtime nodes with build_deps, installer injects `XLINGS_BUILDDEP_<UPPER>_PATH` env vars and prepends the build dep's bin/ to PATH around the install hook subprocess. `cmd_info` shows runtime/build deps separately when the new schema form is declared.
- Joint-debug ergonomics: `xmake f --local_libxpkg=/path/to/libxpkg` pulls libxpkg in via `includes()` so in-flight schema edits show up in xlings without going through xrepo's released-version cache.
- New e2e: `tests/e2e/build_deps_split_test.sh` (E2E-20) installs a fixture pkg with both kinds and asserts payload presence, shim-vs-no-shim, env injection, and `pkginfo.build_dep()` return values. Wired into `xlings-ci-linux.yml`.

## Why

Today every dep declared by a package becomes part of the active workspace, polluting the user's tool versions even if the dep was only needed at install time. Build-time tools (compilers, patchelf, code generators) are per-consumer concerns — different consumers can require different versions without conflict if treated as build-only. This unblocks several real diamond-conflict scenarios where two packages want incompatible versions of the same tool *just for their own builds*.

Design doc: `docs/plans/2026-05-01-build-runtime-deps-split.md`.

## Cross-repo coordination

This consumer change requires `mcpplibs-xpkg >= 0.0.32` (or whichever version contains the `runtime_deps`/`build_deps` fields). Until released, joint-debug via `--local_libxpkg=`. After libxpkg releases the new version, bump `add_requires("mcpplibs-xpkg X.Y.Z")` in `xmake.lua`.

## Test plan

- [x] libxpkg unit tests (8/8 LoaderTest, including the two new schema fixtures)
- [ ] xlings local build (blocked by env: gcc15.1.0 sysroot misconfig + xrepo cache glibc/musl mix; CI will exercise the link path on this PR)
- [ ] CI E2E-20 build_deps_split_test.sh (will run on push)
- [ ] All other CI E2E checks still pass