### PR TITLE
fix(config): fall through to XLINGS_PROJECT_DIR env after projectScope:false skip

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -558,6 +558,23 @@ private:
 
         auto homeNorm = fs::weakly_canonical(paths_.homeDir, ec);
 
+        // Walk cwd → root, looking for a `.xlings.json` that activates project
+        // mode. A file with `projectScope: false` is "deps-manifest only" — it
+        // declares deps for `xlings install` but does NOT mean its directory is
+        // a project root (e.g. xlings's own repo uses this to install build
+        // deps without making the repo look like a user project to nested
+        // commands). load_project_config_from_dir_ honors that opt-out by
+        // returning without setting hasProjectConfig_.
+        //
+        // Critical: when from_dir_ skips a projectScope:false file, we must
+        // NOT early-return — that would hide the real project from any
+        // subprocess whose cwd traversal happens to hit such a file before
+        // reaching the actual project. Instead, continue walking up; if no
+        // real project is found in the rest of the walk, the env-var fallback
+        // below picks it up (the parent xlings exports XLINGS_PROJECT_DIR
+        // whenever it loads a real project, so subprocesses can recover the
+        // intended project context even when their cwd is outside the project
+        // tree).
         fs::path cur = startDir;
         while (!cur.empty()) {
             auto cfg = cur / ".xlings.json";
@@ -565,7 +582,8 @@ private:
                 auto curNorm = fs::weakly_canonical(cur, ec);
                 if (curNorm != homeNorm) {
                     load_project_config_from_dir_(cur);
-                    return;
+                    if (hasProjectConfig_) return;     // real project loaded
+                    // else: projectScope:false skip — keep walking, then env fallback
                 }
             }
             auto parent = cur.parent_path();
@@ -573,7 +591,9 @@ private:
             cur = parent;
         }
 
-        // CWD traversal did not find project config — check XLINGS_PROJECT_DIR env var
+        // CWD traversal did not find project config (either no .xlings.json
+        // at all, or only projectScope:false ones) — check XLINGS_PROJECT_DIR
+        // env var as a last resort.
         if (!hasProjectConfig_) {
             auto env_project = utils::get_env_or_default("XLINGS_PROJECT_DIR");
             if (!env_project.empty()) {


### PR DESCRIPTION
## Bug

A subprocess xlings (e.g. an xvm shim invoked from another package's install/config hook) whose cwd traversal happens to hit a `projectScope:false` `.xlings.json` BEFORE reaching the real project root erroneously falls back to `globalWorkspace_`, ignoring the project-scope versions the parent xlings just wrote.

Concrete instance — xim-pkgindex#109's gcc-specs-config flow on CI's E2E-05:

1. Test scenario at `tests/e2e/scenarios/project_home/` declares a project (real `.xlings.json`)
2. Parent xlings loads it, exports `XLINGS_PROJECT_DIR`
3. Installs `xim:gcc-specs-config` (script type) → `script::default_config` writes `gcc-specs-config = 0.0.1` to project-subos workspace, creates shim
4. Installs `xim:gcc` → gcc's `config` hook spawns the shim via `os.exec("$bindir/gcc-specs-config ...")`
5. **Subprocess shim**: cwd inherited from gcc install_dir (`<XLINGS_HOME>/data/xpkgs/xim-x-gcc/15.1.0/`, OUTSIDE the project tree)
6. `load_project_config_` walks cwd up — eventually hits xlings repo's own `/home/runner/work/xlings/xlings/.xlings.json` (projectScope:false, intentional opt-out for CI self-host)
7. `load_project_config_from_dir_` skips it (correct) — but caller's unconditional `return` here exits without checking the env-var fallback
8. `hasProjectConfig_ = false` → `effective_workspace() = globalWorkspace_` → no `gcc-specs-config` key → "no version set"

## Root cause

`config.cppm:load_project_config_` lost the distinction between two outcomes of `load_project_config_from_dir_`:

| outcome | hasProjectConfig_ | should walker do |
|---|---|---|
| real project loaded | true | return — done |
| projectScope:false skipped | false | **continue walking + env fallback** |

Pre-fix, both paths shared the same `return;`.

## Fix

3-line change in `load_project_config_`:

```diff
-                load_project_config_from_dir_(cur);
-                return;
+                load_project_config_from_dir_(cur);
+                if (hasProjectConfig_) return;
+                // else: projectScope:false skip — continue walking
```

Now the env-var fallback below the loop fires in three cases (vs only one before):
- (a) no `.xlings.json` found at all
- (b) only projectScope:false files found going up
- (c) projectScope:false skip then no further `.xlings.json` upward

Bonus: nested layout where a deeper `.xlings.json` has projectScope:false but an outer ancestor is a real project now resolves the outer correctly (was previously masked).

## Verification

Local repro of the CI failure (matching layout: XLINGS_HOME outside a test project, with a projectScope:false `.xlings.json` on the shared ancestor path) reproduces the `no version set` failure on the **v0.4.13 release binary** (current main):

```
config: invoking mytool at /tmp/.../PROJ/.xlings/subos/_/bin/mytool
[error] xlings: no version set for 'mytool'
[error]   hint: xlings use mytool <version>
config: mytool exit=nil
```

After this patch, the env-var fallback path resolves the project workspace correctly.

## Scope of impact

Affects any user where:
- A subprocess xlings (xvm shim spawned from a hook) runs with cwd outside the project tree
- AND cwd traversal happens to find a `projectScope:false` `.xlings.json` on an ancestor path before reaching the real project root

Production-relevant trigger: the recently-added `xim:gcc-specs-config` runtime dep on `xim:gcc` (xim-pkgindex#109) means any user installing gcc from a project would hit this if their layout has a projectScope:false ancestor (e.g. xlings-the-project users who have nested workdirs).

## Test plan

- [x] Local repro (CI-shaped layout) reproduces failure on unpatched 0.4.13
- [ ] CI three-platform (Linux/macOS/Windows) green
- Note: this PR does NOT bump `XIM_PKGINDEX_REF` — the current pin (83044b5, pre-#108) avoids the gcc-specs-config scenario, so CI doesn't end-to-end exercise this fix. A follow-up PR can bump the pin once xim-pkgindex's libstdc++ closure issue is also resolved.