### PR TITLE
release: 0.4.15 — HEAD-fallback download cache + os.dirs glob fix

### DIFF
--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -2,6 +2,17 @@
 
 ## 2026
 
+### 2026-05 (v0.4.15)
+
+- **下载缓存：sha256 缺失时改用 HEAD 探测，不再每次重下 (#TBD)**
+  - `src/core/xim/downloader.cppm`：包索引中只声明 `url` 不声明 `sha256` 的条目（fixture 索引里约 8%；实际 `node.lua` / `nvm.lua` 之类 `_linux_url` helper 拼出来的 URL 占比更高）原来每次 `xlings install` 都会重下整包。新增 HEAD-fallback 缓存路径：`fs::file_size` 与服务端 `Content-Length` 比对 + `<destFile>.meta` sidecar 记录的 `Last-Modified` / `ETag` 与本次 HEAD 响应比对，命中则跳过下载。HEAD 失败（离线/服务端拒 HEAD）回退"文件存在即信"，airline-friendly。
+  - sha256 路径在不匹配时主动 `fs::remove` 旧文件，预防将来 tinyhttps 启用 Range/resume 时拼出腐烂文件。
+  - `src/libs/tinyhttps.cppm`：`query_remote_meta()` 返回完整 `RemoteFileMeta { contentLength, lastModified, etag, ... }`；老的 `query_content_length()` 改成薄包装。
+  - `tests/unit/test_main.cpp::XimDownloaderTest::MetaSidecarRoundTrip` 锁定写入 + 读取 + 缺失 + 畸形行容错。
+
+- **bump：mcpplibs-xpkg 0.0.37 → 0.0.38**
+  - 带入 libxpkg 的 `os.dirs` glob 修复（POSIX 下 `ls -d "<pat>"` 双引号会让 shell 跳过 glob 展开，导致 `os.dirs("…/v*")` 静默返回空表）。
+
 ### 2026-04 (v0.4.3)
 
 - **下载器：自动识别系统代理 (#222)**

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.14";
+    static constexpr std::string_view VERSION = "0.4.15";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/downloader.cppm
+++ b/src/core/xim/downloader.cppm
@@ -22,6 +22,52 @@ bool is_git_url(const std::string& url) {
     return url.ends_with(".git");
 }
 
+// ── Sidecar (.meta) helpers for HEAD-based cache freshness ────────────
+//
+// When a package recipe omits sha256 (~8% of pkgindex entries declare a
+// URL but no checksum), we can't verify a cached file by hash. Instead
+// we save the server-reported Last-Modified / ETag next to the file in
+// a tiny <name>.meta sidecar and use it on the next install to decide
+// whether to reuse the cached payload.
+//
+// Format: one "key: value" per line, only `last-modified` and `etag`
+// recognized. Anything else is ignored. Missing sidecar = no metadata.
+struct MetaSidecar_ {
+    std::string lastModified;
+    std::string etag;
+};
+
+std::optional<MetaSidecar_> read_meta_sidecar_(const std::filesystem::path& p) {
+    std::ifstream in(p);
+    if (!in) return std::nullopt;
+    MetaSidecar_ m;
+    std::string line;
+    while (std::getline(in, line)) {
+        auto colon = line.find(':');
+        if (colon == std::string::npos) continue;
+        std::string key = line.substr(0, colon);
+        std::string val = line.substr(colon + 1);
+        // trim
+        auto trim = [](std::string& s) {
+            while (!s.empty() && (s.front() == ' ' || s.front() == '\t' || s.front() == '\r')) s.erase(s.begin());
+            while (!s.empty() && (s.back()  == ' ' || s.back()  == '\t' || s.back()  == '\r')) s.pop_back();
+        };
+        trim(key); trim(val);
+        for (auto& c : key) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        if (key == "last-modified") m.lastModified = std::move(val);
+        else if (key == "etag")     m.etag = std::move(val);
+    }
+    return m;
+}
+
+void write_meta_sidecar_(const std::filesystem::path& p,
+                         const tinyhttps::RemoteFileMeta& meta) {
+    std::ofstream out(p, std::ios::trunc);
+    if (!out) return;
+    if (!meta.lastModified.empty()) out << "last-modified: " << meta.lastModified << "\n";
+    if (!meta.etag.empty())         out << "etag: "          << meta.etag         << "\n";
+}
+
 // Derive the destination directory name from a git URL, e.g.
 // "https://github.com/user/repo.git" -> "repo" (or task.name fallback).
 std::string git_dest_repo_name_(const std::string& url, const std::string& fallback) {
@@ -189,16 +235,80 @@ DownloadResult download_one(const DownloadTask& task,
     if (filename.empty()) filename = task.name + ".download";
 
     auto destFile = task.destDir / filename;
+    auto sidecarPath = destFile;
+    sidecarPath += ".meta";
     result.localFile = destFile;
 
-    // Skip if already downloaded and SHA matches
+    // ── Cache hit path 1: sha256 verified (cheapest, most reliable) ──
+    // If the recipe declares a sha256 and the on-disk file matches, we're
+    // byte-identical to upstream — skip download outright.
     if (fs::exists(destFile) && !task.sha256.empty()) {
         auto cmd = std::format("sha256sum \"{}\"", destFile.string());
         auto [rc, output] = platform::run_command_capture(cmd);
         if (rc == 0 && output.find(task.sha256) != std::string::npos) {
-            log::debug("already downloaded: {}", destFile.string());
+            log::debug("already downloaded (sha256): {}", destFile.string());
             result.success = true;
             return result;
+        }
+        // sha mismatch: stale/corrupt cache. Remove before falling through
+        // so the next download_to_file starts from a clean slate (defends
+        // against a future tinyhttps that might enable Range/resume).
+        fs::remove(destFile, ec);
+    }
+
+    // ── Cache hit path 2: HEAD-based freshness (when sha256 is unset) ──
+    // Trade a tiny HEAD round-trip for not re-downloading toolchain-sized
+    // payloads on every `xlings install`. We only consult this when the
+    // recipe omits sha256 — otherwise path 1 already decided.
+    tinyhttps::RemoteFileMeta probedMeta;
+    bool probedMetaValid = false;
+    if (fs::exists(destFile) && task.sha256.empty()) {
+        probedMeta = tinyhttps::query_remote_meta(task.url);
+        probedMetaValid = true;
+
+        if (probedMeta.ok) {
+            std::error_code sec;
+            auto localSize = static_cast<std::int64_t>(fs::file_size(destFile, sec));
+            std::string storedLM, storedETag;
+            if (auto stored = read_meta_sidecar_(sidecarPath)) {
+                storedLM   = std::move(stored->lastModified);
+                storedETag = std::move(stored->etag);
+            }
+            bool sizeMatch = (probedMeta.contentLength > 0)
+                          && (localSize == probedMeta.contentLength);
+            // Strong freshness signal: server's Last-Modified or ETag
+            // matches what we recorded the last time we downloaded.
+            bool freshMatch =
+                (!probedMeta.lastModified.empty() && probedMeta.lastModified == storedLM)
+             || (!probedMeta.etag.empty()         && probedMeta.etag         == storedETag);
+            // Weak signal: no sidecar (legacy file from before this code),
+            // but the size matches what the server reports right now.
+            bool weakMatch = sizeMatch && storedLM.empty() && storedETag.empty();
+
+            if (sizeMatch && (freshMatch || weakMatch)) {
+                log::debug("already downloaded (HEAD cache hit, size={}): {}",
+                           localSize, destFile.string());
+                result.success = true;
+                return result;
+            }
+            // Stale: drop both file and sidecar before re-downloading.
+            fs::remove(destFile, ec);
+            fs::remove(sidecarPath, ec);
+        } else {
+            // HEAD failed (offline, server blocks HEAD, 4xx, etc.). If we
+            // already have a non-empty cached file, prefer it over failing
+            // — being airline-friendly is worth the small risk of serving
+            // a stale payload when sha256 is unset.
+            std::error_code sec;
+            auto localSize = fs::file_size(destFile, sec);
+            if (!sec && localSize > 0) {
+                log::warn("HEAD probe failed for {} ({}); using cached file: {}",
+                          task.url,
+                          probedMeta.error.empty() ? "unknown" : probedMeta.error,
+                          destFile.string());
+                result.success = true;
+                return result;
+            }
         }
     }
 
@@ -247,6 +357,17 @@ DownloadResult download_one(const DownloadTask& task,
             result.error = std::format("SHA256 mismatch for {}", task.name);
             fs::remove(destFile, ec);
             return result;
+        }
+    } else {
+        // No sha256 declared: persist server-reported Last-Modified / ETag
+        // alongside the payload so the next install can use a HEAD probe
+        // to decide cache freshness instead of re-downloading.
+        if (!probedMetaValid) {
+            probedMeta = tinyhttps::query_remote_meta(task.url);
+            probedMetaValid = true;
+        }
+        if (probedMeta.ok && (!probedMeta.lastModified.empty() || !probedMeta.etag.empty())) {
+            write_meta_sidecar_(sidecarPath, probedMeta);
         }
     }
 

--- a/src/libs/tinyhttps.cppm
+++ b/src/libs/tinyhttps.cppm
@@ -23,12 +23,27 @@ struct DownloadFileResult {
     std::string error;
 };
 
+// Result of a HEAD probe used by the cache to decide whether a previously
+// downloaded file is still current. `ok` is true only when the server
+// returned a 2xx response — header fields may still be empty if the
+// server omitted them, in which case callers should fall back to other
+// signals (e.g. file existence) rather than re-downloading blindly.
+struct RemoteFileMeta {
+    bool ok { false };
+    int statusCode { 0 };
+    std::int64_t contentLength { -1 };  // -1 if header missing/unparseable
+    std::string lastModified;           // RFC 1123 string, empty if missing
+    std::string etag;                   // empty if missing
+    std::string error;
+};
+
 void global_init();
 void global_cleanup();
 DownloadFileResult download_file(const DownloadOptions& opts);
 double probe_latency(const std::string& url, int timeoutMs = 2000);
 bool fetch_to_file(const std::string& url, const std::filesystem::path& dest);
 std::int64_t query_content_length(const std::string& url, int connectTimeoutSec = 10);
+RemoteFileMeta query_remote_meta(const std::string& url, int connectTimeoutSec = 10);
 
 // Returns the proxy URL that would be used for `url` (libcurl-style env
 // resolution: HTTPS_PROXY / HTTP_PROXY / ALL_PROXY with NO_PROXY exemption,
@@ -232,7 +247,8 @@ bool fetch_to_file(const std::string& url, const std::filesystem::path& dest) {
     return download_file(o).success;
 }
 
-std::int64_t query_content_length(const std::string& url, int connectTimeoutSec) {
+RemoteFileMeta query_remote_meta(const std::string& url, int connectTimeoutSec) {
+    RemoteFileMeta meta;
     global_init();
     auto client = detail_::make_client(connectTimeoutSec, /*readTimeoutSec=*/60, url);
 
@@ -242,18 +258,34 @@ std::int64_t query_content_length(const std::string& url, int connectTimeoutSec)
     req.headers["User-Agent"] = "xlings/1.0";
 
     auto resp = client.send(req);
+    meta.statusCode = resp.statusCode;
 
-    if (!resp.ok()) return -1;
+    if (!resp.ok()) {
+        meta.error = resp.statusText.empty()
+            ? std::format("HTTP {}", resp.statusCode)
+            : std::format("HTTP {} {}", resp.statusCode, resp.statusText);
+        return meta;
+    }
 
-    // Case-insensitive content-length lookup
+    // Case-insensitive header lookup
     for (auto& [k, v] : resp.headers) {
         std::string lower = k;
         for (auto& c : lower) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
         if (lower == "content-length") {
-            try { return std::stoll(v); } catch (...) { return -1; }
+            try { meta.contentLength = std::stoll(v); } catch (...) { meta.contentLength = -1; }
+        } else if (lower == "last-modified") {
+            meta.lastModified = v;
+        } else if (lower == "etag") {
+            meta.etag = v;
         }
     }
-    return -1;
+    meta.ok = true;
+    return meta;
+}
+
+std::int64_t query_content_length(const std::string& url, int connectTimeoutSec) {
+    auto meta = query_remote_meta(url, connectTimeoutSec);
+    return meta.ok ? meta.contentLength : -1;
 }
 
 } // namespace xlings::tinyhttps

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -686,6 +686,46 @@ TEST(XimDownloaderTest, DownloadAllEmpty) {
     EXPECT_TRUE(results.empty());
 }
 
+// HEAD-based cache sidecar (used when sha256 is unset). Round-trips a
+// minimal sidecar through the writer + parser and verifies missing-file
+// and malformed-line handling.
+TEST(XimDownloaderTest, MetaSidecarRoundTrip) {
+    namespace fs = std::filesystem;
+    auto tmp = fs::temp_directory_path() / "xim_meta_sidecar_test";
+    fs::create_directories(tmp);
+    auto path = tmp / "payload.tar.gz.meta";
+    fs::remove(path);
+
+    xlings::tinyhttps::RemoteFileMeta meta;
+    meta.ok = true;
+    meta.lastModified = "Wed, 21 Oct 2015 07:28:00 GMT";
+    meta.etag = "\"abc123\"";
+
+    xlings::xim::write_meta_sidecar_(path, meta);
+    auto roundtrip = xlings::xim::read_meta_sidecar_(path);
+    ASSERT_TRUE(roundtrip.has_value());
+    EXPECT_EQ(roundtrip->lastModified, meta.lastModified);
+    EXPECT_EQ(roundtrip->etag, meta.etag);
+
+    fs::remove(path);
+    EXPECT_FALSE(xlings::xim::read_meta_sidecar_(path).has_value());
+
+    // Malformed input: extra colons, blank lines, unknown keys all ignored
+    {
+        std::ofstream out(path);
+        out << "\n";
+        out << "x-custom: ignored\n";
+        out << "Last-Modified: Mon, 01 Jan 2024 00:00:00 GMT\n";
+        out << "no-colon-line\n";
+    }
+    auto m2 = xlings::xim::read_meta_sidecar_(path);
+    ASSERT_TRUE(m2.has_value());
+    EXPECT_EQ(m2->lastModified, "Mon, 01 Jan 2024 00:00:00 GMT");
+    EXPECT_TRUE(m2->etag.empty());
+
+    fs::remove_all(tmp);
+}
+
 // ============================================================
 // xim installer tests
 // ============================================================

--- a/xmake.lua
+++ b/xmake.lua
@@ -42,7 +42,7 @@ add_requires("mcpplibs-capi-lua")
 if has_config("local_libxpkg") and get_config("local_libxpkg") ~= "" then
     includes(path.join(get_config("local_libxpkg"), "xmake.lua"))
 else
-    add_requires("mcpplibs-xpkg 0.0.37")
+    add_requires("mcpplibs-xpkg 0.0.38")
 end
 add_requires("gtest 1.15.2")
 add_requires("mcpplibs-tinyhttps 0.2.0")


### PR DESCRIPTION
## Summary

Two compounding download-cache bugs the user reported as "最近感觉好像有问题".

1. **Download cache silently re-downloaded every install when sha256 is unset.** The cache check was `fs::exists(destFile) && !task.sha256.empty()` — recipes that declare `url` but no `sha256` (about 8% of fixture pkgindex; more in the real index where `_linux_url(version)` helpers synthesize URLs without a matching hash) re-fetched the entire payload on every `xlings install`.
2. **`os.dirs("…/v*")` returned empty on POSIX.** The libxpkg shim shelled out as `ls -d "<pattern>" 2>/dev/null` — the surrounding double quotes made the shell skip glob expansion, so `os.dirs("/tmp/x/cuda_v*")` looked for a file literally named `cuda_v*`. Fixed in libxpkg #15 / v0.0.38, brought in via the dep bump below.

## Changes

### Download cache (xlings)

`src/core/xim/downloader.cppm`:
- **Path 1 (sha256 known)** unchanged behavior on hit; on mismatch we now `fs::remove` the stale file before falling through, so a future tinyhttps Range/resume mode can't splice old bytes onto new content.
- **Path 2 (NEW, sha256 empty)**: HEAD-probe → compare local file size to `Content-Length`, cross-check `Last-Modified` / `ETag` against a `<destFile>.meta` sidecar we write after each download. Match → skip. HEAD failure → trust the existing non-empty file rather than wasting bandwidth (airline-friendly).
- After a no-sha256 download, persist server-reported `Last-Modified` / `ETag` to the sidecar so the next install has something to compare against.

`src/libs/tinyhttps.cppm`:
- New `RemoteFileMeta { contentLength, lastModified, etag, ok, statusCode, error }` + `query_remote_meta()` returning all three header fields from one HEAD. `query_content_length()` reduces to a thin wrapper (same semantics, no API break).

`tests/unit/test_main.cpp::XimDownloaderTest::MetaSidecarRoundTrip`:
- Round-trip + missing-file + malformed-line tolerance for the sidecar parser.

### Dep bump

`xmake.lua`: `mcpplibs-xpkg 0.0.37` → `0.0.38`.

`mcpplibs/mcpplibs-index#8` is already merged with the new sha256 entry.

### Behavior comparison

|                     | sha256 declared | sha256 empty               |
| ------------------- | --------------- | -------------------------- |
| **Before**          | hash-verify, skip if match (correct) | re-download every install  |
| **After**           | hash-verify, skip if match (unchanged) | HEAD probe + sidecar; skip if size + Last-Modified / ETag match |

## Test plan

- [x] `xmake build xlings_tests` clean (mcpplibs-xpkg 0.0.38 resolves)
- [x] `xmake run xlings_tests` — 216/220 pass, 4 pre-existing skips
- [x] New `XimDownloaderTest::MetaSidecarRoundTrip` exercises the parser/writer
- [x] Local shell sanity check on the libxpkg `os.dirs` fix: `ls -d /tmp/x/cuda_v*` now globs, escaped-space `/tmp/x\ space/cuda_v*` still resolves
- [ ] CI green (linux + macos + windows)

## Related

- libxpkg openxlings/libxpkg#15 → v0.0.38
- mcpplibs/mcpplibs-index#8 (merged)