### PR TITLE
[codex] update canonical openxlings references

### DIFF
--- a/.agents/skills/xlings-build/SKILL.md
+++ b/.agents/skills/xlings-build/SKILL.md
@@ -36,7 +36,7 @@ Use this path when building the static Linux binary with `musl-gcc@15.1.0`.
 ### 1) Install xlings
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/refs/heads/main/tools/other/quick_install.sh | bash
 source ~/.bashrc
 ```
 
@@ -109,7 +109,7 @@ The checked-in CI uses Homebrew `llvm@20` plus `xmake`. If the user insists on a
 ### 1) Install xlings
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/refs/heads/main/tools/other/quick_install.sh | bash
 source ~/.bashrc
 ```
 

--- a/.agents/skills/xlings-build/references/links.md
+++ b/.agents/skills/xlings-build/references/links.md
@@ -2,10 +2,10 @@
 
 ## Project
 
-- Repository: https://github.com/d2learn/xlings
+- Repository: https://github.com/openxlings/xlings
 - Website: https://xlings.d2learn.org
-- Quick install script (Linux/macOS): https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.sh
-- Quick install script (Windows): https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.ps1
+- Quick install script (Linux/macOS): https://raw.githubusercontent.com/openxlings/xlings/refs/heads/main/tools/other/quick_install.sh
+- Quick install script (Windows): https://raw.githubusercontent.com/openxlings/xlings/refs/heads/main/tools/other/quick_install.ps1
 
 ## CI Workflows
 

--- a/.agents/skills/xlings-build/references/platforms.md
+++ b/.agents/skills/xlings-build/references/platforms.md
@@ -5,7 +5,7 @@
 Install and configure:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/refs/heads/main/tools/other/quick_install.sh | bash
 source ~/.bashrc
 xlings install musl-gcc@15.1.0 -y
 xlings info musl-gcc

--- a/.agents/skills/xlings-quickstart/SKILL.md
+++ b/.agents/skills/xlings-quickstart/SKILL.md
@@ -21,13 +21,13 @@ Use this skill to handle the full operational lifecycle of xlings:
 Linux/macOS:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/refs/heads/main/tools/other/quick_install.sh | bash
 ```
 
 Windows PowerShell:
 
 ```powershell
-irm https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.ps1 | iex
+irm https://raw.githubusercontent.com/openxlings/xlings/refs/heads/main/tools/other/quick_install.ps1 | iex
 ```
 
 ### 2) Verify installation

--- a/.agents/skills/xlings-quickstart/references/commands.md
+++ b/.agents/skills/xlings-quickstart/references/commands.md
@@ -3,7 +3,7 @@
 ## Install and Verify
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/refs/heads/main/tools/other/quick_install.sh | bash
 xlings help
 xim -h
 ```

--- a/.agents/skills/xlings-quickstart/references/links.md
+++ b/.agents/skills/xlings-quickstart/references/links.md
@@ -2,20 +2,20 @@
 
 ## Project and Official Sites
 
-- Project repository: https://github.com/d2learn/xlings
+- Project repository: https://github.com/openxlings/xlings
 - Official website: https://xlings.d2learn.org
 - Quick start (EN): https://xlings.d2learn.org/en/documents/quick-start/one-click-install.html
 - Quick start (ZH): https://xlings.d2learn.org/documents/quick-start/one-click-install.html
 
 ## Package Index and XPackage
 
-- Public package index portal: https://d2learn.github.io/xim-pkgindex
-- Package index source repository: https://github.com/d2learn/xim-pkgindex
-- Add XPackage doc: https://github.com/d2learn/xim-pkgindex/blob/main/docs/add-xpackage.md
+- Public package index portal: https://openxlings.github.io/xim-pkgindex
+- Package index source repository: https://github.com/openxlings/xim-pkgindex
+- Add XPackage doc: https://github.com/openxlings/xim-pkgindex/blob/main/docs/add-xpackage.md
 - XPackage intro: https://xlings.d2learn.org/en/documents/xpkg/intro.html
 
 ## Community and Contribution
 
 - Forum: https://forum.d2learn.org/category/9/xlings
-- Issues: https://github.com/d2learn/xlings/issues
+- Issues: https://github.com/openxlings/xlings/issues
 - Contributing (add xpkg): https://xlings.d2learn.org/en/documents/community/contribute/add-xpkg.html

--- a/.github/workflows/gitee-sync.yml
+++ b/.github/workflows/gitee-sync.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Mirror the Github organization repos to Gitee.
         uses: Yikun/hub-mirror-action@master
         with:
