### PR TITLE
fix(install): quiet per-package "already installed" lines

### DIFF
--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -252,8 +252,14 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
     auto pending = plan.pending_count();
     auto allAlreadyInstalled = (pending == 0);
     if (allAlreadyInstalled) {
+        // Per-package "already installed" lines fire on every re-invocation
+        // of `xlings install <pkg>` against an already-active workspace —
+        // they're noise for the common case of re-running install
+        // commands as a no-op refresh. Demoted to debug; the install
+        // summary at the end of the run still gives the user feedback
+        // when something actually happened.
         for (auto& m : requestedMatches) {
-            log::println("{}@{} is already installed", m.canonicalName, m.version);
+            log::debug("{}@{} is already installed", m.canonicalName, m.version);
         }
     }
 


### PR DESCRIPTION
## Summary

The fast path in `cmd_install` for the all-already-installed case prints one `{}@{} is already installed` line per requested package via `log::println`. This is noise for re-runs of `xlings install <pkg>` against an already-active workspace — a common idempotency path (IDE plugins, scripts, agent loops, CI re-runs).

This PR demotes the per-package message to `log::debug`. The install summary at the end of the command already gives feedback for actual work; an empty no-op run no longer prints filler.

## Reproduction (before)

```
$ xlings install codex@0.125.0    # already installed
xim:codex@0.125.0 is already installed
[xim:xpkg]: 1 - config glibc tool...           # ← noise from xim-pkgindex (fixed in xim-pkgindex#125)
[xim:xpkg]: 2 - config glibc libs...
...
```

## After (this PR + xim-pkgindex#125)

```
$ xlings install codex@0.125.0
$
```

## Test plan

- [ ] CI green