### PR TITLE
release: 0.4.13 — fix(elfpatch): patchelf op order workaround

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
   # release is healthy.
   BOOTSTRAP_XLINGS_VERSION: v0.4.8
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 9cb6982e85b5b9fa1dd43a32eba94cbc4e32d52a
+  XIM_PKGINDEX_REF: 83044b5
 
 jobs:
   build-linux:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
   # release is healthy.
   BOOTSTRAP_XLINGS_VERSION: v0.4.8
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 83044b5
+  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
 
 jobs:
   build-linux:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ env:
   # macOS). Bump this in a dedicated PR after verifying the target
   # release is healthy.
   BOOTSTRAP_XLINGS_VERSION: v0.4.8
+  # See xlings-ci-linux.yml for why this is pinned.
+  XIM_PKGINDEX_REF: 9cb6982e85b5b9fa1dd43a32eba94cbc4e32d52a
 
 jobs:
   build-linux:

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -15,6 +15,12 @@ env:
   # build dependencies. Bump this in a dedicated PR after verifying the
   # target release is healthy.
   BOOTSTRAP_XLINGS_VERSION: v0.4.8
+  # Pinned xim-pkgindex commit for the test fixture clone. Pinning here
+  # decouples xlings CI from in-flight xim-pkgindex churn — bare-name
+  # deps + new runtime-dep declarations on prebuilts (post #107) cascade
+  # into E2E-05's dual-mount scenario. Bump after xim-pkgindex deps
+  # stabilize (namespace prefixes universal + lib-closure verified).
+  XIM_PKGINDEX_REF: 9cb6982e85b5b9fa1dd43a32eba94cbc4e32d52a
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -20,7 +20,7 @@ env:
   # deps + new runtime-dep declarations on prebuilts (post #107) cascade
   # into E2E-05's dual-mount scenario. Bump after xim-pkgindex deps
   # stabilize (namespace prefixes universal + lib-closure verified).
-  XIM_PKGINDEX_REF: 83044b5
+  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -20,7 +20,7 @@ env:
   # deps + new runtime-dep declarations on prebuilts (post #107) cascade
   # into E2E-05's dual-mount scenario. Bump after xim-pkgindex deps
   # stabilize (namespace prefixes universal + lib-closure verified).
-  XIM_PKGINDEX_REF: 9cb6982e85b5b9fa1dd43a32eba94cbc4e32d52a
+  XIM_PKGINDEX_REF: 83044b5
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -17,7 +17,7 @@ env:
   # after verifying the target release is healthy.
   BOOTSTRAP_XLINGS_VERSION: v0.4.8
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 9cb6982e85b5b9fa1dd43a32eba94cbc4e32d52a
+  XIM_PKGINDEX_REF: 83044b5
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -17,7 +17,7 @@ env:
   # after verifying the target release is healthy.
   BOOTSTRAP_XLINGS_VERSION: v0.4.8
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 83044b5
+  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -16,6 +16,8 @@ env:
   # cmake, ninja, and the macOS LLVM toolchain. Bump in a dedicated PR
   # after verifying the target release is healthy.
   BOOTSTRAP_XLINGS_VERSION: v0.4.8
+  # See xlings-ci-linux.yml for why this is pinned.
+  XIM_PKGINDEX_REF: 9cb6982e85b5b9fa1dd43a32eba94cbc4e32d52a
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -15,6 +15,8 @@ env:
   # / cmake / ninja. Windows uses MSVC from the runner image (no compiler
   # in .xlings.json), so xmake's auto-detection still applies.
   BOOTSTRAP_XLINGS_VERSION: v0.4.8
+  # See xlings-ci-linux.yml for why this is pinned.
+  XIM_PKGINDEX_REF: 9cb6982e85b5b9fa1dd43a32eba94cbc4e32d52a
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -16,7 +16,7 @@ env:
   # in .xlings.json), so xmake's auto-detection still applies.
   BOOTSTRAP_XLINGS_VERSION: v0.4.8
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 83044b5
+  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -16,7 +16,7 @@ env:
   # in .xlings.json), so xmake's auto-detection still applies.
   BOOTSTRAP_XLINGS_VERSION: v0.4.8
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 9cb6982e85b5b9fa1dd43a32eba94cbc4e32d52a
+  XIM_PKGINDEX_REF: 83044b5
 
 jobs:
   build-and-test:

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.12";
+    static constexpr std::string_view VERSION = "0.4.13";
     static constexpr std::string_view REPO = "https://github.com/d2learn/xlings";
 };
 

--- a/tests/e2e/prepare_fixture_index.sh
+++ b/tests/e2e/prepare_fixture_index.sh
@@ -15,7 +15,15 @@ rm -rf "$FIXTURE_INDEX_DIR"
 mkdir -p "$(dirname "$FIXTURE_INDEX_DIR")"
 
 echo "[fixture] cloning $XIM_PKGINDEX_URL (ref: $XIM_PKGINDEX_REF) -> $FIXTURE_INDEX_DIR"
