### PR TITLE
release: 0.4.11 — declarative exports schema + predicate-driven elfpatch

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.10";
+    static constexpr std::string_view VERSION = "0.4.11";
     static constexpr std::string_view REPO = "https://github.com/d2learn/xlings";
 };
 


### PR DESCRIPTION
## Summary

Bumps `VERSION` from 0.4.10 to 0.4.11. Pure version-bump PR — actual changes already merged via #253.

### Highlights since 0.4.10

- **#253** — Declarative `xpm.<platform>.exports` package metadata + predicate-driven elfpatch trigger. Providers (libc family) declare `loader`/`libdirs`/`abi`; xlings auto-patches consumer ELFs after install based on those declarations. Existing consumers keep working through the legacy `elfpatch.auto({...})` deprecation alias (drop target 2026-11). Bonus: build_dep RPATH pollution fixed (post-#249 latent bug), `e_machine` cross-arch protection, static-binary skip.
- libxpkg dep bumped to `mcpplibs-xpkg 0.0.33`.
- Design doc landed at `docs/plans/2026-05-02-elfpatch-exports-design.md`.

### Migration

0.4.10 → 0.4.11 is binary-compatible. New behavior (predicate-driven auto-patch) is **opt-in via package metadata** (`exports` field on provider, drop `elfpatch.auto` call from consumer hook). All existing xpkgs continue to work unchanged.

### What this unblocks

- `d2learn/xim-pkgindex#104` (glibc + binutils declarative migration pilot, currently DRAFT) can now bump its `BOOTSTRAP_XLINGS_VERSION` to v0.4.11 in CI workflows, come out of draft, and merge — actually exercising the new path end-to-end.

### Test plan

- [x] `#253` had 3-platform CI green before merge
- [ ] CI on this version-bump PR (Linux/macOS/Windows)
- [ ] After merge: trigger `Release` workflow via workflow_dispatch (input version=0.4.11) to produce artifacts
- [ ] Post-release: bump `xim-pkgindex` CI's `BOOTSTRAP_XLINGS_VERSION` → re-run #104 CI → should be green

### Release flow reminder

`.github/workflows/release.yml` is `workflow_dispatch` only. After merge, run `gh workflow run release.yml -f version=0.4.11` to produce + tag artifacts. **No tag push required**; the workflow tags + cuts the GitHub Release itself.