### PR TITLE
fix(build): libarchive uses xz (liblzma) instead of 7-zip lzma SDK for .tar.xz support

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -9,6 +9,14 @@ end
 
 add_repositories("mcpplibs-index https://github.com/mcpplibs/mcpplibs-index.git")
 
+-- Project-private package overrides. See xmake/packages/libarchive.lua
+-- for why we ship our own libarchive definition (TL;DR: xmake-repo's
+-- libarchive uses 7-Zip LZMA SDK as a dep, libarchive's cmake actually
+-- needs xz-utils' liblzma → .tar.xz extraction silently degrades to a
+-- fork-exec of the system `xz` binary, which doesn't exist on
+-- musl-static minimal containers or Windows).
+includes("xmake/packages/libarchive.lua")
+
 -- Local-libxpkg override for cross-repo joint debugging.
 -- Usage:
 --   xmake f --local_libxpkg=/path/to/mcpplibs/libxpkg ...
@@ -43,12 +51,17 @@ add_requires("mcpplibs-tinyhttps 0.2.0")
 -- picking up the host's glibc-built /usr/lib copies, which can't be
 -- linked into a musl-static binary. Required for the linux release
 -- build; harmless on macOS/Windows.
-add_requires("zlib",  { system = false })
-add_requires("lz4",   { system = false })
+--
+-- Note `xz` (xz-utils / liblzma) replaces the upstream
+-- `lzma` (7-Zip LZMA SDK). See xmake/packages/libarchive.lua header
+-- comment for why; the override of libarchive itself wires `xz` in as
+-- a dep so libarchive's cmake actually finds liblzma.
+add_requires("zlib", { system = false })
+add_requires("lz4",  { system = false })
 add_requires("bzip2", { system = false })
-add_requires("zstd",  { system = false })
-add_requires("lzma",  { system = false })
-add_requires("libarchive 3.8.7")
+add_requires("zstd", { system = false })
+add_requires("xz",   { system = false })
+add_requires("libarchive-xlings 3.8.7")
 
 -- C++23 main binary
 target("xlings")
@@ -64,7 +77,7 @@ target("xlings")
     else
         add_packages("mcpplibs-xpkg")
     end
-    add_packages("mcpplibs-tinyhttps", "libarchive")
+    add_packages("mcpplibs-tinyhttps", "libarchive-xlings")
     set_policy("build.c++.modules", true)
 
     if is_plat("macosx") then
@@ -97,7 +110,7 @@ target("xlings_tests")
     else
         add_packages("mcpplibs-xpkg")
     end
-    add_packages("mcpplibs-tinyhttps", "libarchive")
+    add_packages("mcpplibs-tinyhttps", "libarchive-xlings")
     set_policy("build.c++.modules", true)
 
     if is_plat("macosx") then

