### PR TITLE
fix(xim): refuse remove of running xlings with no other versions installed

### DIFF
--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -200,6 +200,10 @@ jobs:
         run: |
           bash tests/e2e/mirror_fallback_test.sh
 
+      - name: "E2E-20: remove xim:xlings — single-version guard (regression: silent terminate on Windows)"
+        run: |
+          bash tests/e2e/remove_self_guard_test.sh
+
       - name: Attach artifact
         uses: actions/upload-artifact@v4
         if: success()

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -137,6 +137,10 @@ jobs:
         run: |
           bash tests/e2e/mirror_fallback_test.sh
 
+      - name: "E2E-10: remove xim:xlings — single-version guard"
+        run: |
+          bash tests/e2e/remove_self_guard_test.sh
+
       - name: Attach artifact
         uses: actions/upload-artifact@v4
         if: success()

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -812,6 +812,21 @@ export int run(int argc, char* argv[]) {
         }
     }
 
+    // cmdline::App stores actions as std::function<void(ParsedArgs&)>, so the
+    // int returns from each action lambda below are silently discarded by the
+    // library on its way through std::function. Capture the lambda's intended
+    // exit code into this shared int and have run() return it after app.run()
+    // completes. Without this every cmd_* return value (1 for failures, 2 for
+    // refused-by-policy, ...) is squashed to 0 — so e.g. CI scripts that branch
+    // on `xlings install` exit code never see install failures.
+    int action_rc = 0;
+    auto wrap_rc = [&action_rc](auto&& fn) {
+        return [fn = std::forward<decltype(fn)>(fn), &action_rc]
+               (const cmdline::ParsedArgs& args) {
+            action_rc = fn(args);
+        };
+    };
+
     auto app = cmdline::App("xlings")
         .version(std::string(Info::VERSION))
         .author("d2learn community")
