### PR TITLE
feat(deps): bump mcpplibs-xpkg 0.0.34 → 0.0.36 (auto-stamp framework)

### DIFF
--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -1211,6 +1211,24 @@ public:
                 continue;
             }
 
+            // Auto-stamp: drop a `.xim-installed` marker in install_dir if
+            // it's still empty after every install path (hook + extracted-
+            // payload fallback + script default). Wrapper packages
+            // (linux-headers, fromsource:* aliases) legitimately leave
+            // install_dir empty because their real payload lives in a
+            // separately-installed dep — without a stamp, xlings's
+            // installed-probe (`is_directory && !is_empty`) reports
+            // "not installed" and re-runs install + config on every
+            // dependent install. Critical: this MUST come after
+            // stage_extracted_payload_ above; otherwise a stamp written
+            // earlier would falsely make install_dir look "non-empty"
+            // and skip the extracted-payload fallback (which exists for
+            // packages whose hook silently no-ops, e.g. patchelf where
+            // the tarball has no top-level dir).
+            if (!payloadInstalled) {
+                executor.apply_install_stamp_if_empty(ctx);
+            }
+
             // Apply elfpatch auto-patching if the install hook enabled it
             if (!payloadInstalled) {
                 // Ensure binDir is in PATH so elfpatch can find patchelf

--- a/xmake.lua
+++ b/xmake.lua
@@ -42,7 +42,7 @@ add_requires("mcpplibs-capi-lua")
 if has_config("local_libxpkg") and get_config("local_libxpkg") ~= "" then
     includes(path.join(get_config("local_libxpkg"), "xmake.lua"))
 else
-    add_requires("mcpplibs-xpkg 0.0.34")
+    add_requires("mcpplibs-xpkg 0.0.35")
 end
 add_requires("gtest 1.15.2")
 add_requires("mcpplibs-tinyhttps 0.2.0")

--- a/xmake.lua
+++ b/xmake.lua
@@ -42,7 +42,7 @@ add_requires("mcpplibs-capi-lua")
 if has_config("local_libxpkg") and get_config("local_libxpkg") ~= "" then
     includes(path.join(get_config("local_libxpkg"), "xmake.lua"))
 else
-    add_requires("mcpplibs-xpkg 0.0.35")
+    add_requires("mcpplibs-xpkg 0.0.36")
 end
 add_requires("gtest 1.15.2")
 add_requires("mcpplibs-tinyhttps 0.2.0")


### PR DESCRIPTION
## Summary

Picks up libxpkg's auto-stamp executor framework. **No xlings version bump** — deferring 0.4.13 release until more in-flight work lands.

## What 0.0.35 adds

After install hook returns success and \`install_dir\` is non-empty, the executor writes a \`.xim-installed\` stamp file (INI key=value: schema/name/version/platform) into \`install_dir\` if the dir is empty.

## Why this matters

Thin delegator packages (e.g. \`linux-headers\` wrapping \`scode:linux-headers\`, \`fromsource:*\` aliases) have an empty \`install_dir\` because the actual payload lives in a separately-installed dep. xlings's "installed: yes/no" probe checks \`install_dir\` for content; without a stamp it reports "no" → every dependent install re-triggers the wrapper's install + config hooks unnecessarily.

## Test plan

- [x] Local build with 0.0.35: \`xmake build xlings\` ok in 20s
- [ ] CI: pinned BOOTSTRAP_XLINGS_VERSION 0.4.8 should pass cleanly

## Related

- libxpkg PR: https://github.com/openxlings/libxpkg/pull/10 (merged)
- libxpkg tag: v0.0.35
- mcpplibs-index: \`mcpplibs/mcpplibs-index@20e7543\`