-          src: 'github/d2learn'
+          src: 'github/openxlings'
           dst: 'gitee/Sunrisepeak'
           dst_key: ${{ secrets.GITEE_SSH_KEY }}
           dst_token:  ${{ secrets.GITEE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           XLINGS_NON_INTERACTIVE: 1
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings"           >> "$GITHUB_ENV"
           echo "$HOME/.xlings/subos/current/bin"     >> "$GITHUB_PATH"
           echo "$HOME/.xlings/bin"                   >> "$GITHUB_PATH"
@@ -97,7 +97,7 @@ jobs:
           XLINGS_NON_INTERACTIVE: 1
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings"           >> "$GITHUB_ENV"
           echo "$HOME/.xlings/subos/current/bin"     >> "$GITHUB_PATH"
           echo "$HOME/.xlings/bin"                   >> "$GITHUB_PATH"
@@ -145,7 +145,7 @@ jobs:
           XLINGS_NON_INTERACTIVE: '1'
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          irm https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.ps1 | iex
+          irm https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1 | iex
           "XLINGS_HOME=$env:USERPROFILE\.xlings"            >> $env:GITHUB_ENV
           "$env:USERPROFILE\.xlings\subos\current\bin"      >> $env:GITHUB_PATH
           "$env:USERPROFILE\.xlings\bin"                    >> $env:GITHUB_PATH

--- a/.github/workflows/xlings-ci-archlinux.yml
+++ b/.github/workflows/xlings-ci-archlinux.yml
@@ -39,23 +39,22 @@ jobs:
             pwd
             sudo chown -R test .
             echo ::group:: Copy Repo
-              mkdir -p /tmp/build/src
-              cp -Rv ./ /tmp/build/src/xlings
+              mkdir -p /tmp/build
               cp -Rv ./config/aur/* /tmp/build
-              cp -Rv ./config/aur/* /tmp/build/src
             echo ::endgroup::
             echo ::group:: Makepkg Xlings
               cd /tmp/build
-              makepkg -sie --noconfirm
+              makepkg -si --noconfirm
               cd -
             echo ::endgroup::
             echo ::group:: Package Info
               pacman -Qii xlings
               pacman -Ql xlings
             echo ::endgroup::
-            echo ::group:: Xlings Init and test aur
+            echo ::group:: Xlings Init and package index smoke
               xlings
-              xlings install nvm@pmwrapper -y
+              xlings update
+              xlings search nvm
             echo ::endgroup::
             echo ::group:: Xlings Add Test User
               xlings self config --adduser test
@@ -74,7 +73,8 @@ jobs:
           su test -c """
             set -euo pipefail
 
-            echo ::group:: Test XIM AUR Wrapper
-              xlings install wechat@pmwrapper -y
+            echo ::group:: Test XIM package index lookup
+              xlings update
+              xlings info nvm
             echo ::endgroup::
           """

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -52,7 +52,7 @@ jobs:
           XLINGS_NON_INTERACTIVE: 1
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings"           >> "$GITHUB_ENV"
           echo "$HOME/.xlings/subos/current/bin"     >> "$GITHUB_PATH"
           echo "$HOME/.xlings/bin"                   >> "$GITHUB_PATH"

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -34,7 +34,7 @@ jobs:
           XLINGS_NON_INTERACTIVE: 1
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings"           >> "$GITHUB_ENV"
           echo "$HOME/.xlings/subos/current/bin"     >> "$GITHUB_PATH"
           echo "$HOME/.xlings/bin"                   >> "$GITHUB_PATH"

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -34,7 +34,7 @@ jobs:
           XLINGS_NON_INTERACTIVE: '1'
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          irm https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.ps1 | iex
+          irm https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1 | iex
           "XLINGS_HOME=$env:USERPROFILE\.xlings"            >> $env:GITHUB_ENV
           "$env:USERPROFILE\.xlings\subos\current\bin"      >> $env:GITHUB_PATH
           "$env:USERPROFILE\.xlings\bin"                    >> $env:GITHUB_PATH
@@ -103,7 +103,7 @@ jobs:
           Remove-Item Env:XLINGS_HOME -ErrorAction SilentlyContinue
           Remove-Item -Recurse -Force "$env:USERPROFILE\.xlings" -ErrorAction SilentlyContinue
           Write-Host "=== Running quick install script ==="
-          irm https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.ps1 | iex
+          irm https://raw.githubusercontent.com/openxlings/xlings/refs/heads/main/tools/other/quick_install.ps1 | iex
           $env:Path = "$env:USERPROFILE\.xlings\subos\current\bin;$env:Path"
           $atSubos = Test-Path "$env:USERPROFILE\.xlings\subos\current\bin\xlings.exe"
           if (-not $atSubos) { throw "xlings not installed at .xlings\subos\current\bin" }

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "core/xim/pkgindex"]
 	path = core/xim/pkgindex
-	url = https://github.com/d2learn/xim-pkgindex.git
+	url = https://github.com/openxlings/xim-pkgindex.git

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [Website]: https://xlings.d2learn.org
 [Quick Start]: https://xlings.d2learn.org/en/documents/quick-start/one-click-install.html
-[Package Index]: https://d2learn.github.io/xim-pkgindex
+[Package Index]: https://openxlings.github.io/xim-pkgindex
 [XPackage]: https://xlings.d2learn.org/en/documents/xpkg/intro.html
 [Contributing]: https://xlings.d2learn.org/en/documents/community/contribute/add-xpkg.html
 [Forum]: https://forum.d2learn.org/category/9/xlings
@@ -27,7 +27,7 @@
 > [!CAUTION]
 > xlings is currently migrating from Lua to MC++ with a modular architecture. Some packages may be unstable during this transition. If you run into any problems, please report them via [Issues] or the [Forum].
 
-[Issues]: https://github.com/d2learn/xlings/issues
+[Issues]: https://github.com/openxlings/xlings/issues
 
 ## Quick Start
 
@@ -60,13 +60,13 @@ irm https://d2learn.org/xlings-install.ps1.txt | iex
 #### Linux/MacOS
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/refs/heads/main/tools/other/quick_install.sh | bash
 ```
 
 #### Windows - PowerShell
 
 ```bash
-irm https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.ps1 | iex
+irm https://raw.githubusercontent.com/openxlings/xlings/refs/heads/main/tools/other/quick_install.ps1 | iex
 ```
 
 
@@ -186,8 +186,8 @@ pipeline, so a clean local build matches what CI runs.
 
 **👥Contributors**
 
-[![Star History Chart](https://api.star-history.com/svg?repos=d2learn/xlings,d2learn/xim-pkgindex&type=Date)](https://star-history.com/#d2learn/xlings&d2learn/xim-pkgindex&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=openxlings/xlings,openxlings/xim-pkgindex&type=Date)](https://star-history.com/#openxlings/xlings&openxlings/xim-pkgindex&Date)
 
-<a href="https://github.com/d2learn/xlings/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=d2learn/xlings" />
+<a href="https://github.com/openxlings/xlings/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=openxlings/xlings" />
 </a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -18,7 +18,7 @@
 
 [官网]: https://xlings.d2learn.org
 [快速开始]: https://xlings.d2learn.org/documents/quick-start/one-click-install.html
-[包索引]: https://d2learn.github.io/xim-pkgindex
+[包索引]: https://openxlings.github.io/xim-pkgindex
 [XPKG包]: https://xlings.d2learn.org/documents/xpkg/intro.html
 [贡献]: https://xlings.d2learn.org/documents/community/contribute/add-xpkg.html
 [论坛]: https://forum.d2learn.org/category/9/xlings
@@ -27,7 +27,7 @@
 > [!CAUTION]
 > xlings 正在从 Lua 迁移到 MC++ 并进行模块化重构，部分包在迁移期间可能存在不稳定的情况。如遇问题，请通过 [Issues] 或 [论坛] 反馈。
 
-[Issues]: https://github.com/d2learn/xlings/issues
+[Issues]: https://github.com/openxlings/xlings/issues
 
 ## 快速开始
 
@@ -60,13 +60,13 @@ irm https://d2learn.org/xlings-install.ps1.txt | iex
 #### Linux/MacOS
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/refs/heads/main/tools/other/quick_install.sh | bash
 ```
 
 #### Windows - PowerShell
 
 ```bash
-irm https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.ps1 | iex
+irm https://raw.githubusercontent.com/openxlings/xlings/refs/heads/main/tools/other/quick_install.ps1 | iex
 ```
 
 
@@ -159,8 +159,8 @@ xlings install
 
 **👥贡献者**
 
-[![Star History Chart](https://api.star-history.com/svg?repos=d2learn/xlings,d2learn/xim-pkgindex&type=Date)](https://star-history.com/#d2learn/xlings&d2learn/xim-pkgindex&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=openxlings/xlings,openxlings/xim-pkgindex&type=Date)](https://star-history.com/#openxlings/xlings&openxlings/xim-pkgindex&Date)
 
-<a href="https://github.com/d2learn/xlings/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=d2learn/xlings" />
+<a href="https://github.com/openxlings/xlings/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=openxlings/xlings" />
 </a>

--- a/config/aur/PKGBUILD
+++ b/config/aur/PKGBUILD
@@ -1,21 +1,23 @@
 # Maintainer: sunrisepeak <speakshen@163.com>
 pkgname=xlings
-pkgver=0.0.4
+pkgver=0.4.14
 pkgrel=1
 pkgdesc="A Developer's Toolkit for Programming Learning, Development, and Tutorial Creation"
 arch=('x86_64')
-url="https://github.com/d2learn/xlings"
+url="https://github.com/openxlings/xlings"
 license=('Apache-2.0')
 depends=()
-makedepends=('git')
 source=(
-    "git+https://github.com/d2learn/xlings.git"
+    "https://github.com/openxlings/xlings/releases/download/v${pkgver}/xlings-${pkgver}-linux-x86_64.tar.gz"
     "xlings-remove.hook"
 )
-sha256sums=('SKIP' 'SKIP' 'SKIP')
+sha256sums=(
+    '4d5ba18fb5f8b32ec899c43c64719302445fe13eec952629f28cce9d8c400b71'
+    'SKIP'
+)
 
 package() {
-  cd "$srcdir/$pkgname"
+  cd "$srcdir/$pkgname-$pkgver-linux-x86_64"
 
   # Install binary
   install -Dm755 bin/xlings "$pkgdir/usr/bin/xlings"
@@ -24,7 +26,7 @@ package() {
   install -d "$pkgdir/usr/share/$pkgname"
   cp -r . "$pkgdir/usr/share/$pkgname"
 
-  chmod 766 "$pkgdir/usr/share/$pkgname/config/xlings.json"
+  chmod 766 "$pkgdir/usr/share/$pkgname/.xlings.json"
 
   # Set permissions for files
   # find "$pkgdir/usr/share/$pkgname" -type f -exec chmod 644 {} +

--- a/config/xlings.json
+++ b/config/xlings.json
@@ -9,7 +9,7 @@
   "xim": {
     "mirrors": {
       "index-repo": {
-        "GLOBAL": "https://github.com/d2learn/xim-pkgindex.git",
+        "GLOBAL": "https://github.com/openxlings/xim-pkgindex.git",
         "CN": "https://gitee.com/sunrisepeak/xim-pkgindex.git"
       },
       "res-server": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@
 | 资源 | 链接 |
 |------|------|
 | 官网 | https://xlings.d2learn.org |
-| 包索引 | [xim-pkgindex](https://github.com/d2learn/xim-pkgindex) |
+| 包索引 | [xim-pkgindex](https://github.com/openxlings/xim-pkgindex) |
 | 论坛 | https://forum.d2learn.org/category/9/xlings |
 | QQ 群 | 167535744 / 1006282943 |
 
@@ -72,12 +72,12 @@
 
 #### xim-pkgindex — 官方包索引
 
-- **仓库**: [github.com/d2learn/xim-pkgindex](https://github.com/d2learn/xim-pkgindex)
+- **仓库**: [github.com/openxlings/xim-pkgindex](https://github.com/openxlings/xim-pkgindex)
 - **简介**: 61 个 xpkg 包定义 + V1 规范 + Pytest 测试框架
 - **关键文档**:
-  - [xpackage-spec.md](https://github.com/d2learn/xim-pkgindex/blob/main/docs/xpackage-spec.md) — xpkg 规范
-  - [add-xpackage.md](https://github.com/d2learn/xim-pkgindex/blob/main/docs/add-xpackage.md) — 添加包指南
-  - [test/design.md](https://github.com/d2learn/xim-pkgindex/blob/main/test/design.md) — 测试框架设计
+  - [xpackage-spec.md](https://github.com/openxlings/xim-pkgindex/blob/main/docs/xpackage-spec.md) — xpkg 规范
+  - [add-xpackage.md](https://github.com/openxlings/xim-pkgindex/blob/main/docs/add-xpackage.md) — 添加包指南
+  - [test/design.md](https://github.com/openxlings/xim-pkgindex/blob/main/test/design.md) — 测试框架设计
 
 #### xpkg 规范要点
 
@@ -113,7 +113,7 @@
 ## 贡献者指南
 
 - **Issues 与 Bug 修复** — [官网指南](https://xlings.d2learn.org)
-- **添加 XPackage 包** — [官网指南](https://xlings.d2learn.org) / [xim-pkgindex 仓库](https://github.com/d2learn/xim-pkgindex)
+- **添加 XPackage 包** — [官网指南](https://xlings.d2learn.org) / [xim-pkgindex 仓库](https://github.com/openxlings/xim-pkgindex)
 - **文档编写** — [官网指南](https://xlings.d2learn.org)
 - **社区**: [论坛](https://forum.d2learn.org/category/9/xlings) / QQ 群 167535744 / 1006282943
 
@@ -155,7 +155,7 @@
 [AGENTS.md](../AGENTS.md) → [architecture.md](../.agents/docs/architecture.md) → [tests/README.md](../tests/README.md) → [changelog.md](../.agents/docs/changelog.md)
 
 **包贡献者**:
-[xpackage-spec.md](https://github.com/d2learn/xim-pkgindex/blob/main/docs/xpackage-spec.md) → [add-xpackage.md](https://github.com/d2learn/xim-pkgindex/blob/main/docs/add-xpackage.md) → 示例包 → [测试框架](https://github.com/d2learn/xim-pkgindex/blob/main/test/design.md)
+[xpackage-spec.md](https://github.com/openxlings/xim-pkgindex/blob/main/docs/xpackage-spec.md) → [add-xpackage.md](https://github.com/openxlings/xim-pkgindex/blob/main/docs/add-xpackage.md) → 示例包 → [测试框架](https://github.com/openxlings/xim-pkgindex/blob/main/test/design.md)
 
 **设计贡献者**:
 [architecture.md](../.agents/docs/architecture.md) → [mcpp-version/README.md](../.agents/docs/mcpp-version/README.md) → 设计文档 → [tasks/](../.agents/tasks/)

--- a/docs/plans/2026-05-04-openxlings-migration-evaluation.md
+++ b/docs/plans/2026-05-04-openxlings-migration-evaluation.md
@@ -1,0 +1,257 @@
+# openxlings 组织迁移评估报告
+
+**日期**: 2026-05-04
+**目标**: 评估将 `d2learn` 组织下的 xlings 生态仓库迁移到 `openxlings` 组织，并同步内部生态引用，使迁移后安装、索引、CI、发布、文档入口全面可用。
+
+## 结论
+
+迁移可行，但不能只复制代码或改 README。建议采用 GitHub 原仓库 transfer，而不是新建仓库后 force push，因为 transfer 会保留 issues、PR、releases、stars、watchers、wiki、webhooks/secrets/deploy keys 的关联，并保留 git/网页旧地址跳转。GitHub 官方约束也明确要求目标账号不能已有同名仓库或同一 fork network 中的 fork。
+
+当前阻塞点:
+
+- `openxlings/xlings` 当前重定向到 `openxlings/xlings-tmp`；该仓库是旧 fork，`main` 停在 `3207d8e...` / `v0.4.2`，没有 release。需要先删除或继续保留为 `xlings-tmp`，并确认 `openxlings/xlings` 名称可用于 transfer。
+- 除 `xlings-tmp` 外，`openxlings/xim-pkgindex`、`openxlings/xim-pkgindex-scode`、`openxlings/xim-pkgindex-fromsource`、`openxlings/xpkgindex`、`openxlings/xim-pkgindex-skills`、`openxlings/xim-pkgindex-awesome`、`openxlings/xim-pkgindex-template` 当前查询均为 `NOT_FOUND`。
+- `d2x` 系列仓库明确保留在 `d2learn`，包括 `d2learn/d2x` 和 `d2learn/xim-pkgindex-d2x`；迁移后应作为 external/d2learn 依赖声明和验证。
+- GitHub Pages 不随仓库 transfer 自动重定向，因此 `https://d2learn.github.io/xim-pkgindex` 必须有新的 Pages/DNS 方案。
+
+总体风险: **中等**。如果按 transfer + 分阶段改配置 + 三平台验证执行，风险可控；如果用新仓库替换或只改文档，风险为高。
+
+## 仓库清单和现状
+
+| 仓库 | 当前 d2learn 状态 | openxlings 状态 | 迁移建议 |
+| --- | --- | --- | --- |
+| `d2learn/xlings` | 活跃；`main=1594d3e...`；latest release `v0.4.14`，3 个资产；约 320 files | `openxlings/xlings` 当前 301 到 `openxlings/xlings-tmp`；旧 fork `main=3207d8e...`，无 release | 先释放/确认 `openxlings/xlings` 名称，再 transfer 原仓库 |
+| `d2learn/xim-pkgindex` | 活跃；`main=c72b6b...`；86 个包；6 个 workflow；GitHub Pages 开启 | `NOT_FOUND` | transfer；迁移后立即重跑 pkgindex site deploy |
+| `d2learn/xim-pkgindex-scode` | 活跃；15 个包；无 workflow | `NOT_FOUND` | transfer；同步 README 和注册入口 |
+| `d2learn/xim-pkgindex-fromsource` | 活跃；45 个包；2 个 workflow | `NOT_FOUND` | transfer；CI 依赖 quick_install，需和 xlings 同步切换 |
+| `d2learn/xpkgindex` | 静态站点生成工具；Python/HTML；20 files | `NOT_FOUND` | transfer；`xim-pkgindex` workflow 的 `pip install git+...` 要改 |
+| `d2learn/xim-pkgindex-skills` | 仅 LICENSE/README；1 commit | `NOT_FOUND` | transfer 或归档后保留重定向 |
+| `d2learn/xim-pkgindex-awesome` | 7 个索引包；公开索引仓库列表 | `NOT_FOUND` | transfer；它是子索引发现入口，必须优先修 |
+| `d2learn/xim-pkgindex-template` | template repo；README 含 template_owner | `NOT_FOUND` | transfer；改 GitHub template 创建链接 |
+| `d2learn/xim-pkgindex-d2x` | d2x 系列子索引；明确保留在 d2learn | 保留为 `d2learn/xim-pkgindex-d2x` | 不 transfer；在 openxlings 生态中标记为 external/d2learn |
+
+取证摘要:
+
+- GitHub API / `gh repo view` 显示 `d2learn/xlings` latest release 为 `v0.4.14`，发布时间 `2026-05-03T14:26:33Z`，3 个 assets。
+- `git ls-remote` 显示 `openxlings/xlings-tmp` 的 `main` 为 `3207d8e...`，只到 `v0.4.2`；`d2learn/xlings` 的 `main` 和 `v0.4.14` 为 `1594d3e...`。
+- GitHub API 对 `openxlings/xlings` 返回 301 到 repository id `1210660337`，实际 full name 为 `openxlings/xlings-tmp`；网页 `https://github.com/openxlings/xlings` 也 301 到 `https://github.com/openxlings/xlings-tmp`。
+
+## 生态引用面
+
+浅克隆扫描的旧生态引用数量:
+
+| 仓库 | 文件数 | 包文件数 | workflow 数 | `d2learn` / 旧站点 / 旧镜像引用数 |
+| --- | ---: | ---: | ---: | ---: |
+| `xim-pkgindex` | 194 | 86 | 6 | 104 |
+| `xim-pkgindex-awesome` | 12 | 7 | 0 | 38 |
+| `xim-pkgindex-fromsource` | 110 | 45 | 2 | 5 |
+| `xim-pkgindex-scode` | 19 | 15 | 0 | 5 |
+| `xim-pkgindex-skills` | 2 | 0 | 0 | 0 |
+| `xim-pkgindex-template` | 3 | 1 | 0 | 5 |
+| `xlings` | 320 | 0 | 6 | 123 |
+| `xpkgindex` | 20 | 0 | 0 | 2 |
+
+必须改的功能性引用:
+
+- `config/xlings.json` 默认 GLOBAL index repo 仍是 `https://github.com/d2learn/xim-pkgindex.git`，CN 仍是 `https://gitee.com/sunrisepeak/xim-pkgindex.git`。
+- `src/core/config.cppm` 的 `Info::REPO` 和默认 index repo 仍指向 `d2learn/xlings` / `d2learn/xim-pkgindex`。
+- `tools/other/quick_install.sh`、`tools/other/quick_install.ps1` 的 `GITHUB_REPO` 仍是 `d2learn/xlings`；banner 也输出 d2learn/forum。
+- release package fallback JSON 仍写入 `d2learn/xim-pkgindex`、`gitee.com/sunrisepeak/xim-pkgindex`、`gitee.com/sunrisepeak/xlings`。
+- xlings CI/release workflow 使用 `raw.githubusercontent.com/d2learn/xlings/.../quick_install.*` bootstrap 自身。
+- `xim-pkgindex/.github/workflows/pkgindex-deloy.yml` 通过 `pip install git+https://github.com/d2learn/xpkgindex.git` 安装站点生成器。
+- `xim-pkgindex/.github/workflows/gitee-sync.yml` 和 `xlings/.github/workflows/gitee-sync.yml` 的 `src` 为 `github/d2learn`，`dst` 为 `gitee/Sunrisepeak`。
+- `xim-pkgindex/xim-indexrepos.lua` 把 `awesome`、`scode`、`d2x` 子索引注册到 `https://github.com/d2learn/...`。
+- `xim-pkgindex/pkgs/x/xlings.lua` 中 `repo`、contributors、`0.4.4` 到 `0.4.14` release asset URL 都写死 `https://github.com/d2learn/xlings/...`。
+- `xim-pkgindex-awesome` 的 README 和 `pkgs/*/*.lua` 是子索引发现入口，仍指向 `d2learn/xim-pkgindex-*`。
+- `xim-pkgindex-template` README 的 `xim --add-indexrepo ...` 和 GitHub template owner 都仍是 `d2learn`。
+- `xpkgindex` footer/about 模板仍显示 `https://github.com/d2learn/xpkgindex`。
+
+可延后但需要决策的品牌/社区引用:
+
+- `xlings.d2learn.org`、`forum.d2learn.org`、`d2learn.github.io/xim-pkgindex`。
+- `d2learn/d2x`、`d2learn/xim-pkgindex-d2x`、`d2learn/xlings-project-templates`、`xlings-res/*` 资源组织明确不纳入本轮 transfer。
+- Gitee/GitCode CN 镜像是否继续使用 `Sunrisepeak` / `xlings-res`，还是建立 openxlings 对应镜像。
+
+## 推荐迁移策略
+
+### Phase 0: 冻结和备份
+
+1. 冻结 `d2learn/xlings`、`d2learn/xim-pkgindex`、`d2learn/xim-pkgindex-fromsource` 的发布和合并窗口。
+2. 导出仓库设置、Actions secrets、Pages 设置、branch protection/rulesets、webhooks、deploy keys。
+3. 记录当前 `main` SHA、tag 列表、latest release、Pages URL、CI 状态。
+
+### Phase 1: GitHub 仓库 transfer
+
+优先用 GitHub transfer:
+
+1. 处理 `openxlings/xlings-tmp`:
+   - 保留为历史 fork，确认 `openxlings/xlings` 可用；或
+   - 若 GitHub transfer 报同名/fork network 冲突，删除/重命名/断开该 fork 后重试。
+2. 将原仓库 transfer 到 `openxlings`:
+   - `d2learn/xlings` -> `openxlings/xlings`
+   - `d2learn/xim-pkgindex` -> `openxlings/xim-pkgindex`
+   - `d2learn/xim-pkgindex-scode` -> `openxlings/xim-pkgindex-scode`
+   - `d2learn/xim-pkgindex-fromsource` -> `openxlings/xim-pkgindex-fromsource`
+   - `d2learn/xpkgindex` -> `openxlings/xpkgindex`
+   - `d2learn/xim-pkgindex-skills` -> `openxlings/xim-pkgindex-skills`
+   - `d2learn/xim-pkgindex-awesome` -> `openxlings/xim-pkgindex-awesome`
+   - `d2learn/xim-pkgindex-template` -> `openxlings/xim-pkgindex-template`
+   - 不迁移 d2x 系列: `d2learn/d2x`、`d2learn/xim-pkgindex-d2x` 保留在 d2learn
+3. 验证旧 URL 跳转仍有效，但不要把跳转作为长期配置依赖。
+
+GitHub transfer 注意点:
+
+- 需要源仓库 admin 权限，以及在目标组织创建仓库的权限。
+- 目标账号不能已有同名仓库或同一 fork network 的 fork。
+- GitHub 会转移 issues、PR、wiki、stars、watchers、releases、webhooks、secrets、deploy keys 等，但 GitHub Pages URL 不会自动重定向。
+
+### Phase 2: 代码和配置同步
+
+在 transfer 后提交一组同步 PR，建议按仓库拆分:
+
+1. `openxlings/xlings`
+   - `src/core/config.cppm`: `Info::REPO` 改为 `https://github.com/openxlings/xlings`，默认 GLOBAL index repo 改为 `https://github.com/openxlings/xim-pkgindex.git`。
+   - `config/xlings.json`: GLOBAL index repo 改为 openxlings；`repo` 字段改为 GitHub/openxlings 或新的 CN 镜像。
+   - `tools/other/quick_install.*`: `GITHUB_REPO=openxlings/xlings`，示例 raw URL 和 banner 更新。
+   - `tools/*_release.*`: fallback `.xlings.json` 改为 openxlings。
+   - `.github/workflows/*`: raw quick_install URL 改为 openxlings；release workflow 的说明和 pinned bootstrap 保持可追踪。
+   - README、docs、i18n、AUR PKGBUILD、tests 默认 URL 同步。
+
+2. `openxlings/xim-pkgindex`
+   - `xim-indexrepos.lua`: `awesome`、`scode`、`d2x` 改为 openxlings。
+   - `pkgs/x/xlings.lua`: `repo`、contributors、release URLs 改为 openxlings。历史版本可依赖 GitHub redirect，但建议统一改掉，避免未来旧 owner redirect 被破坏。
+   - `.github/workflows/pkgindex-deloy.yml`: `pip install git+https://github.com/openxlings/xpkgindex.git`。
+   - `.github/workflows/gitee-sync.yml`: 如果继续同步 Gitee，调整 `src`/`dst`/`static_list` 和 secrets。
+   - README/docs/badges/issue links 改为 openxlings。
+
+3. `openxlings/xim-pkgindex-awesome`
+   - README 列表、GitHub template 创建链接、`pkgs/*/*.lua` 的 `repo`/`docs`。
+   - 若 `xim-pkgindex-d2x` 暂不迁移，明确标记为 external/d2learn。
+
+4. `openxlings/xim-pkgindex-scode`、`openxlings/xim-pkgindex-fromsource`、`openxlings/xim-pkgindex-template`
+   - README 的 `xim --add-indexrepo` 命令改为 openxlings。
+   - CI quick_install raw URL 改为 openxlings。
+   - package metadata 的 `repo` 字段改为 openxlings。
+
+5. `openxlings/xpkgindex`
+   - footer/about 模板链接改为 openxlings。
+   - 可考虑发布 PyPI 或 GitHub release，减少 `xim-pkgindex` Pages workflow 对 git URL 的耦合。
+
+### Phase 3: Pages、域名和镜像
+
+建议选择一个主入口:
+
+- 最小变更: 保留 `xlings.d2learn.org` 和 `forum.d2learn.org`，只把 GitHub owner 改为 openxlings。风险最低，但品牌不完全迁移。
+- 完整迁移: 启用 `xlings.openxlings.org` 或 `openxlings.github.io/xlings`，`xim-pkgindex` 使用 `openxlings.github.io/xim-pkgindex` 或 `pkgindex.openxlings.org`。需要 DNS、Pages、文档、README、i18n 同步。
+
+无论选择哪种，`d2learn.github.io/xim-pkgindex` 不会自动跳到新 owner，需要:
+
+1. 在 `openxlings/xim-pkgindex` 启用 Pages。
+2. 更新 README、官网、i18n、package index portal 链接。
+3. 如需旧 URL 兼容，在 d2learn 侧保留 Pages stub 做跳转说明。
+
+CN 镜像建议单独决策:
+
+- 若继续用 `gitee.com/sunrisepeak/*` 和 `gitcode.com/xlings-res/*`，配置中保留 CN 但文档标注为镜像服务。
+- 若迁移到 openxlings 命名，应新增 Gitee/GitCode 组织或仓库，并更新 `gitee-sync` secrets。
+
+### Phase 4: 验证清单
+
+迁移后必须通过这些检查，才算“全面可用”:
+
+1. GitHub 仓库:
+   - `gh repo view openxlings/xlings` 显示非 fork 原仓库，latest release 为当前最新 tag。
+   - 8 个原清单仓库均存在于 `openxlings`；`d2learn/d2x` 和 `d2learn/xim-pkgindex-d2x` 仍存在于 `d2learn`。
+   - `git ls-remote https://github.com/openxlings/xlings.git HEAD refs/tags/v0.4.14` 正常。
+   - 旧 `https://github.com/d2learn/...` URL 仍跳转，且 d2learn 旧位置没有新建同名仓库破坏 redirect。
+
+2. 安装和自举:
+   - Linux/macOS:
+     ```bash
+     XLINGS_NON_INTERACTIVE=1 curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
+     xlings -h
+     xlings config
+     xim --update index
+     ```
+   - Windows:
+     ```powershell
+     $env:XLINGS_NON_INTERACTIVE='1'
+     irm https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1 | iex
+     xlings -h
+     xlings config
+     xim --update index
+     ```
+
+3. 包索引:
+   - `xlings search xlings`
+   - `xlings install xlings@0.4.14 -y`
+   - `xim --add-indexrepo scode:https://github.com/openxlings/xim-pkgindex-scode.git`
+   - `xim --add-indexrepo fromsource:https://github.com/openxlings/xim-pkgindex-fromsource.git`
+   - `xlings install awesome:scode -y` 或等价的子索引安装/搜索 smoke。
+
+4. CI/发布:
+   - `openxlings/xlings` 三平台 CI 和 Release workflow 通过。
+   - `openxlings/xim-pkgindex` 的 `ci-test.yml`、`ci-xpkg-test.yml`、`pkgindex-deloy.yml` 通过。
+   - `openxlings/xim-pkgindex-fromsource` 的两个 CI 通过。
+   - GitHub Pages 新 URL 可访问，About 页面 build info 指向 openxlings commit。
+
+5. 引用审计:
+   - 对所有迁移仓库运行:
+     ```bash
+     rg -n "github.com/d2learn|raw.githubusercontent.com/d2learn|d2learn.github.io|xlings.d2learn.org|forum.d2learn.org|gitee.com/sunrisepeak"
+     ```
+   - 所有结果必须归类为 `legacy compatibility`、`external project`、`CN mirror` 或已修复。
+
+## 风险和缓解
+
+| 风险 | 影响 | 缓解 |
+| --- | --- | --- |
+| 目标 org 已有同名 fork/network 冲突 | transfer 失败 | 先处理 `openxlings/xlings-tmp`，用 GitHub transfer 前做 dry-run/手动确认 |
+| Pages 不自动跳转 | 包索引门户和文档入口断链 | 新 Pages 先上线；旧 Pages 保留跳转页；所有链接改为新 URL |
+| quick_install 自举依赖旧 owner | CI/用户安装仍从 d2learn 拉包 | transfer 后第一批 PR 先改 quick_install 和 CI raw URL；验证 `XLINGS_VERSION` pin |
+| `xim-pkgindex` release URL 写死旧 owner | `xlings install xlings` 依赖 redirect | 批量改 `pkgs/x/xlings.lua`；保留 checksum 不变；重跑 package index CI |
+| gitee-sync secrets 不存在 | 镜像停止更新 | 迁移前导出/重建 secrets；如果不迁移 CN 镜像，显式暂停 workflow |
+| `xim-pkgindex-d2x` 保留在 d2learn | openxlings 生态中可能被误判为漏迁 | 显式标注 external/d2learn，并在审计规则中允许 d2x 系列 |
+| 用户本地 clone/remotes 仍指向旧地址 | 可用但混乱 | 发布迁移公告，建议 `git remote set-url origin https://github.com/openxlings/<repo>.git` |
+| d2learn 旧位置新建同名仓库 | GitHub redirect 被永久破坏 | transfer 后锁定旧 owner 命名，避免创建同名 repo/fork |
+
+## Go / No-Go 判断
+
+可以执行迁移的前置条件:
+
+- `openxlings/xlings` 名称可用于 transfer，且不会被 `xlings-tmp` fork network 阻塞。
+- `openxlings` 组织 owner/admin 权限确认完毕。
+- Actions secrets、Pages、branch protection/rulesets 迁移计划已确认。
+- 已决定 `d2x`、`xim-pkgindex-d2x`、`xlings-project-templates` 保留在 d2learn；仍需决定 `xlings-res`、Gitee/GitCode、官网/论坛的保留或迁移边界。
+- 已准备迁移后一批同步 PR 和验证脚本。
+
+No-Go 条件:
+
+- 只能创建空仓库/镜像，不能 transfer 原仓库。
+- 未确认 Pages 新入口。
+- 没有权限恢复 CI secrets 或发布 release。
+- 不声明 `d2x` 系列为 external/d2learn，但仍要求 awesome/子索引全面可用。
+
+## 建议执行顺序
+
+1. 先转移 `xlings` 和 `xpkgindex`，发布 `openxlings/xlings` quick_install 可用版本。
+2. 转移 `xim-pkgindex`，改默认 index repo、Pages workflow、`pkgs/x/xlings.lua`。
+3. 转移 `xim-pkgindex-awesome`、`xim-pkgindex-scode`、`xim-pkgindex-fromsource`、`xim-pkgindex-template`、`xim-pkgindex-skills`。
+4. 声明并验证 `d2x` 系列和 `xlings-project-templates` 保留在 d2learn。
+5. 跑三平台安装/索引/CI/Pages 验证。
+6. 发布迁移公告，保留旧 URL redirect 和旧 Pages 跳转说明至少一个 release 周期。
+
+## 参考来源
+
+- GitHub transfer 文档: https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository
+- `d2learn/xlings`: https://github.com/d2learn/xlings
+- `openxlings/xlings-tmp`: https://github.com/openxlings/xlings-tmp
+- `d2learn/xim-pkgindex`: https://github.com/d2learn/xim-pkgindex
+- `d2learn/xim-pkgindex-awesome`: https://github.com/d2learn/xim-pkgindex-awesome
+- `d2learn/xim-pkgindex-scode`: https://github.com/d2learn/xim-pkgindex-scode
+- `d2learn/xim-pkgindex-fromsource`: https://github.com/d2learn/xim-pkgindex-fromsource
+- `d2learn/xpkgindex`: https://github.com/d2learn/xpkgindex
+- `d2learn/xim-pkgindex-skills`: https://github.com/d2learn/xim-pkgindex-skills
+- `d2learn/xim-pkgindex-template`: https://github.com/d2learn/xim-pkgindex-template
+- `d2learn/xim-pkgindex-d2x`: https://github.com/d2learn/xim-pkgindex-d2x
+- `d2learn/xlings-project-templates`: https://github.com/d2learn/xlings-project-templates

--- a/docs/plans/2026-05-04-openxlings-post-transfer-reference-migration.md
+++ b/docs/plans/2026-05-04-openxlings-post-transfer-reference-migration.md
@@ -1,0 +1,300 @@
+# openxlings 仓库转移后引用迁移报告
+
+**日期**: 2026-05-04
+**范围**: 已 transfer 到 `openxlings` 的 xlings 生态仓库，以及明确保留在 `d2learn` 的 d2x 系列仓库。
+**目标**: 找出仓库内仍指向旧 GitHub owner、旧 Pages、旧 badge、旧自举脚本的引用，并拆分后续 PR。
+
+## 当前仓库归属
+
+已迁移到 `openxlings`:
+
+- `openxlings/xlings`
+- `openxlings/xim-pkgindex`
+- `openxlings/xim-pkgindex-scode`
+- `openxlings/xim-pkgindex-fromsource`
+- `openxlings/xpkgindex`
+- `openxlings/xim-pkgindex-skills`
+- `openxlings/xim-pkgindex-awesome`
+- `openxlings/xim-pkgindex-template`
+
+明确保留在 `d2learn`:
+
+- `d2learn/d2x`
+- `d2learn/xim-pkgindex-d2x`
+
+本轮不处理:
+
+- `d2learn/xlings-project-templates`: 当前在 `xim-pkgindex` 的包元数据中仍被引用；本轮不 transfer，按 external/d2learn 保留。
+- `xlings-res/*`、`gitee.com/sunrisepeak/*`、`gitcode.com/xlings-res/*`: 当前属于资源镜像/CN 镜像范围，不随本次 GitHub transfer 自动迁移。
+
+## 链接可用性取证
+
+已确认:
+
+- `https://d2learn.github.io/xim-pkgindex` -> HTTP 404
+- `https://openxlings.github.io/xim-pkgindex/` -> HTTP 200
+- `https://xlings.d2learn.org/documents/xim/intro.html` -> HTTP 200
+- `https://forum.d2learn.org/category/9/xlings` -> HTTP 200
+- `https://github.com/d2learn/xim-pkgindex/actions/workflows/ci-test.yml` 会跳转到 `openxlings/xim-pkgindex`，但 README/badge 仍应改成 canonical `openxlings` 地址。
+
+结论:
+
+- `d2learn.github.io/xim-pkgindex` 必须迁移到 `openxlings.github.io/xim-pkgindex/`。
+- `xlings.d2learn.org` 和 `forum.d2learn.org` 目前可用；如果继续采用“最小品牌迁移”，暂不强制替换，但应在审计报告中归类为保留项。
+
+## 待迁移引用统计
+
+扫描规则只统计应迁移到 `openxlings` 的 GitHub/Pages 引用，不把 `d2x` 系列算作错误。
+
+| 仓库 | 待改匹配数 | 涉及文件数 | 主要类型 |
+| --- | ---: | ---: | --- |
+| `openxlings/xlings` | 30 | 12 | 项目内历史/agent 文档、mcpp skill、旧 quick-install 示例、旧 PR/仓库链接 |
+| `openxlings/xim-pkgindex` | 71 | 21 | README、workflow bootstrap、Pages URL、子索引 URL、包元数据、release asset URL |
+| `openxlings/xim-pkgindex-scode` | 4 | 2 | README、`pkgindex-build.lua` |
+| `openxlings/xim-pkgindex-fromsource` | 4 | 2 | README、AGENTS；另有 workflow bootstrap 需改 |
+| `openxlings/xpkgindex` | 2 | 2 | HTML 模板 footer/about 链接 |
+| `openxlings/xim-pkgindex-skills` | 0 | 0 | 无需 PR |
+| `openxlings/xim-pkgindex-awesome` | 14 | 7 | README、template 创建链接、子索引包元数据 |
+| `openxlings/xim-pkgindex-template` | 4 | 2 | README、模板包元数据 |
+
+## 必须迁移的引用类型
+
+### GitHub 仓库链接
+
+这些应统一从 `d2learn` 改为 `openxlings`:
+
+- `https://github.com/d2learn/xlings` -> `https://github.com/openxlings/xlings`
+- `https://github.com/d2learn/xim-pkgindex` -> `https://github.com/openxlings/xim-pkgindex`
+- `https://github.com/d2learn/xim-pkgindex-scode` -> `https://github.com/openxlings/xim-pkgindex-scode`
+- `https://github.com/d2learn/xim-pkgindex-fromsource` -> `https://github.com/openxlings/xim-pkgindex-fromsource`
+- `https://github.com/d2learn/xpkgindex` -> `https://github.com/openxlings/xpkgindex`
+- `https://github.com/d2learn/xim-pkgindex-skills` -> `https://github.com/openxlings/xim-pkgindex-skills`
+- `https://github.com/d2learn/xim-pkgindex-awesome` -> `https://github.com/openxlings/xim-pkgindex-awesome`
+- `https://github.com/d2learn/xim-pkgindex-template` -> `https://github.com/openxlings/xim-pkgindex-template`
+
+保留:
+
+- `https://github.com/d2learn/d2x`
+- `https://github.com/d2learn/xim-pkgindex-d2x`
+
+### Raw install/bootstrap URL
+
+这些会影响 CI 和一键安装，必须改:
+
+- `https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh`
+- `https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.ps1`
+
+目标:
+
+- `https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh`
+- `https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1`
+
+### GitHub Actions badge / workflow link
+
+README 中的 badge 和 workflow URL 应改成 canonical openxlings 地址，避免依赖 redirect:
+
+- `https://github.com/d2learn/xim-pkgindex/actions/...`
+- `https://github.com/d2learn/<repo>/actions/...`
+
+### GitHub Pages
+
+必须改:
+
+- `https://d2learn.github.io/xim-pkgindex` -> `https://openxlings.github.io/xim-pkgindex/`
+
+目前 `openxlings/xim-pkgindex` Pages API 显示:
+
+- `html_url`: `https://openxlings.github.io/xim-pkgindex/`
+- `source`: `main` / `/`
+
+## 按仓库拆分的建议 PR
+
+### PR 1: `openxlings/xlings`
+
+**建议标题**: `chore: update canonical openxlings references`
+
+范围:
+
+- 已完成的运行时和安装入口迁移保持在本仓库当前工作树中:
+  - `src/core/config.cppm`
+  - `config/xlings.json`
+  - `tools/other/quick_install.sh`
+  - `tools/other/quick_install.ps1`
+  - `.github/workflows/*`
+  - release scripts
+  - README/docs/project skills
+- 补充处理仍残留在 tracked 非计划文档中的旧链接:
+  - `.agents/docs/changelog.md` 中历史 PR/commit 链接可选择保留为历史记录，或统一改为 redirect 后的新 canonical URL。
+  - `.agents/docs/mcpp-version/*` 和 `.agents/docs/quick_start.md` 中 quick install / GitHub API 示例应改为 `openxlings`。
+  - `.agents/skills/mcpp-style-ref/SKILL.md` 中 raw quick install 和 GitHub 链接应改为 `openxlings`。
+- `tests/unit/test_main.cpp` 中 `../d2learn/xim-pkgindex` 是本地路径 fixture，不是 GitHub URL；建议保留或单独改名为 neutral path。
+
+验证:
+
+- `bash tests/e2e/github_owner_migration_audit.sh`
+- `git diff --check`
+- `bash -n tools/other/quick_install.sh tools/linux_release.sh tools/macos_release.sh`
+
+### PR 2: `openxlings/xim-pkgindex`
+
+**建议标题**: `chore: update openxlings repository and Pages links`
+
+范围:
+
+- `README.md`
+  - 标题中的 `[xlings](https://github.com/d2learn/xlings)` 改为 `openxlings/xlings`。
+  - `Package Index` 改为 `https://openxlings.github.io/xim-pkgindex/`。
+  - workflow badges 改为 `https://github.com/openxlings/xim-pkgindex/actions/...`。
+  - 表格中的 `xim-pkgindex-template`、`xim-pkgindex-fromsource` 改为 `openxlings`。
+  - `xim-pkgindex-d2x` 保留 `d2learn`，并标注为 d2x external index。
+- `.github/workflows/ci-test.yml`、`.github/workflows/ci-xpkg-test.yml`
+  - quick install raw URL 改为 `openxlings/xlings`。
+- `.github/workflows/pkgindex-deloy.yml`
+  - `pip install git+https://github.com/d2learn/xpkgindex.git` 改为 `openxlings/xpkgindex.git`。
+  - 注释中的 `d2learn/xpkgindex` 改为 `openxlings/xpkgindex`。
+- `.github/workflows/gitee-sync.yml`
+  - `src: github/d2learn` 改为 `github/openxlings`；`dst` 是否仍为 `gitee/Sunrisepeak` 需要确认镜像策略。
+- `xim-indexrepos.lua`
+  - `awesome` 和 `scode` 改为 `openxlings`。
+  - `d2x` 保留 `d2learn/xim-pkgindex-d2x`。
+- `docs/V0/*`、`docs/V1/*`、`docs/migrations/*`
+  - 当前仍有 issue、PR、raw quick install、旧 repo 链接；历史 PR 链接可保留或改 canonical。
+- `pkgs/x/xlings.lua`
+  - `repo`、contributors、release asset URL 改为 `openxlings/xlings`。
+- `pkgs/x/xvm.lua`
+  - `repo`、contributors 改为 `openxlings/xlings`。
+- `pkgs/*/*.lua`
+  - 指向 `d2learn/xim-pkgindex` 的本仓库包元数据改为 `openxlings/xim-pkgindex`。
+- `pkgs/d/d2x.lua`
+  - 保留 `https://github.com/d2learn/d2x`。
+- `pkgs/x/xlings-project-templates.lua`
+  - 保留 `d2learn/xlings-project-templates`，本轮不处理。
+
+验证:
+
+- `rg -n "github.com/d2learn|raw.githubusercontent.com/d2learn|d2learn.github.io" README.md .github docs pkgs xim-indexrepos.lua`
+- `xim --update index`
+- `xlings install xlings@0.4.14 -y`
+- Pages workflow 成功后访问 `https://openxlings.github.io/xim-pkgindex/`
+
+### PR 3: `openxlings/xim-pkgindex-awesome`
+
+**建议标题**: `chore: update openxlings sub-index references`
+
+范围:
+
+- `README.md`
+  - GitHub template 创建链接的 `template_owner=d2learn` 改为 `template_owner=openxlings`。
+  - 指向 `xim-pkgindex-awesome/blob/...` 的链接改为 `openxlings`。
+  - xlings 工具和 xim 主索引链接改为 `openxlings`。
+  - `xim-pkgindex-d2x` 保留 d2learn。
+- `pkgindex-build.lua`
+  - repo 改为 `openxlings/xim-pkgindex-awesome`。
+- `pkgs/a/awesome.lua`、`pkgs/f/fromsource.lua`、`pkgs/s/scode.lua`、`pkgs/t/template.lua`、`pkgs/x/xim.lua`
+  - repo 改为对应 `openxlings/*`。
+- `pkgs/d/d2x.lua`
+  - 保留 `d2learn/xim-pkgindex-d2x`。
+
+验证:
+
+- `rg -n "github.com/d2learn/xim-pkgindex-(awesome|fromsource|scode|template)|github.com/d2learn/xim-pkgindex([^A-Za-z0-9._-]|$)|template_owner=d2learn"`
+- `xim --add-indexrepo awesome:https://github.com/openxlings/xim-pkgindex-awesome.git`
+
+### PR 4: `openxlings/xim-pkgindex-scode`
+
+**建议标题**: `chore: update openxlings links`
+
+范围:
+
+- `README.md`
+  - add-indexrepo 命令改为 `https://github.com/openxlings/xim-pkgindex-scode.git`。
+  - xlings 工具和 xim 主索引链接改为 `openxlings`。
+  - 论坛链接保留 `forum.d2learn.org`，除非后续品牌策略决定迁移。
+- `pkgindex-build.lua`
+  - repo 改为 `openxlings/xim-pkgindex-scode`。
+
+验证:
+
+- `rg -n "github.com/d2learn|raw.githubusercontent.com/d2learn|d2learn.github.io"`
+- `xim --add-indexrepo scode:https://github.com/openxlings/xim-pkgindex-scode.git`
+
+### PR 5: `openxlings/xim-pkgindex-fromsource`
+
+**建议标题**: `chore: update openxlings bootstrap and docs links`
+
+范围:
+
+- `README.md` 和 `AGENTS.md`
+  - xlings / xim-pkgindex 链接改为 `openxlings`。
+  - add-indexrepo 命令改为 `https://github.com/openxlings/xim-pkgindex-fromsource.git`。
+- `.github/workflows/ci-test.yml`、`.github/workflows/ci-xpkg-test.yml`
+  - quick install raw URL 改为 `openxlings/xlings`。
+
+验证:
+
+- `rg -n "github.com/d2learn|raw.githubusercontent.com/d2learn|d2learn.github.io"`
+- `xim --add-indexrepo fromsource:https://github.com/openxlings/xim-pkgindex-fromsource.git`
+
+### PR 6: `openxlings/xim-pkgindex-template`
+
+**建议标题**: `chore: update openxlings template references`
+
+范围:
+
+- `README.md`
+  - add-indexrepo 示例改为 `openxlings/xim-pkgindex-template.git`。
+  - xlings 工具和 xim 主索引链接改为 `openxlings`。
+- `pkgs/x/xpackage.lua`
+  - repo 改为 `openxlings/xim-pkgindex`。
+
+验证:
+
+- 从 GitHub template 创建新仓库，确认默认 README 中不再带旧 owner。
+- `rg -n "github.com/d2learn|raw.githubusercontent.com/d2learn|d2learn.github.io"`
+
+### PR 7: `openxlings/xpkgindex`
+
+**建议标题**: `chore: update openxlings xpkgindex links`
+
+范围:
+
+- `xpkgindex/templates/base.html`
+- `xpkgindex/templates/about.html`
+
+把 footer/about 中的 `https://github.com/d2learn/xpkgindex` 改为 `https://github.com/openxlings/xpkgindex`。
+
+验证:
+
+- `rg -n "github.com/d2learn/xpkgindex"`
+- 在 `openxlings/xim-pkgindex` 的 Pages workflow 中用新 URL 安装并生成站点。
+
+### 无需 PR: `openxlings/xim-pkgindex-skills`
+
+当前扫描无旧 owner / Pages / badge 引用。
+
+## 建议执行顺序
+
+1. 先合并 `openxlings/xlings` 当前迁移 PR，使 quick install、release、默认 index repo 都指向新 org。
+2. 合并 `openxlings/xpkgindex`，保证 `xim-pkgindex` Pages workflow 可从新 owner 安装生成器。
+3. 合并 `openxlings/xim-pkgindex`，这是用户可见断链最多的仓库，尤其是 README、badge、Pages、package release URL。
+4. 合并 `xim-pkgindex-awesome`、`xim-pkgindex-scode`、`xim-pkgindex-fromsource`、`xim-pkgindex-template`。
+5. 最后重新跑全生态引用审计，允许项只应剩:
+   - `d2learn/d2x`
+   - `d2learn/xim-pkgindex-d2x`
+   - `xlings.d2learn.org`
+   - `forum.d2learn.org`
+   - 明确保留的 CN/resource mirrors
+
+## 统一审计命令建议
+
+每个仓库 PR 后运行:
+
+```bash
+rg -n "github.com/d2learn|raw.githubusercontent.com/d2learn|d2learn.github.io|github/d2learn|template_owner=d2learn"
+```
+
+然后逐条归类:
+
+- 必须改: 已迁移到 `openxlings` 的仓库、raw install、badge、Pages。
+- 允许保留: `d2x` 系列、官网、论坛、CN/resource mirrors。
+- 允许保留: `xlings-project-templates`。

--- a/docs/quick-install.md
+++ b/docs/quick-install.md
@@ -5,17 +5,17 @@ One-line installer scripts for Linux, macOS, and Windows.
 ## Linux / macOS
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
 ```
 
 ### Specify Version
 
 ```bash
 # Positional argument
-curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash -s -- v0.5.0
+curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash -s -- v0.5.0
 
 # Environment variable
-XLINGS_VERSION=v0.5.0 curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+XLINGS_VERSION=v0.5.0 curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
 ```
 
 Version numbers with or without the `v` prefix are both accepted (`v0.5.0` and `0.5.0`).
@@ -26,13 +26,13 @@ When a version is specified, the script skips the network query for the latest r
 If `github.com` is not accessible, set a mirror:
 
 ```bash
-XLINGS_GITHUB_MIRROR=https://mirror.example.com curl -fsSL https://mirror.example.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+XLINGS_GITHUB_MIRROR=https://mirror.example.com curl -fsSL https://mirror.example.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
 ```
 
 ### CI / Non-Interactive Mode
 
 ```bash
-XLINGS_NON_INTERACTIVE=1 curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+XLINGS_NON_INTERACTIVE=1 curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
 ```
 
 When piped (`curl | bash`), the script automatically redirects stdin from `/dev/tty` to support interactive prompts. Set `XLINGS_NON_INTERACTIVE=1` to disable this behavior in CI environments.
@@ -42,7 +42,7 @@ When piped (`curl | bash`), the script automatically redirects stdin from `/dev/
 ## Windows (PowerShell)
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1 | iex"
 ```
 
 ### Specify Version
@@ -50,7 +50,7 @@ powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/d2l
 ```powershell
 # Environment variable
 $env:XLINGS_VERSION = "v0.5.0"
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1 | iex"
 
 # Or run the script directly with -Version parameter
 .\quick_install.ps1 -Version v0.5.0
@@ -60,7 +60,7 @@ powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/d2l
 
 ```powershell
 $env:XLINGS_GITHUB_MIRROR = "https://mirror.example.com"
-powershell -ExecutionPolicy Bypass -c "irm https://mirror.example.com/d2learn/xlings/main/tools/other/quick_install.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://mirror.example.com/openxlings/xlings/main/tools/other/quick_install.ps1 | iex"
 ```
 
 ### TUI rendering on Windows (terminal & font)
@@ -113,4 +113,4 @@ font gaps.
 
 ## How Version Resolution Works
 
-When no version is specified, the scripts resolve the latest release by following the HTTP redirect from `https://github.com/d2learn/xlings/releases/latest` and extracting the tag name from the final URL. This avoids the GitHub API rate limit (60 requests/hour for unauthenticated users).
+When no version is specified, the scripts resolve the latest release by following the HTTP redirect from `https://github.com/openxlings/xlings/releases/latest` and extracting the tag name from the final URL. This avoids the GitHub API rate limit (60 requests/hour for unauthenticated users).

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -1030,12 +1030,12 @@ export int run(int argc, char* argv[]) {
         log::error("filesystem error: {}", e.what());
         if (!e.path1().empty()) log::error("  path: {}", e.path1().string());
         log::error("  hint: this is likely a bug; please report at "
-                   "https://github.com/d2learn/xlings/issues");
+                   "https://github.com/openxlings/xlings/issues");
         return 1;
     } catch (const std::exception& e) {
         log::error("internal error: {}", e.what());
         log::error("  hint: this is likely a bug; please report at "
-                   "https://github.com/d2learn/xlings/issues");
+                   "https://github.com/openxlings/xlings/issues");
         return 1;
     } catch (...) {
         log::error("internal error: unknown exception");

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -14,7 +14,7 @@ namespace xlings {
 
 export struct Info {
     static constexpr std::string_view VERSION = "0.4.14";
-    static constexpr std::string_view REPO = "https://github.com/d2learn/xlings";
+    static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 
 export struct IndexRepo {
@@ -68,7 +68,7 @@ private:
     static constexpr std::string_view DEFAULT_INDEX_REPO_DIR = "xim-pkgindex";
 
     static std::vector<IndexRepo> default_global_index_repos_(const std::string& mirror) {
-        std::string url = "https://github.com/d2learn/xim-pkgindex.git";
+        std::string url = "https://github.com/openxlings/xim-pkgindex.git";
         if (mirror == "CN") {
             url = "https://gitee.com/sunrisepeak/xim-pkgindex.git";
         }

--- a/src/core/xim/README.md
+++ b/src/core/xim/README.md
@@ -74,8 +74,8 @@ xlings update
 
 ## 包索引
 
-- 包索引仓库: [xim-pkgindex](https://github.com/d2learn/xim-pkgindex)
-- 添加 XPackage 文档: [add-xpackage](https://github.com/d2learn/xim-pkgindex/blob/main/docs/add-xpackage.md)
+- 包索引仓库: [xim-pkgindex](https://github.com/openxlings/xim-pkgindex)
+- 添加 XPackage 文档: [add-xpackage](https://github.com/openxlings/xim-pkgindex/blob/main/docs/add-xpackage.md)
 
 ### sub 索引仓库 mirror 选择位置
 

--- a/tests/e2e/bootstrap_home_test.ps1
+++ b/tests/e2e/bootstrap_home_test.ps1
@@ -21,7 +21,7 @@ if (-not (Test-Path $BIN_SRC)) { Fail "built xlings binary not found at $BIN_SRC
 # Prepare fixture index (clone if not present)
 if (-not (Test-Path "$FIXTURE_INDEX\pkgs")) {
     $fixtureRef = if ($env:XIM_PKGINDEX_REF) { $env:XIM_PKGINDEX_REF } else { 'xlings_0.4.0' }
-    $fixtureUrl = if ($env:XIM_PKGINDEX_URL) { $env:XIM_PKGINDEX_URL } else { 'https://github.com/d2learn/xim-pkgindex.git' }
+    $fixtureUrl = if ($env:XIM_PKGINDEX_URL) { $env:XIM_PKGINDEX_URL } else { 'https://github.com/openxlings/xim-pkgindex.git' }
     if (Test-Path $FIXTURE_INDEX) { Remove-Item -Recurse -Force $FIXTURE_INDEX }
     New-Item -ItemType Directory -Force -Path (Split-Path $FIXTURE_INDEX) | Out-Null
     git clone --depth 1 --branch $fixtureRef $fixtureUrl $FIXTURE_INDEX

--- a/tests/e2e/github_owner_migration_audit.sh
+++ b/tests/e2e/github_owner_migration_audit.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Audit the minimal openxlings migration contract:
+# - active product/CI/docs entrypoints must not point at d2learn GitHub owners
+# - xlings.d2learn.org and forum.d2learn.org stay as public site/forum URLs
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+scan_paths=(
+  ".agents/skills/xlings-build"
+  ".agents/skills/xlings-quickstart"
+  ".github"
+  ".gitmodules"
+  "README.md"
+  "README.zh.md"
+  "config"
+  "docs/README.md"
+  "docs/quick-install.md"
+  "src"
+  "tests/e2e/bootstrap_home_test.ps1"
+  "tests/e2e/mirror_fallback_test.sh"
+  "tests/e2e/prepare_fixture_index.sh"
+  "tests/e2e/release_quick_install_test.sh"
+  "tests/e2e/release_test_lib.ps1"
+  "tests/e2e/scenarios/linux_headers/.xlings.json"
+  "tests/unit/test_main.cpp"
+  "tools"
+)
+
+forbidden_patterns=(
+  "github\\.com/d2learn/(xlings|xim-pkgindex|xim-pkgindex-scode|xim-pkgindex-fromsource|xpkgindex|xim-pkgindex-skills|xim-pkgindex-awesome|xim-pkgindex-template)([/.\"?#]|$)"
+  "raw\\.githubusercontent\\.com/d2learn/xlings([/.]|$)"
+  "d2learn\\.github\\.io/xim-pkgindex"
+  "github/d2learn"
+  "GITHUB_REPO=\"d2learn/xlings"
+  "\\\$GITHUB_REPO = \"d2learn/xlings"
+  "repos=d2learn/(xlings|xim-pkgindex)"
+  "repo=d2learn/xlings"
+  "#d2learn/(xlings|xim-pkgindex)"
+  "mirror\\.example\\.com/d2learn/xlings"
+)
+
+failed=0
+for pattern in "${forbidden_patterns[@]}"; do
+  if rg -n "$pattern" "${scan_paths[@]}"; then
+    echo "FAIL: old GitHub owner reference remains: $pattern" >&2
+    failed=1
+  fi
+done
+
+if ! rg -q --fixed-strings "xlings.d2learn.org" README.md README.zh.md docs/README.md config/i18n .agents/skills/xlings-quickstart; then
+  echo "FAIL: xlings.d2learn.org should remain for the minimal migration" >&2
+  failed=1
+fi
+
+if ! rg -q --fixed-strings "forum.d2learn.org" README.md README.zh.md docs/README.md tools/other .agents/skills/xlings-quickstart; then
+  echo "FAIL: forum.d2learn.org should remain for the minimal migration" >&2
+  failed=1
+fi
+
+exit "$failed"

--- a/tests/e2e/mirror_fallback_test.sh
+++ b/tests/e2e/mirror_fallback_test.sh
@@ -68,7 +68,7 @@ write_indexrepos() {
 EOF
 }
 
-GH_BAD_URL="https://github.com/d2learn/this-repo-deliberately-does-not-exist-xlings-mirror-test.git"
+GH_BAD_URL="https://github.com/openxlings/this-repo-deliberately-does-not-exist-xlings-mirror-test.git"
 
 write_indexrepos "$GH_BAD_URL"
 

--- a/tests/e2e/prepare_fixture_index.sh
+++ b/tests/e2e/prepare_fixture_index.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FIXTURE_INDEX_DIR="${1:-$ROOT_DIR/tests/fixtures/xim-pkgindex}"
 XIM_PKGINDEX_REF="${XIM_PKGINDEX_REF:-main}"
-XIM_PKGINDEX_URL="${XIM_PKGINDEX_URL:-https://github.com/d2learn/xim-pkgindex.git}"
+XIM_PKGINDEX_URL="${XIM_PKGINDEX_URL:-https://github.com/openxlings/xim-pkgindex.git}"
 
 if [[ -d "$FIXTURE_INDEX_DIR/pkgs" ]]; then
   echo "[fixture] reuse existing fixture index: $FIXTURE_INDEX_DIR"

--- a/tests/e2e/release_quick_install_test.sh
+++ b/tests/e2e/release_quick_install_test.sh
@@ -11,7 +11,7 @@ HOME="$QUICK_HOME" \
 PATH="$(minimal_system_path)" \
 XLINGS_NON_INTERACTIVE=1 \
 env -u XLINGS_HOME \
-  bash -c 'curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/refs/heads/main/tools/other/quick_install.sh | bash'
+  bash -c 'curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/refs/heads/main/tools/other/quick_install.sh | bash'
 
 INSTALLED_HOME="$QUICK_HOME/.xlings"
 [[ -x "$INSTALLED_HOME/subos/current/bin/xlings" ]] || fail "quick install did not create current xlings shim"

--- a/tests/e2e/release_test_lib.ps1
+++ b/tests/e2e/release_test_lib.ps1
@@ -64,7 +64,7 @@ function Require-FixtureIndex {
         return
     }
     $ref = if ($env:XIM_PKGINDEX_REF) { $env:XIM_PKGINDEX_REF } else { 'xlings_0.4.0' }
-    $url = if ($env:XIM_PKGINDEX_URL) { $env:XIM_PKGINDEX_URL } else { 'https://github.com/d2learn/xim-pkgindex.git' }
+    $url = if ($env:XIM_PKGINDEX_URL) { $env:XIM_PKGINDEX_URL } else { 'https://github.com/openxlings/xim-pkgindex.git' }
     if (Test-Path $FIXTURE_INDEX_DIR) { Remove-Item -Recurse -Force $FIXTURE_INDEX_DIR }
     $parentDir = Split-Path $FIXTURE_INDEX_DIR
     New-Item -ItemType Directory -Force -Path $parentDir | Out-Null

--- a/tests/e2e/scenarios/linux_headers/.xlings.json
+++ b/tests/e2e/scenarios/linux_headers/.xlings.json
@@ -3,7 +3,7 @@
   "index_repos": [
     {
       "name": "xim",
-      "url": "https://github.com/d2learn/xim-pkgindex.git"
+      "url": "https://github.com/openxlings/xim-pkgindex.git"
     }
   ],
   "workspace": {

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -459,7 +459,7 @@ TEST(ConfigTest, ResolveRepoSourceFileScheme) {
 TEST(ConfigTest, ResolveRepoSourceRemoteUrlReturnsEmpty) {
     xlings::IndexRepo repo {
         .name = "xim",
-        .url = "https://github.com/d2learn/xim-pkgindex.git"
+        .url = "https://github.com/openxlings/xim-pkgindex.git"
     };
     EXPECT_TRUE(xlings::Config::resolve_repo_source(repo, false).empty());
     EXPECT_FALSE(xlings::Config::is_local_repo_source(repo, false));
@@ -1546,11 +1546,11 @@ TEST(XimSubReposTest, DiscoverSubReposFromLuaFile) {
     // Write a mock xim-indexrepos.lua
     std::string lua = R"(xim_indexrepos = {
     ["awesome"] = {
-        ["GLOBAL"] = "https://github.com/d2learn/xim-pkgindex-awesome.git",
+        ["GLOBAL"] = "https://github.com/openxlings/xim-pkgindex-awesome.git",
         ["CN"] = "https://gitee.com/d2learn/xim-pkgindex-awesome.git",
     },
     ["scode"] = {
-        ["GLOBAL"] = "https://github.com/d2learn/xim-pkgindex-scode.git",
+        ["GLOBAL"] = "https://github.com/openxlings/xim-pkgindex-scode.git",
     }
 }
 )";
@@ -1565,10 +1565,10 @@ TEST(XimSubReposTest, DiscoverSubReposFromLuaFile) {
     for (auto& r : repos) {
         if (r.name == "awesome") {
             foundAwesome = true;
-            EXPECT_EQ(r.url, "https://github.com/d2learn/xim-pkgindex-awesome.git");
+            EXPECT_EQ(r.url, "https://github.com/openxlings/xim-pkgindex-awesome.git");
         } else if (r.name == "scode") {
             foundScode = true;
-            EXPECT_EQ(r.url, "https://github.com/d2learn/xim-pkgindex-scode.git");
+            EXPECT_EQ(r.url, "https://github.com/openxlings/xim-pkgindex-scode.git");
         }
     }
     EXPECT_TRUE(foundAwesome);
@@ -1581,7 +1581,7 @@ TEST(XimSubReposTest, DiscoverSubReposFromLuaFile) {
         if (r.name == "awesome") {
             EXPECT_EQ(r.url, "https://gitee.com/d2learn/xim-pkgindex-awesome.git");
         } else if (r.name == "scode") {
-            EXPECT_EQ(r.url, "https://github.com/d2learn/xim-pkgindex-scode.git");
+            EXPECT_EQ(r.url, "https://github.com/openxlings/xim-pkgindex-scode.git");
         }
     }
 
@@ -1602,8 +1602,8 @@ TEST(XimSubReposTest, DiscoverSubReposNoFile) {
 
 TEST(XimSubReposTest, SyncRepoUrlKeepsGithubOnCNMirror) {
     auto url = xlings::xim::sync_repo_url(
-        "https://github.com/d2learn/xim-pkgindex-awesome.git", "CN");
-    EXPECT_EQ(url, "https://github.com/d2learn/xim-pkgindex-awesome.git");
+        "https://github.com/openxlings/xim-pkgindex-awesome.git", "CN");
+    EXPECT_EQ(url, "https://github.com/openxlings/xim-pkgindex-awesome.git");
 }
 
 // ============================================================

--- a/tools/linux_release.sh
+++ b/tools/linux_release.sh
@@ -86,7 +86,7 @@ if command -v jq &>/dev/null && [[ -f config/xlings.json ]]; then
     config/xlings.json > "$OUT_DIR/.xlings.json"
 else
   cat > "$OUT_DIR/.xlings.json" << DOTJSON
-{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/d2learn/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
+{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/openxlings/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
 DOTJSON
 fi
 

--- a/tools/macos_release.sh
+++ b/tools/macos_release.sh
@@ -79,7 +79,7 @@ if command -v jq &>/dev/null && [[ -f config/xlings.json ]]; then
     config/xlings.json > "$OUT_DIR/.xlings.json"
 else
   cat > "$OUT_DIR/.xlings.json" << DOTJSON
-{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/d2learn/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
+{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/openxlings/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
 DOTJSON
 fi
 

--- a/tools/other/quick_install.ps1
+++ b/tools/other/quick_install.ps1
@@ -1,5 +1,5 @@
 # One-line installer for xlings (Windows).
-#   powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.ps1 | iex"
+#   powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1 | iex"
 #Requires -Version 5
 
 param(
@@ -14,7 +14,7 @@ function Log-Info  { param([string]$Msg) Write-Host "[xlings]: $Msg" -Foreground
 function Log-Warn  { param([string]$Msg) Write-Host "[xlings]: $Msg" -ForegroundColor Yellow }
 function Log-Error { param([string]$Msg) Write-Host "[xlings]: $Msg" -ForegroundColor Red }
 
-$GITHUB_REPO = "d2learn/xlings"
+$GITHUB_REPO = "openxlings/xlings"
 $GITHUB_MIRROR = $env:XLINGS_GITHUB_MIRROR
 
 # --------------- banner ---------------
@@ -30,7 +30,7 @@ Write-Host @"
                             __/ |
                            |___/
 
-repo:  https://github.com/d2learn/xlings
+repo:  https://github.com/openxlings/xlings
 forum: https://forum.d2learn.org
 
 "@ -ForegroundColor Cyan

--- a/tools/other/quick_install.sh
+++ b/tools/other/quick_install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # One-line installer for xlings (Linux / macOS).
-#   curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
 
 set -euo pipefail
 
@@ -16,7 +16,7 @@ log_error() { echo -e "${RED}[xlings]:${RESET} $1"; }
 
 trap 'log_error "Interrupted"; exit 1' INT TERM
 
-GITHUB_REPO="d2learn/xlings"
+GITHUB_REPO="openxlings/xlings"
 GITHUB_MIRROR="${XLINGS_GITHUB_MIRROR:-}"
 
 # Specify version: curl ... | bash -s -- v0.5.0
@@ -72,7 +72,7 @@ cat << 'EOF'
                             __/ |
                            |___/
 
-repo:  https://github.com/d2learn/xlings
+repo:  https://github.com/openxlings/xlings
 forum: https://forum.d2learn.org
 
 EOF

--- a/tools/windows_release.ps1
+++ b/tools/windows_release.ps1
@@ -69,7 +69,7 @@ if (Test-Path $configSrc) {
   $base | ConvertTo-Json -Depth 10 -Compress | Set-Content "$OUT_DIR\.xlings.json" -Encoding UTF8
 } else {
   @"
-{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/d2learn/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
+{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/openxlings/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
 "@ | Set-Content "$OUT_DIR\.xlings.json" -Encoding UTF8
 }
 


### PR DESCRIPTION
## Summary
- update xlings runtime/config/docs/CI/release references from d2learn GitHub owner to openxlings
- keep d2x-series repositories, xlings-project-templates, xlings.d2learn.org, and forum.d2learn.org out of this migration scope
- add migration audit coverage and post-transfer reference migration reports

## Validation
- `bash tests/e2e/github_owner_migration_audit.sh`
- `git diff --check main..HEAD`
- `jq -e . config/xlings.json`
- `jq -e . tests/e2e/scenarios/linux_headers/.xlings.json`
- `bash -n tools/other/quick_install.sh tools/linux_release.sh tools/macos_release.sh tests/e2e/prepare_fixture_index.sh tests/e2e/release_quick_install_test.sh tests/e2e/mirror_fallback_test.sh tests/e2e/github_owner_migration_audit.sh`

## Notes
- `d2x`, `xim-pkgindex-d2x`, and `xlings-project-templates` remain external d2learn repositories.