--- a/xmake/packages/libarchive.lua
+++ b/xmake/packages/libarchive.lua
@@ -1,0 +1,115 @@
+-- libarchive package override (project-private).
+--
+-- Why this file exists
+-- --------------------
+-- xmake-repo's `libarchive` package definition declares its compression
+-- backend deps as:
+--
+--     add_deps("zlib", "bzip2", "lz4", "zstd", "lzma")
+--
+-- Four of those names match the cmake `find_package` names that
+-- libarchive's CMakeLists.txt probes during build (`ZLIB`, `BZip2`,
+-- `lz4`, `zstd`) — so the libarchive build wires them in correctly.
+--
+-- The fifth, `lzma`, does NOT. xmake-repo's `lzma` package is the
+-- 7-Zip LZMA SDK (header `LzmaLib.h`, function `LzmaCompress`). What
+-- libarchive's cmake actually probes is `find_package(LibLZMA)` —
+-- xz-utils' liblzma (header `lzma.h`, function `lzma_code`). Different
+-- API surface entirely. xrepo's package for that is `xz`.
+--
+-- Net effect of the upstream `add_deps("lzma")` line: cmake's
+-- LibLZMA detection fails, libarchive falls back to its
+-- `archive_read_support_filter_xz_external` path that fork-exec's the
+-- system `xz` / `lzma` binary at runtime. Symptoms:
+--   * Linux musl-static deployments that lack a host `xz` binary →
+--     .tar.xz / .tar.lzma extraction fails at runtime.
+--   * Windows builds → no system `xz.exe` → same failure.
+--   * Even on hosts where it works, every .tar.xz extract is a
+--     fork-exec round-trip (slow, temp-file IO).
+--
+-- Concrete xim-pkgindex packages affected today: node@* (linux uses
+-- node-vXXX-linux-x64.tar.xz) and llvm (macos arm64 uses .tar.xz).
+--
+-- Override strategy
+-- -----------------
+-- Re-declare libarchive as `libarchive-xlings`, set_base("libarchive")
+-- to inherit URL list / version table / etc., then:
+--   * swap `lzma` → `xz` in the deps so the cmake find_package call
+--     resolves to xrepo-built liblzma instead of falling back;
+--   * pass explicit `-DENABLE_LZMA=ON` (and the other backends) so
+--     cmake's auto-detection cannot silently disable any of them on a
+--     stripped builder image.
+--
+-- Including this file from the project's root xmake.lua is enough;
+-- xmake's `package()` block registers a private package alongside any
+-- xmake-repo packages and `add_requires("libarchive-xlings ...")`
+-- picks it up.
+--
+-- When this can be removed
+-- ------------------------
+-- After xmake-repo merges a fix that changes `add_deps("lzma")` to
+-- `add_deps("xz")` in their libarchive package def. Track at:
+--   https://github.com/xmake-io/xmake-repo/tree/dev/packages/l/libarchive
+
+package("libarchive-xlings")
+
+    set_base("libarchive")
+
+    -- Pin the same versions xmake-repo ships, so set_base inherits the
+    -- URL templates and we just need version → sha256 mappings.
+    add_versions("3.8.7", "4b787cca6697a95c7725e45293c973c208cbdc71ae2279f30ef09f52472b9166")
+    add_versions("3.8.6", "213269b05aac957c98f6e944774bb438d0bd168a2ec60b9e4f8d92035925821c")
+
+    -- Replace the upstream deps list. `xz` is xz-utils / liblzma
+    -- (provides lzma.h), the one libarchive's CMakeLists actually
+    -- probes via find_package(LibLZMA). The other four match what
+    -- libarchive expects already.
+    add_deps("cmake")
+    add_deps("zlib", "bzip2", "lz4", "zstd", "xz")
+
+    if is_plat("windows") then
+        add_syslinks("advapi32")
+    end
+
+    on_install("windows", "linux", "macosx", function (package)
+        local configs = {
+            -- Match xmake-repo's defaults...
+            "-DENABLE_TEST=OFF",
+            "-DENABLE_CAT=OFF",
+            "-DENABLE_TAR=OFF",
+            "-DENABLE_CPIO=OFF",
+            "-DENABLE_OPENSSL=OFF",
+            "-DENABLE_PCREPOSIX=OFF",
+            "-DENABLE_LibGCC=OFF",
+            "-DENABLE_CNG=OFF",
+            "-DENABLE_ICONV=OFF",
+            "-DENABLE_ACL=OFF",
+            "-DENABLE_EXPAT=OFF",
+            "-DENABLE_LIBXML2=OFF",
+            "-DENABLE_LIBB2=OFF",
+            -- ...and force-enable every compression backend we ship a
+            -- dep for. cmake's auto-detection silently disables a
+            -- backend if the find_package probe fails on the build
+            -- host (e.g. minimal CI image with no system xz-dev),
+            -- which is precisely what produced the original bug. Be
+            -- explicit so the build either uses the xrepo-built
+            -- backend or fails loudly.
+            "-DENABLE_ZLIB=ON",
+            "-DENABLE_BZip2=ON",
+            "-DENABLE_LZ4=ON",
+            "-DENABLE_ZSTD=ON",
+            "-DENABLE_LZMA=ON",
+        }
+        table.insert(configs, "-DCMAKE_BUILD_TYPE=" .. (package:debug() and "Debug" or "Release"))
+        table.insert(configs, "-DBUILD_SHARED_LIBS=" .. (package:config("shared") and "ON" or "OFF"))
+        if not package:config("shared") then
+            package:add("defines", "LIBARCHIVE_STATIC")
+        end
+        import("package.tools.cmake").install(package, configs)
+    end)
+
+    on_test(function (package)
+        assert(package:has_cfuncs("archive_version_number", {includes = "archive.h"}))
+    end)
+
+package_end()


### PR DESCRIPTION
## Summary

xmake-repo's `libarchive` package def lists `add_deps("zlib", "bzip2", "lz4", "zstd", "lzma")`. Four of those names match libarchive's cmake `find_package` probes — but xrepo's **`lzma` is the 7-Zip LZMA SDK** (`LzmaLib.h`, `LzmaCompress`), while libarchive's CMakeLists actually probes for **xz-utils' liblzma** (`lzma.h`, `lzma_code`). xrepo's package for that is **`xz`**.

Result on `main`: libarchive's cmake `find_package(LibLZMA)` silently fails → `HAVE_LZMA=0` → libarchive falls back to its `archive_read_support_filter_xz_external` path that **fork-exec's the system `xz` binary at runtime**. On musl-static minimal containers and Windows (no `xz` on PATH), `.tar.xz` / `.tar.lzma` extraction silently fails.

Concrete affected xpkgs in xim-pkgindex today: `node@*` (linux `.tar.xz`), `llvm` (macosx-arm64 `.tar.xz`).

## Fix

Project-private libarchive override in `xmake/packages/libarchive.lua`:

- `set_base("libarchive")` to inherit URL templates / version table
- Swap deps `lzma` → `xz`
- Force `-DENABLE_LZMA=ON` (+ all other backends) so cmake auto-detection can't silently disable any of them on a stripped builder image

Root `xmake.lua` `includes("xmake/packages/libarchive.lua")` so the override registers before `add_requires` resolves; targets switch from `add_packages("libarchive")` to `add_packages("libarchive-xlings")`.

## Verification

Before:
```
$ nm libarchive.a | grep "U lzma_"          # zero matches
$ strings libarchive.a | grep "Using external xz"
Using external xz program for xz decompression       # ← fork-exec fallback
```

After:
```
$ nm libarchive-xlings.a | grep "U lzma_"
U lzma_alone_decoder
U lzma_code
U lzma_crc32
U lzma_end
U lzma_properties_decode
$ strings libarchive-xlings.a | grep "Using external xz"   # zero matches
```

## Test plan

- [x] Local compile reaches link stage (92%); link blocked by pre-existing local env glibc/musl xrepo cache mismatch — CI handles real link
- [ ] CI 三平台跑通（依赖 PR 评审 + reviewer 触发）
- [ ] 后续：以 xpkgs 实际 .tar.xz install 跑 xim-x-node@22 + xim-x-llvm 来端到端验证

## Drop-the-override criterion

When xmake-repo merges a fix to its libarchive `add_deps("lzma")` → `add_deps("xz")` line, this whole `xmake/packages/libarchive.lua` file can be deleted and the root `xmake.lua` reverted to `add_requires("libarchive 3.8.7")` + `add_packages("libarchive")`.