### PR TITLE
fix(remove): refuse to "remove" a version that isn't installed (remove-loop regression)

### DIFF
--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -408,22 +408,46 @@ int cmd_remove(const std::string& target, bool yes, EventStream& stream) {
         auto bareName = target.substr(target.rfind(':') + 1);
         auto active = xvm::get_active_version(
             Config::effective_workspace(), bareName);
+        // Fall back to "any installed version" when the active binding
+        // has been cleared. The catalog's default version pick is the
+        // recipe's highest *declared* version, which may not match what's
+        // on disk. Before this fallback, a sequence like
+        //
+        //     xlings remove d2x        # detaches active binding
+        //     xlings use d2x           # error: 'd2x' not in version DB
+        //     xlings remove d2x        # ← still picks declared 0.1.4!
+        //
+        // would loop forever: each subsequent remove re-resolved to the
+        // recipe's latest, hit `installer.uninstall` as a no-op (xvm DB
+        // already empty, payload dir already gone), and printed
+        // "✓ removed" anyway. Picking from the xvm DB instead anchors
+        // the resolution to reality.
+        if (active.empty()) {
+            const auto* vinfo = xvm::get_vinfo(Config::versions(), bareName);
+            if (vinfo && !vinfo->versions.empty()) {
+                active = xvm::pick_highest_version(vinfo->versions);
+            }
+        }
         if (!active.empty()) {
             resolveTarget = target + "@" + active;
         }
     }
