### PR TITLE
release: 0.4.10 — Windows self-uninstall safety + build/runtime deps split + .tar.xz fix

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.9";
+    static constexpr std::string_view VERSION = "0.4.10";
     static constexpr std::string_view REPO = "https://github.com/d2learn/xlings";
 };
 


### PR DESCRIPTION
## Summary

Bumps `VERSION` from 0.4.9 to 0.4.10. Pure version-bump PR — all the actual fixes are already merged via #249 / #250 / #251.

### Highlights since 0.4.9

- **#250** — `xlings remove xim:xlings` no longer silently terminates on Windows when xlings has only one version installed. Three layered fixes: error_code overload at the throw sites, single-version self-removal guard with redirect to `self uninstall`, top-level catch in `cli::run`. Bonus: action-lambda rc threading via `wrap_rc` helper so every `cmd_*` exit code now propagates to the process exit code (was being squashed to 0 by cmdline lib's `std::function<void(...)>` action signature).
- **#249** — Schema-level split between `runtime_deps` and `build_deps` in xpkg packages. Build deps land in xpkgs but never activate in the user's workspace — the consumer's install hook reaches them via `pkginfo.build_dep("name")` or injected env. Legacy `deps = { ... }` array form preserved via loader fan-out. Carries libxpkg 0.0.32 forward.
- **#251** — `.tar.xz` / `.tar.lzma` extraction uses internal liblzma instead of fork-exec'ing the system `xz` binary at runtime. Project-private libarchive override at `xmake/packages/libarchive.lua` swaps the upstream `lzma` (7-Zip LZMA SDK) dep for `xz` (liblzma). Verified via `nm`. Affected xpkgs in xim-pkgindex: node@* linux, llvm macosx-arm64.

### Migration

0.4.9 → 0.4.10 is binary-compatible; self-replace path handles the upgrade. The new build_deps schema is opt-in (legacy array form keeps working).

### Test plan

- [x] All three constituent PRs (#249/#250/#251) had three-platform CI green before merge
- [ ] CI on this version-bump PR (Linux/macOS/Windows)
- [ ] After merge: trigger `Release` workflow via workflow_dispatch (input version=0.4.10) to produce artifacts

### Release flow reminder

`.github/workflows/release.yml` is `workflow_dispatch` only — manually triggered via GH Actions UI or `gh workflow run release.yml -f version=0.4.10` after this PR merges to main. **No tag push required**; the workflow tags + cuts the GitHub Release itself.