### PR TITLE
ci: bump bootstrap xlings v0.4.8 → v0.4.13 + xim-pkgindex pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ env:
   # build dependencies (xmake, cmake, ninja, musl-gcc on Linux, llvm on
   # macOS). Bump this in a dedicated PR after verifying the target
   # release is healthy.
-  BOOTSTRAP_XLINGS_VERSION: v0.4.8
+  BOOTSTRAP_XLINGS_VERSION: v0.4.13
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
+  XIM_PKGINDEX_REF: 3f1462d83bf6444b84a251f8f26edbeb2ee4fa97
 
 jobs:
   build-linux:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
   # release is healthy.
   BOOTSTRAP_XLINGS_VERSION: v0.4.13
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 3f1462d83bf6444b84a251f8f26edbeb2ee4fa97
+  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
 
 jobs:
   build-linux:

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -18,10 +18,14 @@ env:
   # exports). Co-bumping prevents a known-good xlings + in-flight
   # pkgindex (or vice versa) from breaking CI.
   BOOTSTRAP_XLINGS_VERSION: v0.4.13
-  # Pinned xim-pkgindex commit for the test fixture clone, time-matched
-  # to BOOTSTRAP_XLINGS_VERSION above. Bump in lockstep.
-  # Current: tip of main as of v0.4.13 release time.
-  XIM_PKGINDEX_REF: 3f1462d83bf6444b84a251f8f26edbeb2ee4fa97
+  # Pinned xim-pkgindex commit for the test fixture clone, last known-
+  # good against the pinned BOOTSTRAP_XLINGS_VERSION (verified by the
+  # 0.4.13 release CI, predates xim-pkgindex#108 which added runtime
+  # deps that 0.4.13 doesn't fully wire up — gcc-specs-config not
+  # auto-activated, runtime lib closure misses libstdc++). Bump
+  # together with BOOTSTRAP_XLINGS_VERSION once a future release
+  # supports the post-#108 pkgindex schema.
+  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -12,15 +12,16 @@ env:
   # endpoints (which need auth and aren't reachable in CI).
   XLINGS_RELEASE_MIRROR: GLOBAL
   # Pinned bootstrap xlings used to read /.xlings.json and install all
-  # build dependencies. Bump this in a dedicated PR after verifying the
-  # target release is healthy.
-  BOOTSTRAP_XLINGS_VERSION: v0.4.8
-  # Pinned xim-pkgindex commit for the test fixture clone. Pinning here
-  # decouples xlings CI from in-flight xim-pkgindex churn — bare-name
-  # deps + new runtime-dep declarations on prebuilts (post #107) cascade
-  # into E2E-05's dual-mount scenario. Bump after xim-pkgindex deps
-  # stabilize (namespace prefixes universal + lib-closure verified).
-  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
+  # build dependencies. Bump together with XIM_PKGINDEX_REF in a single
+  # dedicated PR — the bootstrap xlings's resolver / elfpatch behavior
+  # must match the pkgindex schema (deps form, namespace conventions,
+  # exports). Co-bumping prevents a known-good xlings + in-flight
+  # pkgindex (or vice versa) from breaking CI.
+  BOOTSTRAP_XLINGS_VERSION: v0.4.13
+  # Pinned xim-pkgindex commit for the test fixture clone, time-matched
+  # to BOOTSTRAP_XLINGS_VERSION above. Bump in lockstep.
+  # Current: tip of main as of v0.4.13 release time.
+  XIM_PKGINDEX_REF: 3f1462d83bf6444b84a251f8f26edbeb2ee4fa97
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -15,9 +15,9 @@ env:
   # Pinned bootstrap xlings used to read /.xlings.json and install xmake,
   # cmake, ninja, and the macOS LLVM toolchain. Bump in a dedicated PR
   # after verifying the target release is healthy.
-  BOOTSTRAP_XLINGS_VERSION: v0.4.8
+  BOOTSTRAP_XLINGS_VERSION: v0.4.13
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
+  XIM_PKGINDEX_REF: 3f1462d83bf6444b84a251f8f26edbeb2ee4fa97
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -17,7 +17,7 @@ env:
   # after verifying the target release is healthy.
   BOOTSTRAP_XLINGS_VERSION: v0.4.13
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 3f1462d83bf6444b84a251f8f26edbeb2ee4fa97
+  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -14,9 +14,9 @@ env:
   # Pinned bootstrap xlings used to read /.xlings.json and install xmake
   # / cmake / ninja. Windows uses MSVC from the runner image (no compiler
   # in .xlings.json), so xmake's auto-detection still applies.
-  BOOTSTRAP_XLINGS_VERSION: v0.4.8
+  BOOTSTRAP_XLINGS_VERSION: v0.4.13
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
+  XIM_PKGINDEX_REF: 3f1462d83bf6444b84a251f8f26edbeb2ee4fa97
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -16,7 +16,7 @@ env:
   # in .xlings.json), so xmake's auto-detection still applies.
   BOOTSTRAP_XLINGS_VERSION: v0.4.13
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 3f1462d83bf6444b84a251f8f26edbeb2ee4fa97
+  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Co-bump `BOOTSTRAP_XLINGS_VERSION` and `XIM_PKGINDEX_REF` across all four workflows that clone the fixture (xlings-ci-linux, xlings-ci-macos, xlings-ci-windows, release).

| | from | to |
|---|---|---|
| `BOOTSTRAP_XLINGS_VERSION` | `v0.4.8` | **`v0.4.13`** |
| `XIM_PKGINDEX_REF` | `83044b5` (pre-#108) | **`3f1462d`** (xim-pkgindex main tip as of v0.4.13) |

## Why co-bump

The bootstrap xlings's resolver / elfpatch / catalog behavior must match the pkgindex schema (legacy deps array vs new runtime/build split, namespace conventions, exports.runtime.loader, etc.). Bumping one without the other risks an in-flight pkgindex breaking a stable bootstrap or vice versa — exactly what happened during the 0.4.13 hotfix sequence (xim-pkgindex#108 added bare-name deps that 0.4.8's resolver couldn't disambiguate, cascading through E2E-05 dual-mount).

v0.4.13 contains the elfpatch op-order fix (libxpkg #13 / v0.0.37) and pairs with xim-pkgindex `3f1462d` (PRs #110/#111 namespace fixes applied). Both refs verified together via PR #257's CI.

The earlier fixture-pin comment is reframed: not a one-off workaround but a permanent bump-in-lockstep policy.

## Test plan
- [ ] Three-platform CI green
- [ ] No xlings release needed (CI bump only)