### PR TITLE
ci: bump XIM_PKGINDEX_REF to gcc-runtime fix (E2E verify config + pkgindex chain)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
   # release is healthy.
   BOOTSTRAP_XLINGS_VERSION: v0.4.13
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
+  XIM_PKGINDEX_REF: 19f4383ba5d65ab86cc6904f6392ceecb0be5d09
 
 jobs:
   build-linux:

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -18,14 +18,19 @@ env:
   # exports). Co-bumping prevents a known-good xlings + in-flight
   # pkgindex (or vice versa) from breaking CI.
   BOOTSTRAP_XLINGS_VERSION: v0.4.13
-  # Pinned xim-pkgindex commit for the test fixture clone, last known-
-  # good against the pinned BOOTSTRAP_XLINGS_VERSION (verified by the
-  # 0.4.13 release CI, predates xim-pkgindex#108 which added runtime
-  # deps that 0.4.13 doesn't fully wire up — gcc-specs-config not
-  # auto-activated, runtime lib closure misses libstdc++). Bump
-  # together with BOOTSTRAP_XLINGS_VERSION once a future release
-  # supports the post-#108 pkgindex schema.
-  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
+  # Pinned xim-pkgindex commit for the test fixture clone. Bump in
+  # lockstep with BOOTSTRAP_XLINGS_VERSION when both sides have shipped
+  # the schema features they need from each other:
+  #   - bootstrap xlings v0.4.13 + post-merge config.cppm fix (PR #259)
+  #     handles projectScope:false fall-through correctly, so subprocess
+  #     shims spawned from install hooks (e.g. gcc-specs-config) resolve
+  #     project workspace via XLINGS_PROJECT_DIR env fallback
+  #   - xim-pkgindex 19f4383 = main HEAD with #110/#111 (namespace
+  #     deps), #116 (gcc-runtime as standalone xpkg), #117 (ninja/node/
+  #     mdbook switched to xim:gcc-runtime), #118 (use libdirs not abi
+  #     for lib export). End-to-end exercises the full predicate-driven
+  #     elfpatch + script-as-runtime-dep flow on Linux E2E-05.
+  XIM_PKGINDEX_REF: 19f4383ba5d65ab86cc6904f6392ceecb0be5d09
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -17,7 +17,7 @@ env:
   # after verifying the target release is healthy.
   BOOTSTRAP_XLINGS_VERSION: v0.4.13
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
+  XIM_PKGINDEX_REF: 19f4383ba5d65ab86cc6904f6392ceecb0be5d09
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -16,7 +16,7 @@ env:
   # in .xlings.json), so xmake's auto-detection still applies.
   BOOTSTRAP_XLINGS_VERSION: v0.4.13
   # See xlings-ci-linux.yml for why this is pinned.
-  XIM_PKGINDEX_REF: 83044b5488b739139ea66214e22870e087eec4d8
+  XIM_PKGINDEX_REF: 19f4383ba5d65ab86cc6904f6392ceecb0be5d09
 
 jobs:
   build-and-test:


### PR DESCRIPTION
End-to-end CI verification. Bumps the pinned xim-pkgindex commit so the test fixture exercises the full predicate-driven elfpatch + script-as-runtime-dep flow.

## Pin diff

| | from | to |
|---|---|---|
| `XIM_PKGINDEX_REF` | `83044b5` (pre-#108) | **`19f4383`** (current main) |
| `BOOTSTRAP_XLINGS_VERSION` | `v0.4.13` | (unchanged) |

## What `19f4383` brings vs the previous pin

| xim-pkgindex PR | content |
|---|---|
| #110 / #111 | namespace all bare-name deps → no dual-mount ambiguity |
| #116 | new `xim:gcc-runtime` standalone xpkg (~25 MB libstdc++/libgcc_s/...) |
| #117 | switch ninja/node/mdbook from xim:gcc to xim:gcc-runtime |
| **#118** | gcc-runtime declares correct `exports.runtime.libdirs` (was `abi`) |

## What pairs with this on the xlings side

- `v0.4.13` (already shipped): patchelf op order fix
- **PR #259 (just merged into main)**: `load_project_config_` falls through to `XLINGS_PROJECT_DIR` env after a `projectScope:false` skip — fixes "no version set for gcc-specs-config" when gcc.config hook spawns the script-type shim from a cwd outside the project tree

## What this verifies end-to-end

E2E-05 (Fixed Project Scenarios) was previously skipped past gcc-specs-config because the old pin predated #108. Now it should:
1. install `xim:gcc` (which depends on `xim:gcc-specs-config` script-type runtime dep)
2. gcc.config hook invokes `gcc-specs-config` shim from gcc install_dir cwd (outside project)
3. shim subprocess walks up cwd → hits xlings repo's `projectScope:false` `.xlings.json`
4. **with #259 fix**: skip continues walking + env fallback finds project workspace → resolves gcc-specs-config version → shim succeeds → gcc.config completes
5. install `xim:node` or similar (declares xim:gcc-runtime runtime dep)
6. **with #117/#118**: predicate-driven elfpatch closure picks up gcc-runtime/lib64 → node binary RPATH includes libstdc++ location → node runs

If CI green → both fixes compose correctly, lockstep-pin policy works.
If red → expose whatever's still missing (e.g. another schema gap).