-git clone --depth 1 --branch "$XIM_PKGINDEX_REF" "$XIM_PKGINDEX_URL" "$FIXTURE_INDEX_DIR"
+
+# git clone --branch accepts branches/tags but not commit SHAs. Detect a
+# 40-char hex SHA and use the deeper clone-then-checkout path instead.
+if [[ "$XIM_PKGINDEX_REF" =~ ^[0-9a-f]{40}$ ]]; then
+  git clone "$XIM_PKGINDEX_URL" "$FIXTURE_INDEX_DIR"
+  git -C "$FIXTURE_INDEX_DIR" checkout --quiet "$XIM_PKGINDEX_REF"
+else
+  git clone --depth 1 --branch "$XIM_PKGINDEX_REF" "$XIM_PKGINDEX_URL" "$FIXTURE_INDEX_DIR"
+fi
 
 if [[ ! -d "$FIXTURE_INDEX_DIR/pkgs" ]]; then
   echo "[fixture] FAIL: missing pkgs directory after clone: $FIXTURE_INDEX_DIR" >&2

--- a/xmake.lua
+++ b/xmake.lua
@@ -42,7 +42,7 @@ add_requires("mcpplibs-capi-lua")
 if has_config("local_libxpkg") and get_config("local_libxpkg") ~= "" then
     includes(path.join(get_config("local_libxpkg"), "xmake.lua"))
 else
-    add_requires("mcpplibs-xpkg 0.0.36")
+    add_requires("mcpplibs-xpkg 0.0.37")
 end
 add_requires("gtest 1.15.2")
 add_requires("mcpplibs-tinyhttps 0.2.0")


### PR DESCRIPTION
## Summary

Hotfix for a patchelf 0.18.0 corruption bug that just went production-wide after [xim-pkgindex#108](https://github.com/d2learn/xim-pkgindex/pull/108) declared \`runtime = { glibc, gcc }\` deps on cmake / mdbook / ninja / node / xmake. The predicate-driven elfpatch then fires on these binaries; for compact ELFs (~≤ 280 KB, e.g. ninja 1.12.1 at 273 KB) patchelf 0.18.0 has an order-sensitive corruption bug.

\`mcpplibs-xpkg v0.0.37\` reverses the op order so \`--set-rpath\` runs before \`--set-interpreter\`. This PR bumps to 0.0.37 + version 0.4.13.

## Repro on 0.4.12 (current state of \`main\`)

\`\`\`sh
$ xlings install ninja
$ ninja --version
Segmentation fault (core dumped)   # SEGV @ 0x8 right after execve
\`\`\`

\`\`\`sh
# OR via cmake driving small subprocesses:
$ ... → cmake failed(-1)   # child killed by signal
\`\`\`

**Evidence**: libxpkg \`main\` CI was green at 18:23 UTC, then went red after I rerun it at 21:00 UTC — without any libxpkg code change. Only xim-pkgindex#108 changed in between. Same chicken-and-egg as 0.4.12 hotfix.

## After fix (verified locally)

\`\`\`
elfpatch._apply: source=predicate:single
ninja: elfpatch auto: 1 1 0
$ ninja --version
1.12.1                                                ← exit 0

INTERP=…/xim-x-glibc/2.39/lib64/ld-linux-x86-64.so.2  ← rewrites correctly
RUNPATH=…/glibc/lib64:…/gcc/lib64:…/subos/default/lib ← closure correct
\`\`\`

## Migration / known limitation

0.4.12 → 0.4.13 is binary-compatible (in-place self-update via \`xlings self install\` / quick_install).

**Already-broken payloads** (e.g. ninja installed under 0.4.12 after #108 deps were declared) need a manual \`xlings uninstall <pkg> && xlings install <pkg>\` cycle — the new \`apply_elfpatch_auto\` won't rerun on a "non-empty install_dir" (intentional, see installer.cppm \`payloadInstalled\` gate). For automatic re-patch, a future \`xlings doctor --fix-elfpatch\` could detect + heal corrupted payloads.

## Test plan

- [x] libxpkg unit tests 27/27 pass (post-fix, new \`ApplyElfpatchAuto_LinuxRpathBeforeInterpreter\` regression test)
- [x] E2E in isolated \`XLINGS_HOME\`: \`xlings install ninja\` from scratch with v0.4.13 binary + v0.0.37 libxpkg
  - elfpatch \`source=predicate:single\` triggers
  - ninja file size 273 KB → 290 KB (patched correctly)
  - INTERP rewrites to xim-x-glibc loader
  - RUNPATH = correct closure
  - \`ninja --version\` exits 0
- [ ] CI: pinned BOOTSTRAP_XLINGS_VERSION 0.4.8 should pass cleanly (same as PR #255)

## Related

- libxpkg PR: https://github.com/openxlings/libxpkg/pull/13 (merged, v0.0.37)
- Analysis: \`docs/plans/2026-05-03-patchelf-order-bug-analysis.md\` in libxpkg repo
- mcpplibs-index: \`mcpplibs/mcpplibs-index@bc4f740\` registers v0.0.37