-    bool resolvedToDefiniteVersion = (resolveTarget.find('@') != std::string::npos);
 
     auto match = catalog.resolve_target(resolveTarget, detect_platform());
     if (match) {
         displayName = match->canonicalName;
         displayVersion = match->version;
-        // Only short-circuit "not installed" when the resolution is
-        // unambiguous (user pinned, or matches the active version).
-        // Otherwise the catalog may have picked the highest *declared*
-        // version, which can differ from what's actually installed —
-        // let installer.uninstall handle that path.
-        if (!match->installed && resolvedToDefiniteVersion) {
+        // Refuse to "remove" a version whose payload isn't on disk. The
+        // earlier version of this check only fired when the user pinned
+        // a version — under the theory that installer.uninstall would
+        // resolve the mismatch when the catalog had picked a non-installed
+        // version on its own. It does not. uninstall runs through the
+        // motions (xvm ops over an already-empty DB, fs::remove_all over
+        // a non-existent dir) and reports success, which loops the user.
+        // The xvm-DB fallback above already anchors resolution to a real
+        // installed version when one exists, so reaching here with
+        // `!installed` means nothing is installed for this target.
+        if (!match->installed) {
             log::warn("{}@{} is not installed", displayName, displayVersion);
             return 0;
         }

--- a/tests/e2e/remove_multi_version_test.sh
+++ b/tests/e2e/remove_multi_version_test.sh
@@ -232,4 +232,44 @@ PY
 [[ ! -e "$SHIM_PATH" ]] \
   || fail "S3: shim should be removed when the last version is uninstalled"
 
-log "PASS: remove-multi-version scenarios 1, 2, 3"
+# ── Scenario 4: remove after fully uninstalled — must NOT loop ─────────────
+# Regression for the bug where, after the last version was removed, the next
+# `xlings remove rm-fixture` (no version) re-resolved to the recipe's highest
+# *declared* version (e.g. 3.0.0), ran installer.uninstall as a no-op (xvm DB
+# already empty, payload dir already gone), and printed "✓ removed" anyway —
+# trapping the user in a remove loop with stale UI claiming a version was
+# uninstalled that wasn't even installed.
+log "Scenario 4: remove rm-fixture after full uninstall (regression: must not loop)"
+
+set +e
+out=$(RUN remove rm-fixture -y 2>&1)
+rc=$?
+set -e
+
+# The command must exit cleanly (we treat "nothing to do" as success, not an
+# error — matches the existing pattern for `xlings remove <pinned-version>`
+# when that version isn't installed) but it MUST NOT print the success
+# summary, and the DB / workspace / store must still be empty.
+[[ $rc -eq 0 ]] || fail "S4: remove after full uninstall should exit 0; got $rc (output: $out)"
+
+if grep -qE "removed.*subos" <<<"$out"; then
+  fail "S4: 'removed' summary printed for a package that isn't installed; output: $out"
+fi
+grep -qE "not installed" <<<"$out" \
+  || fail "S4: expected 'not installed' diagnostic; got: $out"
+
+python3 - "$HOME_DIR" <<'PY' || fail "S4 state should remain fully cleared"
+import json, sys, pathlib
+home = sys.argv[1]
+data = json.loads(pathlib.Path(home, ".xlings.json").read_text())
+assert "rm-fixture" not in (data.get("versions") or {}), \
+    "S4: versions DB should still be empty for rm-fixture"
+ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
+assert "rm-fixture" not in (ws.get("workspace") or {}), \
+    "S4: workspace should still be empty for rm-fixture"
+PY
+
+[[ ! -d "$STORE_DIR" ]] || [[ -z "$(ls -A "$STORE_DIR" 2>/dev/null)" ]] \
+  || fail "S4: store dir should remain absent or empty after no-op remove"
+
+log "PASS: remove-multi-version scenarios 1, 2, 3, 4"


### PR DESCRIPTION
## Bug report (user)

```
xlings remove d2x          # ✓ xim:d2x@0.1.2 removed
xlings remove d2x          # ✓ xim:d2x@0.1.4 removed   ← still finds 0.1.4!
xlings remove d2x          # ✓ xim:d2x@0.1.4 removed
xlings remove d2x          # ✓ xim:d2x@0.1.4 removed
xlings use d2x
[error] 'd2x' not found in version database
xlings remove d2x          # ✓ xim:d2x@0.1.4 removed   ← STILL!
```

`xlings use d2x` correctly reports the package is gone, but `xlings remove d2x` cheerfully "removes" the same `0.1.4` over and over. The user can run this loop indefinitely.

## Root cause

`cmd_remove` in `src/core/xim/commands.cppm`:

1. When the user did not pin a version (`xlings remove d2x`), the active binding lookup returns empty (cleared by the previous remove). `resolveTarget` is then passed unpinned to the catalog.

2. The catalog's default is the **recipe's highest declared version** (`select_version_` in `catalog.cppm` — `latest` ref → highest declared otherwise). That has no relation to what's installed on disk. So `match.version = "0.1.4"` no matter how many times you've removed it.

3. The "not installed" guard was gated on `resolvedToDefiniteVersion` — i.e., it only fired when the user explicitly pinned a version. The justification was "let `installer.uninstall` sort out the mismatch when the catalog picked the wrong version."

4. `installer.uninstall` doesn't sort it out: it runs through the motions over an already-empty xvm DB and a missing payload dir, and reports success.

End result: the success path printed `✓ xim:d2x@0.1.4 removed` for a package that wasn't installed.

## Fix

Two changes in `cmd_remove`:

- **Resolve to an installed version, not a declared one.** When the active binding is empty, fall back to the xvm DB's installed-versions list (`xvm::get_vinfo` + `xvm::pick_highest_version`) before letting the catalog pick its declared latest. `pick_highest_version` is the same helper `installer.cppm` already uses on the auto-switch-after-remove path.
- **Drop the `resolvedToDefiniteVersion` gate** on the "not installed" guard. With the new resolution path, reaching it means nothing is installed under this name — the gate's justification ("uninstall will sort it out") was always wrong, and is now also redundant.

## Regression test

`tests/e2e/remove_multi_version_test.sh` already exercises Scenarios 1-3 (active removal, non-active removal, last-version removal). Added Scenario 4: after Scenario 3 has fully uninstalled `rm-fixture`, run `xlings remove rm-fixture` again and assert:

- exit code 0 (we treat "nothing to do" as success — same shape as the existing pinned-but-not-installed path)
- "not installed" diagnostic in stderr/stdout
- **no** `✓ removed` summary
- DB / workspace / store remain empty

Verified the test **fails** on the un-fixed binary — it prints `✓ xim:rm-fixture@3.0.0 removed (subos: default)` for an already-uninstalled package, exactly matching the user's report.

## Test plan

- [x] `xmake build xlings_tests` clean
- [x] `xmake run xlings_tests` — 216/220 pass, 4 pre-existing skips
- [x] `bash tests/e2e/remove_multi_version_test.sh` — all 4 scenarios pass
- [x] Reverted the cmd_remove patch and re-ran the e2e — Scenario 4 fails as expected (proves the regression test bites)
- [ ] CI green (linux + macos + windows)