### PR TITLE
release: 0.4.16 — fix xlings remove loop on already-uninstalled package

### DIFF
--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -2,6 +2,13 @@
 
 ## 2026
 
+### 2026-05 (v0.4.16)
+
+- **修复：对未安装的包再次 `xlings remove` 仍打印 "✓ removed" 的循环 (#266)**
+  - `src/core/xim/commands.cppm`：`cmd_remove` 在用户不带版本号、active 绑定又为空时,曾把解析降级到 catalog 配方里的"声明最高版本",再把 `!installed` 的判定门控在 `resolvedToDefiniteVersion` 上 —— 注释里那句"留给 installer.uninstall 处理"是错的,uninstall 在空 DB 上会跑完所有 no-op 仍报 success,把用户卡在重复卸载循环里。
+  - 修复双管齐下:active 为空时先回查 xvm DB(`xvm::pick_highest_version`,与 multi-version remove 的兜底复用同一函数);移除 `resolvedToDefiniteVersion` 守门,只要 catalog 解出的 match 不在磁盘上就 warn `"<pkg>@<ver> is not installed"` 并 exit 0,不再 emit `remove_summary`。
+  - `tests/e2e/remove_multi_version_test.sh` 加 Scenario 4:第三次卸完最后一个版本后再 `remove`,断言 exit 0、无 `removed.*subos` 摘要、有 `not installed` 诊断、DB / workspace / store 仍为空。
+
 ### 2026-05 (v0.4.15)
 
 - **下载缓存：sha256 缺失时改用 HEAD 探测，不再每次重下 (#TBD)**

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.15";
+    static constexpr std::string_view VERSION = "0.4.16";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 


### PR DESCRIPTION
## Summary

Patch release for the `xlings remove` regression reported in chat:

```
xlings remove d2x:d2mcpp        # actually removes
xlings remove d2x:d2mcpp        # prints "✓ removed" again
xlings remove d2x:d2mcpp        # …forever, with no real-world side effects
```

Picks up the only behavior change on main since v0.4.15 — PR #266 (`ded03a7`) — which fixes `cmd_remove` to refuse to claim success when the package isn't installed:

- when the active binding is empty, resolution falls back to xvm DB versions instead of the catalog's *declared* latest (which has nothing to do with what's on disk);
- `!match->installed` short-circuits unconditionally now, instead of only when the user pinned a version. The previous "let installer.uninstall handle that path" rationale was wrong: installer.uninstall walks an empty DB as no-ops and `fs::remove_all`s a non-existent directory (ENOENT, no warn), reporting success.

The other commit on main since 0.4.15 (`116eb87` PR #267) is a CI cache; no runtime effect on the built binary.

## Changes

- `src/core/config.cppm`: `VERSION = "0.4.15"` → `"0.4.16"`
- `.agents/docs/changelog.md`: v0.4.16 entry crediting #266 and pointing at Scenario 4 of `remove_multi_version_test.sh`

## Test plan

- [x] Local rebuild of main HEAD (`116eb87`)
- [x] `tests/e2e/remove_multi_version_test.sh` — Scenario 1/2/3/4 all pass; Scenario 4 is the explicit regression for the user's repro: third remove on an already-empty pkg returns 0, never prints `removed.*subos`, prints `not installed`, and DB / workspace / store stay empty.
- [ ] CI green on linux + macos + windows
- [ ] After merge, `Release` workflow_dispatch triggers and publishes `v0.4.16` artifacts (linux-x86_64.tar.gz, macosx-arm64.tar.gz, windows-x86_64.zip)