### PR TITLE
release: 0.4.14 — self uninstall + projectScope fall-through fix

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.13";
+    static constexpr std::string_view VERSION = "0.4.14";
     static constexpr std::string_view REPO = "https://github.com/d2learn/xlings";
 };
 


### PR DESCRIPTION
Bumps `VERSION` 0.4.13 → 0.4.14. Highlights since 0.4.13:

| PR | Change |
|---|---|
| #259 | `load_project_config_` falls through to XLINGS_PROJECT_DIR env after projectScope:false skip — fixes "no version set for gcc-specs-config" in subprocess shims |
| #260 | CI: bump XIM_PKGINDEX_REF to xim-pkgindex main HEAD (incl. #110/#111 namespace, #116 gcc-runtime split, #117 ninja/node/mdbook → gcc-runtime, #118 libdirs schema fix) |
| **#261** | `xlings self uninstall` real implementation (-y / --keep-data / --dry-run) + cross-platform self-deletion + safety invariants + bonus: unknown-action exit 2 |

## Migration

0.4.13 → 0.4.14 is binary-compatible. `xlings self install` / quick_install handles the upgrade.

## Test plan
- [x] All component PRs CI green individually
- [x] Local isolated-env E2E for self uninstall (8/8 pass)
- [ ] Three-platform CI green
- After merge: trigger Release workflow