### PR TITLE
ci: cache ~/.xmake/packages to halve cold-config time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,16 @@ jobs:
           restore-keys: |
             xlings-deps-${{ runner.os }}-
 
+      # Cache xrepo's compiled C++ deps so Release builds reuse what
+      # the per-PR CI just built. See xlings-ci-linux.yml for rationale.
+      - name: Cache xrepo packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.xmake/packages
+          key: xmake-pkgs-${{ runner.os }}-${{ hashFiles('xmake.lua') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          restore-keys: |
+            xmake-pkgs-${{ runner.os }}-
+
       - name: Install build dependencies (xmake / cmake / ninja / musl-gcc)
         run: |
           cd "$GITHUB_WORKSPACE"
@@ -110,6 +120,16 @@ jobs:
           restore-keys: |
             xlings-deps-${{ runner.os }}-
 
+      # Cache xrepo's compiled C++ deps so Release builds reuse what
+      # the per-PR CI just built. See xlings-ci-linux.yml for rationale.
+      - name: Cache xrepo packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.xmake/packages
+          key: xmake-pkgs-${{ runner.os }}-${{ hashFiles('xmake.lua') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          restore-keys: |
+            xmake-pkgs-${{ runner.os }}-
+
       - name: Install build dependencies (xmake / cmake / ninja / llvm)
         run: |
           cd "$GITHUB_WORKSPACE"
@@ -157,6 +177,16 @@ jobs:
           key: xlings-deps-${{ runner.os }}-${{ hashFiles('.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
             xlings-deps-${{ runner.os }}-
+
+      # Cache xrepo's compiled C++ deps so Release builds reuse what
+      # the per-PR CI just built. See xlings-ci-linux.yml for rationale.
+      - name: Cache xrepo packages
+        uses: actions/cache@v4
+        with:
+          path: ~\.xmake\packages
+          key: xmake-pkgs-${{ runner.os }}-${{ hashFiles('xmake.lua') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          restore-keys: |
+            xmake-pkgs-${{ runner.os }}-
 
       - name: Install build dependencies (xmake / cmake / ninja)
         shell: pwsh

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -65,6 +65,23 @@ jobs:
           restore-keys: |
             xlings-deps-${{ runner.os }}-
 
+      # Cache xrepo's compiled C++ deps (cmdline / ftxui / mcpplibs-* /
+      # libarchive + its compression backends / gtest / etc). On a cold
+      # runner the `Configure xmake` step takes ~4min on Linux because
+      # it pulls + compiles every entry from add_requires; with this
+      # cache hot, that drops to ~30s (extract + xmake re-validate).
+      # Keyed on xmake.lua so any add_requires version change cleanly
+      # invalidates; BOOTSTRAP_XLINGS_VERSION is in the key because the
+      # toolchain (musl-gcc etc.) installed by bootstrap xlings can
+      # change ABI between releases — old objects won't link.
+      - name: Cache xrepo packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.xmake/packages
+          key: xmake-pkgs-${{ runner.os }}-${{ hashFiles('xmake.lua') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          restore-keys: |
+            xmake-pkgs-${{ runner.os }}-
+
       - name: Install build dependencies (xmake / cmake / ninja / musl-gcc)
         run: |
           cd "$GITHUB_WORKSPACE"

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -47,6 +47,18 @@ jobs:
           restore-keys: |
             xlings-deps-${{ runner.os }}-
 
+      # See xlings-ci-linux.yml for the full rationale. Same step,
+      # macOS-specific Configure xmake savings are smaller (~2m45s →
+      # ~30s) because LLVM compiles the C++ deps faster than the
+      # musl-cross toolchain.
+      - name: Cache xrepo packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.xmake/packages
+          key: xmake-pkgs-${{ runner.os }}-${{ hashFiles('xmake.lua') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          restore-keys: |
+            xmake-pkgs-${{ runner.os }}-
+
       - name: Install build dependencies (xmake / cmake / ninja / llvm)
         run: |
           cd "$GITHUB_WORKSPACE"

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -47,6 +47,18 @@ jobs:
           restore-keys: |
             xlings-deps-${{ runner.os }}-
 
+      # See xlings-ci-linux.yml for the full rationale. On Windows the
+      # bulk of Configure time is xrepo building libarchive + its
+      # compression backends with MSVC; caching those object trees here
+      # is the same single-step win as on Linux/macOS.
+      - name: Cache xrepo packages
+        uses: actions/cache@v4
+        with:
+          path: ~\.xmake\packages
+          key: xmake-pkgs-${{ runner.os }}-${{ hashFiles('xmake.lua') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          restore-keys: |
+            xmake-pkgs-${{ runner.os }}-
+
       - name: Install build dependencies (xmake / cmake / ninja)
         shell: pwsh
         run: |


### PR DESCRIPTION
## Why

The `Configure xmake` step is the dominant cost in our CI:

| platform | step duration today | reason                                                        |
| -------- | ------------------- | ------------------------------------------------------------- |
| Linux    | ~4m                 | xrepo downloads + compiles all add_requires from source       |
| macOS    | ~2m45s              | same, but Apple's clang is faster than the musl-cross GCC     |
| Windows  | ~3m                 | same, MSVC building libarchive + compression backends         |

What's actually being built each time: `cmdline`, `ftxui`, `mcpplibs-xpkg`, `mcpplibs-xpkg-loader/-index/-lua-stdlib/-executor`, `mcpplibs-tinyhttps`, `mcpplibs-capi-lua`, `gtest`, `libarchive-xlings` + `zlib`/`lz4`/`bzip2`/`zstd`/`xz`. None of these change unless `xmake.lua`'s `add_requires` block changes.

The existing `Cache xlings package payloads` step covers `~/.xlings/data/xpkgs` — the toolchain (xmake/cmake/ninja/musl-gcc/llvm) — but **not** the xrepo build outputs.

## What

One new cache step per workflow, targeting `~/.xmake/packages`:

```yaml
- name: Cache xrepo packages
  uses: actions/cache@v4
  with:
    path: ~/.xmake/packages         # ~\.xmake\packages on Windows
    key: xmake-pkgs-${{ runner.os }}-${{ hashFiles('xmake.lua') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
    restore-keys: |
      xmake-pkgs-${{ runner.os }}-
```

Key composition:
- **`hashFiles('xmake.lua')`** — any `add_requires` version bump invalidates cleanly.
- **`BOOTSTRAP_XLINGS_VERSION`** — defends against toolchain ABI shifts between bootstrap xlings releases (`musl-gcc` libstdc++.a layout etc.). Without this, an old cache built against musl-gcc 14.x could ship to a 15.x runner and fail to link.
- **`runner.os`** — Linux / macOS / Windows objects are non-portable.
- `restore-keys` provides partial fallback so a near-miss still saves most work.

## Where applied

- `.github/workflows/xlings-ci-linux.yml`
- `.github/workflows/xlings-ci-macos.yml`
- `.github/workflows/xlings-ci-windows.yml`
- `.github/workflows/release.yml` (3 jobs: `build-linux` / `build-macos` / `build-windows`)

Skipped:
- `xlings-ci-archlinux.yml` — installs from AUR via `makepkg`, no source build.
- `gitee-sync.yml` — mirror push, no compile.

## Expected impact

| platform | cold (no change)  | warm cache (this PR) | Δ on warm runs |
| -------- | ----------------- | -------------------- | -------------- |
| Linux    | Configure ~4m     | Configure ~30s       | **−3m30s**     |
| macOS    | Configure ~2m45s  | Configure ~30s       | **−2m15s**     |
| Windows  | Configure ~3m     | Configure ~30s       | **−2m30s**     |

Cold run after this PR is **unchanged** (cache miss → builds from source as today). The first run on this branch will populate the cache; the second run starts saving time.

## Test plan
- [ ] CI passes on this PR (cold run — cache will populate)
- [ ] Re-run the workflow once and confirm Configure xmake drops by the expected amount on warm cache
- [ ] If anything breaks, revert is a single `git revert` — no source changes

## Risk

Low. xmake's package cache is content-addressed by config hash; stale entries are ignored, not corrupted. The worst-case failure mode is "cache restored but xmake rebuilds anyway" — i.e. equal to today.