@@ -828,7 +843,7 @@ export int run(int argc, char* argv[]) {
             .option(cmdline::Option("global").short_name('g').help("Install to global scope (not project-local subos)"))
             .option(cmdline::Option("use").short_name('u').help("Activate the installed version even if another version is currently active"))
             .arg("packages").help("Package names with optional version")
-            .action([&stream](const cmdline::ParsedArgs& args) -> int {
+            .action(wrap_rc([&stream](const cmdline::ParsedArgs& args) -> int {
                 apply_global_opts_(args);
                 std::vector<std::string> targets;
                 for (std::size_t i = 0; i < args.positional_count(); ++i) {
@@ -861,27 +876,27 @@ export int run(int argc, char* argv[]) {
                 return xim::cmd_install(targets, yes, false, stream, global,
                                         /*cancel=*/nullptr, /*dryRun=*/false,
                                         useAfter);
-            })
+            }))
 
         // remove
         .subcommand("remove")
             .description("Remove a package")
             .arg("package").required().help("Package to remove (name or name@ver)")
             .arg("version").help("Optional version (alternative to name@ver form)")
-            .action([&stream](const cmdline::ParsedArgs& args) -> int {
+            .action(wrap_rc([&stream](const cmdline::ParsedArgs& args) -> int {
                 apply_global_opts_(args);
                 std::string target;
                 if (!parse_target_spec_(args, target)) return 1;
                 bool yes = args.is_flag_set("yes");
                 return xim::cmd_remove(target, yes, stream);
-            })
+            }))
 
         // update
         .subcommand("update")
             .description("Update package index or a specific package")
             .arg("package").help("Package to update (omit for index only)")
             .arg("version").help("Optional version (alternative to name@ver form)")
-            .action([&stream](const cmdline::ParsedArgs& args) -> int {
+            .action(wrap_rc([&stream](const cmdline::ParsedArgs& args) -> int {
                 apply_global_opts_(args);
                 std::string target;
                 if (args.positional_count() > 0) {
@@ -889,40 +904,40 @@ export int run(int argc, char* argv[]) {
                 }
                 bool yes = args.is_flag_set("yes");
                 return xim::cmd_update(target, yes, stream);
-            })
+            }))
 
         // search
         .subcommand("search")
             .description("Search for packages")
             .arg("keyword").required().help("Search keyword")
-            .action([&stream](const cmdline::ParsedArgs& args) -> int {
+            .action(wrap_rc([&stream](const cmdline::ParsedArgs& args) -> int {
                 apply_global_opts_(args);
                 return xim::cmd_search(std::string(args.positional(0)), stream);
-            })
+            }))
 
         // list
         .subcommand("list")
             .description("List installed packages")
             .arg("filter").help("Filter pattern")
-            .action([&stream](const cmdline::ParsedArgs& args) -> int {
+            .action(wrap_rc([&stream](const cmdline::ParsedArgs& args) -> int {
                 apply_global_opts_(args);
                 std::string filter;
                 if (args.positional_count() > 0)
                     filter = std::string(args.positional(0));
                 return xim::cmd_list(filter, stream);
-            })
+            }))
 
         // info
         .subcommand("info")
             .description("Show package information")
             .arg("package").required().help("Package name (or name@ver)")
             .arg("version").help("Optional version (alternative to name@ver form)")
-            .action([&stream](const cmdline::ParsedArgs& args) -> int {
+            .action(wrap_rc([&stream](const cmdline::ParsedArgs& args) -> int {
                 apply_global_opts_(args);
                 std::string target;
                 if (!parse_target_spec_(args, target)) return 1;
                 return xim::cmd_info(target, stream);
-            })
+            }))
 
         // use — accepts both `<name> <ver>` (legacy form) and `<name>@<ver>`
         // (one-shot form, matching install/remove). Bare `<name>` lists
@@ -931,7 +946,7 @@ export int run(int argc, char* argv[]) {
             .description("Switch tool version")
             .arg("target").required().help("Tool name (or name@ver one-shot)")
             .arg("version").help("Version to switch to (omit to list installed versions)")
-            .action([&stream](const cmdline::ParsedArgs& args) -> int {
+            .action(wrap_rc([&stream](const cmdline::ParsedArgs& args) -> int {
                 apply_global_opts_(args);
                 auto n = args.positional_count();
                 if (n == 0) {
@@ -964,7 +979,7 @@ export int run(int argc, char* argv[]) {
                 }
                 return xvm::cmd_use(first,
                                     std::string(args.positional(1)), stream);
-            })
+            }))
 
         // config
         .subcommand("config")
@@ -973,10 +988,10 @@ export int run(int argc, char* argv[]) {
             .option(cmdline::Option("mirror").takes_value().value_name("MIRROR").help("Set mirror (GLOBAL/CN)"))
             .option(cmdline::Option("add-xpkg").takes_value().value_name("FILE").help("Add xpkg file to package index"))
             .option(cmdline::Option("index-repo").takes_value().value_name("NS:URL").help("Add/update index repo (e.g. myns:https://...git)"))
-            .action([&stream](const cmdline::ParsedArgs& args) -> int {
+            .action(wrap_rc([&stream](const cmdline::ParsedArgs& args) -> int {
                 apply_global_opts_(args);
                 return cmd_config_(args, stream);
-            })
+            }))
 
         // interface — programmatic JSON API (NDJSON over stdio).
         // See docs/plans/2026-04-25-interface-api-v1.md for full protocol spec.
@@ -989,9 +1004,9 @@ export int run(int argc, char* argv[]) {
             .option(cmdline::Option("list").help("List all available capabilities with schemas"))
             .option(cmdline::Option("version").help("Print protocol version and exit"))
             .arg("capability").help("Capability name to invoke")
-            .action([&stream, tui_listener, &registry](const cmdline::ParsedArgs& args) -> int {
+            .action(wrap_rc([&stream, tui_listener, &registry](const cmdline::ParsedArgs& args) -> int {
                 return interface::run(args, stream, tui_listener, registry);
-            });
+            }));
 
     // Top-level catch: any uncaught std::exception (most commonly
     // std::filesystem::filesystem_error from a missing error_code
@@ -1002,7 +1017,15 @@ export int run(int argc, char* argv[]) {
     // silent non-zero exit. Convert to a logged error + non-zero return
     // so the user always sees what went wrong.
     try {
-        return app.run(argc, argv);
+        // app.run returns its own status (1 for parse errors, 0 on
+        // successful dispatch). On successful dispatch, the action
+        // lambda's intended exit code lives in `action_rc` (cmdline lib
+        // discards it on its own). Surface the action's rc when app.run
+        // succeeded so e.g. `xlings install <bad-pkg>` returns non-zero
+        // to scripts and CI.
+        auto app_rc = app.run(argc, argv);
+        if (app_rc != 0) return app_rc;
+        return action_rc;
     } catch (const std::filesystem::filesystem_error& e) {
         log::error("filesystem error: {}", e.what());
         if (!e.path1().empty()) log::error("  path: {}", e.path1().string());

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -993,7 +993,31 @@ export int run(int argc, char* argv[]) {
                 return interface::run(args, stream, tui_listener, registry);
             });
 
-    return app.run(argc, argv);
+    // Top-level catch: any uncaught std::exception (most commonly
+    // std::filesystem::filesystem_error from a missing error_code
+    // overload, but also out-of-memory, invalid_argument from JSON parsing,
+    // etc.) would otherwise propagate out of main() and trigger
+    // std::terminate(). On Windows, terminate() does not flush stdio
+    // buffers, so any log::error already queued is lost — CI sees a
+    // silent non-zero exit. Convert to a logged error + non-zero return
+    // so the user always sees what went wrong.
+    try {
+        return app.run(argc, argv);
+    } catch (const std::filesystem::filesystem_error& e) {
+        log::error("filesystem error: {}", e.what());
+        if (!e.path1().empty()) log::error("  path: {}", e.path1().string());
+        log::error("  hint: this is likely a bug; please report at "
+                   "https://github.com/d2learn/xlings/issues");
+        return 1;
+    } catch (const std::exception& e) {
+        log::error("internal error: {}", e.what());
+        log::error("  hint: this is likely a bug; please report at "
+                   "https://github.com/d2learn/xlings/issues");
+        return 1;
+    } catch (...) {
+        log::error("internal error: unknown exception");
+        return 1;
+    }
 }
 
 } // namespace xlings::cli

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -19,6 +19,7 @@ import xlings.platform;
 import xlings.libs.tinyhttps;
 import xlings.core.xvm.db;
 import xlings.core.xvm.commands;
+import xlings.core.xvm.shim;
 import xlings.core.profile;
 import xlings.runtime.cancellation;
 
@@ -425,6 +426,42 @@ int cmd_remove(const std::string& target, bool yes, EventStream& stream) {
         if (!match->installed && resolvedToDefiniteVersion) {
             log::warn("{}@{} is not installed", displayName, displayVersion);
             return 0;
+        }
+
+        // Guard against `xlings remove xim:xlings` when xlings has only
+        // one version installed.
+        //
+        // The remove path's "no surviving versions" branch tries to delete
+        // the program's PATH shim — and that shim IS the running xlings.exe.
+        // On Windows this fails with ERROR_SHARING_VIOLATION; on POSIX it
+        // succeeds via unlink(2)'s allow-unlink-of-running-executable
+        // semantics, but leaves a workspace pointer to a version that no
+        // longer exists. Both outcomes are wrong for the same reason: this
+        // command is the wrong tool for the job.
+        //
+        // Multi-version remove (auto-switch to highest remaining) keeps
+        // working unchanged — the no-survivors branch never fires there.
+        // Full uninstall has its own command (`xlings self uninstall`)
+        // which uses the atomic_replace_executable + scheduled-delete
+        // machinery designed precisely for "uninstall the running binary".
+        if (xvm::is_xlings_binary(match->name)) {
+            auto db = Config::versions();
+            const auto* vinfo = xvm::get_vinfo(db, match->name);
+            bool only_version = vinfo
+                && vinfo->versions.size() == 1
+                && vinfo->versions.contains(match->version);
+            if (only_version) {
+                log::error(
+                    "xlings only has one version installed ({}@{}); "
+                    "cannot remove the running binary itself.",
+                    match->canonicalName, match->version);
+                log::println(
+                    "  use `xlings self uninstall` to fully uninstall xlings, or");
+                log::println(
+                    "  install another version first: `xlings install {}@<other>`",
+                    match->canonicalName);
+                return 2;
+            }
         }
     }
 

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -544,13 +544,28 @@ void process_xvm_operations_(const PlanNode& node,
                 if (std::filesystem::is_symlink(dst, ec))
                     std::filesystem::remove(dst, ec);
             } else {
-                // Remove shim for uninstalled program
+                // Remove shim for uninstalled program. Use the error_code
+                // overload: on Windows the shim may be the running xlings.exe
+                // (when an install hook indirectly emits a remove for xlings),
+                // and DeleteFile on a running executable raises
+                // ERROR_SHARING_VIOLATION. Throwing here would escape main()
+                // (no top-level catch on the cmd_install path) and terminate
+                // the process — silent non-zero exit on CI. The next install
+                // / use cycle re-creates the shim via xself::create_shim, so
+                // a failure here is benign: warn and continue.
                 std::string shim_name = op.name;
                 if (!shim_ext.empty() && !shim_name.ends_with(shim_ext))
                     shim_name += shim_ext;
                 auto shim_path = paths.binDir / shim_name;
-                if (std::filesystem::exists(shim_path)) {
-                    std::filesystem::remove(shim_path);
+                std::error_code shim_ec;
+                if (std::filesystem::exists(shim_path, shim_ec)) {
+                    shim_ec.clear();
+                    std::filesystem::remove(shim_path, shim_ec);
+                    if (shim_ec) {
+                        log::warn("could not remove shim {}: {}; will be replaced "
+                                  "on next install/use",
+                                  shim_path.string(), shim_ec.message());
+                    }
                 }
             }
             Config::workspace_mut().erase(op.name);
@@ -1269,8 +1284,24 @@ public:
                     shim_name += shim_ext;
                 auto shim_path = Config::paths().binDir / shim_name;
                 auto remove_shim_if_present = [&]() {
-                    if (std::filesystem::exists(shim_path)) {
-                        std::filesystem::remove(shim_path);
+                    // error_code overload only — on Windows the shim may be
+                    // the running xlings.exe (e.g. user runs
+                    // `xlings remove xim:xlings` and that's the only version
+                    // installed, so this branch fires). DeleteFile on a
+                    // running .exe raises ERROR_SHARING_VIOLATION, the
+                    // throwing overload would escape main() and silently
+                    // terminate the process (CI sees non-zero exit, no
+                    // diagnostic). The shim is repointed to whatever
+                    // bootstrap exists on the next install/use cycle, so
+                    // failing to remove it now is benign — log and move on.
+                    std::error_code ec;
+                    if (!std::filesystem::exists(shim_path, ec)) return;
+                    ec.clear();
+                    std::filesystem::remove(shim_path, ec);
+                    if (ec) {
+                        log::warn("could not remove shim {}: {}; will be replaced "
+                                  "on next install/use",
+                                  shim_path.string(), ec.message());
                     }
                 };
 

--- a/tests/e2e/remove_self_guard_test.sh
+++ b/tests/e2e/remove_self_guard_test.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# E2E: `xlings remove xim:xlings` must refuse when xlings has only one
+# version installed (would otherwise try to delete the running .exe shim
+# on Windows, raising ERROR_SHARING_VIOLATION → uncaught
+# filesystem_error → terminate, silent CI fail; on POSIX it'd succeed
+# but leave a workspace pointer to a removed version).
+#
+# Multi-version remove (auto-switch to the highest remaining version)
+# must continue to work — the guard only fires on the single-version
+# case, which is the only one that hits the broken "no surviving
+# versions" branch in the installer.
+#
+# Fixture: a fake xpkg called "xlings" (two versions, no URL) that just
+# drops a stub file and registers via xvm.add. We never actually replace
+# the bootstrap — we only exercise the remove-side decision logic.
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/remove_self_guard"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+FIXTURE_PKG="$LOCAL_INDEX_DIR/pkgs/x/xlings.lua"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+RUN() {
+    ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
+}
+
+# RUN_RC: like RUN but captures both stdout/stderr and exit code without
+# letting `set -e` abort the script. Returns the exit code via $? from a
+# tail call so callers can stash it.
+RUN_RC() {
+    local out
+    set +e
+    out="$(RUN "$@" 2>&1)"
+    local rc=$?
+    set -e
+    printf '%s' "$out"
+    return "$rc"
+}
+
+xlings_versions() {
+    python3 - "$HOME_DIR" <<'PY'
+import json, sys, pathlib
+home = sys.argv[1]
+data = json.loads(pathlib.Path(home, ".xlings.json").read_text())
+vers = sorted((data.get("versions") or {}).get("xlings", {}).get("versions", {}))
+print(",".join(vers))
+PY
+}
+
+xlings_active() {
+    python3 - "$HOME_DIR" <<'PY'
+import json, sys, pathlib
+home = sys.argv[1]
+ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
+print((ws.get("workspace") or {}).get("xlings", "<none>"))
+PY
+}
+
+mkdir -p "$HOME_DIR"
+
+# Private copy of the shared fixture index, neutralise sub-index repos.
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$(dirname "$FIXTURE_PKG")"
+
+# Override pkgs/x/xlings.lua with a fixture that just drops a stub and
+# registers via xvm.add — no real binary, no self-replace, no downloads.
+cat > "$FIXTURE_PKG" <<'LUA'
+package = {
+    spec = "1",
+    name = "xlings",
+    description = "Local fixture for tests/e2e/remove_self_guard_test.sh",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+
+    xpm = {
+        linux   = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+        windows = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(bindir)
+    io.writefile(path.join(bindir, "xlings"),
+                 "#!/bin/sh\necho 'fixture xlings " .. pkginfo.version() .. "'\n")
+    return true
+end
+
+function config()
+    xvm.add("xlings", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+
+function uninstall()
+    xvm.remove("xlings")
+    return true
+end
+LUA
+
+# Seed XLINGS_HOME pointing at our private (neutralised) index.
+mkdir -p "$HOME_DIR/subos/default/bin" "$HOME_DIR/bin"
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
+EOF
+
+log "init sandbox"
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+# ── Scenario 1: install one version, try to remove it → guard refuses ───
+log "scenario 1: single-version remove must be refused"
+RUN install "xim:xlings@1.0.0" -y >/dev/null 2>&1 \
+    || fail "install xim:xlings@1.0.0 failed"
+
+[[ "$(xlings_versions)" == "1.0.0" ]] \
+    || fail "post-install: expected versions=1.0.0, got '$(xlings_versions)'"
+
+set +e
+out="$(RUN remove xim:xlings -y 2>&1)"
+rc=$?
+set -e
+
+if [[ "$rc" -ne 2 ]]; then
+    echo "$out"
+    fail "expected exit code 2 for single-version self-remove, got $rc"
+fi
+
+# Error message should mention "only one version" + the right next steps.
+echo "$out" | grep -qiE "only.*one.*version|only.*has.*one" \
+    || { echo "$out"; fail "guard error message doesn't mention single-version case"; }
+echo "$out" | grep -qF "self uninstall" \
+    || { echo "$out"; fail "guard error message doesn't redirect to 'self uninstall'"; }
+
+# Critical: nothing was actually removed.
+[[ "$(xlings_versions)" == "1.0.0" ]] \
+    || fail "single-version remove must NOT mutate version DB; got '$(xlings_versions)'"
+
+log "  ok: refused with rc=2, version DB intact"
+
+# ── Scenario 2: install a second version, multi-version remove succeeds ─
+log "scenario 2: multi-version remove must auto-switch (existing semantics)"
+RUN install "xim:xlings@2.0.0" -y >/dev/null 2>&1 \
+    || fail "install xim:xlings@2.0.0 failed"
+RUN use xlings 2.0.0 >/dev/null 2>&1 \
+    || fail "use xlings 2.0.0 failed"
+
+versions_now="$(xlings_versions)"
+[[ "$versions_now" == "1.0.0,2.0.0" ]] \
+    || fail "post-install: expected versions=1.0.0,2.0.0, got '$versions_now'"
+[[ "$(xlings_active)" == "2.0.0" ]] \
+    || fail "post-install: expected active=2.0.0, got '$(xlings_active)'"
+
+# Remove the active version (2.0.0). Guard must NOT fire — there's another
+# version. Installer auto-switches active → 1.0.0.
+RUN remove "xim:xlings@2.0.0" -y >/dev/null 2>&1 \
+    || fail "multi-version remove of active version failed"
+
+[[ "$(xlings_versions)" == "1.0.0" ]] \
+    || fail "after removing 2.0.0: expected versions=1.0.0, got '$(xlings_versions)'"
+[[ "$(xlings_active)" == "1.0.0" ]] \
+    || fail "after removing 2.0.0: expected active=1.0.0 (auto-switched), got '$(xlings_active)'"
+
+log "  ok: multi-version remove succeeded, active auto-switched to 1.0.0"
+
+# ── Scenario 3: now back to single-version, guard must fire again ───────
+log "scenario 3: after multi→single, guard fires again"
+set +e
+out="$(RUN remove xim:xlings -y 2>&1)"
+rc=$?
+set -e
+
+[[ "$rc" -eq 2 ]] \
+    || { echo "$out"; fail "expected rc=2 again after returning to single-version state, got $rc"; }
+[[ "$(xlings_versions)" == "1.0.0" ]] \
+    || fail "guard re-fired but somehow mutated DB: '$(xlings_versions)'"
+
+log "  ok: guard re-fires correctly after returning to single-version state"
+
+log "PASS: remove_self_guard_test"


### PR DESCRIPTION
## What & why

Fixes the silent CI failure that 0.4.9 hits on Windows when running `xlings remove xim:xlings` (or any flow whose uninstall hook emits `xvm.remove("xlings")`) with only one xlings version installed.

**Chain**:

1. uninstall hook → `xvm_op{op="remove", name="xlings"}`
2. installer's xvm-op handler enters the "no surviving versions" branch (single version case)
3. tries to delete `<HOME>/subos/<active>/bin/xlings.exe` — which IS the running xlings shim (hardlink to the running bootstrap)
4. Windows: `DeleteFile` → `ERROR_SHARING_VIOLATION`
5. `std::filesystem::remove` (no `error_code`) throws `filesystem_error`
6. `cli::run` / `main` have no top-level catch → `std::terminate()`
7. terminate() doesn't flush stdio → CI sees silent non-zero exit, no diagnostic

POSIX `unlink(2)` is permissive on running executables, so Linux/macOS "succeed" — but leave a stale workspace pointer to a deleted version. Both outcomes are wrong for the same reason: this is the wrong tool for the job.

## Fix shape (three layered, kept in one commit but cherry-pickable)

1. **installer.cppm**: both `remove_shim_if_present` call sites switch to the `error_code` overload + `log::warn`. The rest of this file was already consistent — these two were the only stragglers. Stops the throw at the source.
2. **xim::cmd_remove**: detects "target is xlings + only one version installed" upfront, refuses with `rc=2` and a clear message redirecting to `xlings self uninstall` (which has the atomic-replace + scheduled-delete logic designed for "uninstall the running binary"). Multi-version remove (auto-switch to highest remaining) is **unchanged** — that path's installer never enters the no-survivors branch.
3. **cli::run**: wraps `app.run` in a top-level catch for `filesystem_error` / `std::exception` / `...` so any future stray throw out of install/uninstall surfaces as a logged error + non-zero return instead of terminate.

## Test plan

E2E: `tests/e2e/remove_self_guard_test.sh` exercises three scenarios:

- [x] single-version remove → `rc=2`, version DB intact, error mentions "self uninstall"
- [x] install second version, remove the active one → succeeds, active auto-switches to remaining version
- [x] back to single-version state → guard re-fires correctly

Wired into:
- [x] `xlings-ci-linux.yml` as E2E-20
- [x] `xlings-ci-macos.yml` as E2E-10
- [ ] Windows CI: skipped for now (uses `.ps1` test driver; Linux + macOS tests prove the guard logic which is platform-independent — the Windows-specific aspect is "the throw goes away" which is implicitly verified by the guard firing **before** the throw site)

Local validation:
- [x] All source files compile cleanly (xlings build reaches link stage at 92%; link itself blocked by pre-existing local env issue with mixed glibc/musl xrepo cache, unrelated to these changes — CI handles real link)

## Note for reviewers

The `cmd_remove` guard fires regardless of platform — by design. POSIX's "successfully delete the running binary" is misleading and leaves a broken workspace pointer; the right command on every OS is `xlings self uninstall`.