### PR TITLE
release: 0.4.12 — fix(elfpatch): self-patch opt-in + cross-platform polish

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.11";
+    static constexpr std::string_view VERSION = "0.4.12";
     static constexpr std::string_view REPO = "https://github.com/d2learn/xlings";
 };
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -42,7 +42,7 @@ add_requires("mcpplibs-capi-lua")
 if has_config("local_libxpkg") and get_config("local_libxpkg") ~= "" then
     includes(path.join(get_config("local_libxpkg"), "xmake.lua"))
 else
-    add_requires("mcpplibs-xpkg 0.0.33")
+    add_requires("mcpplibs-xpkg 0.0.34")
 end
 add_requires("gtest 1.15.2")
 add_requires("mcpplibs-tinyhttps 0.2.0")


### PR DESCRIPTION
## Summary

Hotfix for 0.4.11's predicate-driven elfpatch regression. Bumps `mcpplibs-xpkg` 0.0.33 → 0.0.34, version 0.4.11 → 0.4.12.

- **Bug A (P0)** — Rule 1 (self-patch) was unconditional. A loader-provider declaring \`exports.runtime.loader\` got auto-self-patched → rewrites \`libc.so.6\`'s \`.interp\` → falsifies offsets baked into glibc's static RO data → any consumer segfaults at execve+1 (SEGV_MAPERR @ 0x8). Now opt-in.
- **Bug B (P1)** — \`exec failed (code=1)\` log spam on every shared lib (patchelf rejects --set-interpreter on .so without PT_INTERP). Now classifies via \`_has_pt_interp()\` so libs only get RPATH, no INTERP attempt.
- **Cross-platform polish** — Windows early-bail in \`M._apply\`; macOS rpath-only auto-fire when deps declare \`libdirs\`; documented support matrix.

## Repro on 0.4.11 (before fix)

\`\`\`sh
$ xlings install openssl
$ openssl version
Segmentation fault (core dumped)   # SEGV_MAPERR @ 0x8 right after execve
\`\`\`

## After fix (0.4.12)

\`\`\`sh
$ xlings install openssl
$ openssl version
OpenSSL 3.1.5 30 Jan 2024 (Library: OpenSSL 3.1.5 30 Jan 2024)
\`\`\`

## Cross-platform behavior matrix

| Platform | Tool | INTERP | RPATH | Predicate auto-fire |
|---|---|---|---|---|
| Linux | patchelf | ✅ \`--set-interpreter\` | ✅ \`--set-rpath\` | When ≥1 runtime dep declares \`exports.runtime.loader\` |
| macOS | install_name_tool | — (no Mach-O analog) | ✅ \`-add_rpath\` | When ≥1 runtime dep declares \`exports.runtime.libdirs\` |
| Windows | — | — | — | Skipped at \`M._apply\` entry; PE has no analog |

## Migration

0.4.11 → 0.4.12 is binary-compatible. The in-place self-update path (xlings's own \`xself install\` / quick_install) handles the upgrade. Any payload installed under 0.4.11 that's known working stays as-is.

## Test plan

- [x] libxpkg unit tests (\`xpkg_executor_test\`) 22/22 pass locally — covers Linux + macOS + Windows code paths
- [x] E2E in isolated \`XLINGS_HOME\` with **0.4.12 binary + 0.0.34 libxpkg**:
  - \`xlings install openssl\` from scratch
  - glibc payload: untouched (libc.so.6 INTERP unchanged from tarball)
  - openssl bin: INTERP rewrites to xim-x-glibc loader; RUNPATH = correct closure
  - libssl.so.3: silent skip on \`--set-interpreter\`; RUNPATH set
  - \`openssl version\` → exits 0
- [ ] CI (uses pinned \`BOOTSTRAP_XLINGS_VERSION: v0.4.8\` — pre-regression — so should pass cleanly)

## Related

- libxpkg PR: https://github.com/openxlings/libxpkg/pull/11 (merged, tagged \`v0.0.34\`)
- mcpplibs-index: \`mcpplibs/mcpplibs-index@e46fd07\` registers v0.0.34
- After merge + 0.4.12 release: libxpkg PR #10 (auto-stamp) Linux CI should also unblock since quick_install will pull 0.4.12.