### PR TITLE
fix(0.4.17): save_workspace must not write to subos/_ under -g + anonymous project

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -896,14 +896,33 @@ public:
             if (!projectHomeDir.empty()) fs::create_directories(projectHomeDir);
             subosConfigPath = self.project_state_path_();
         } else {
-            // Use paths_.activeSubos (env-aware) rather than
-            // globalActiveSubos_ (~/.xlings.json snapshot). Without this
-            // honoring of XLINGS_ACTIVE_SUBOS, `xvm use` from inside a
-            // spawned subos shell writes back to the persistent default
-            // instead of the active env-resolved subos — the workspace
-            // change leaks to other shells. The load side (Config init)
-            // is symmetric.
-            subosConfigPath = self.paths_.homeDir / "subos" / self.paths_.activeSubos / ".xlings.json";
+            // useProject=false here — either no project config, or
+            // forceGlobalScope_ override is on (e.g. `xlings install -g`).
+            // Both paths mean "act on global scope, ignore project mode".
+            //
+            // We must NOT use paths_.activeSubos directly: when the user
+            // is inside an anonymous-project directory, paths_.activeSubos
+            // was set to "_" by update_effective_paths_ (the anonymous
+            // marker) and stays "_" even after forceGlobalScope_ flips
+            // useProject to false. Writing to `~/.xlings/subos/_/.xlings.json`
+            // (a directory that doesn't exist) then fails the workspace
+            // save — surfaced as `Failed to write file` during
+            // `xlings self install`'s patchelf-runtime-dep step (which
+            // spawns `xlings install -g`) when the user happens to run
+            // self install from inside an xlings repo / project tree.
+            //
+            // Compose the global-scope path from XLINGS_ACTIVE_SUBOS env
+            // (per-shell override) or globalActiveSubos_ (~/.xlings.json
+            // snapshot) — both are valid global-scope subos names whose
+            // directories exist on disk.
+            std::string global_name;
+            if (auto env = utils::get_env_or_default("XLINGS_ACTIVE_SUBOS");
+                !env.empty()) {
+                global_name = env;
+            } else {
+                global_name = self.globalActiveSubos_;
+            }
+            subosConfigPath = self.paths_.homeDir / "subos" / global_name / ".xlings.json";
         }
 
         nlohmann::json json;

--- a/src/core/xself/profile_resources.cppm
+++ b/src/core/xself/profile_resources.cppm
@@ -49,13 +49,17 @@ namespace xlings::xself::profile_resources {
 //   4 — prompt marker label tightened to [xsubos:<name>] for clarity
 //   5 — prompt marker uses ANSI color when terminal supports it
 //       (respects NO_COLOR and TERM=dumb opt-outs)
-//   6 — prompt marker uses inverted "tag" style (bold black on cyan
-//       background) so it visually separates from neighbouring prompt
-//       text instead of just blending in as colored letters
-export inline constexpr std::string_view kVersion = "6";
+//   6 — prompt marker tried inverted "tag pill" (bold black on cyan bg);
+//       too aggressive in real prompts, dropped in v7
+//   7 — prompt marker is foreground-only: brackets/label in default
+//       color, the subos name itself in bold green
+//   8 — prompt marker brackets/label tinted gray (slate-400) so they
+//       sit visually behind the bold-green subos name without leaving
+//       the marker as plain white text on the user's prompt line
+export inline constexpr std::string_view kVersion = "8";
 
 export inline constexpr std::string_view bash_sh =
-R"XPROFILE(# xlings-profile-version: 6
+R"XPROFILE(# xlings-profile-version: 8
 # Xlings Shell Profile (bash/zsh)
 
 _xlings_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." 2>/dev/null && pwd)"
@@ -91,12 +95,16 @@ if [ -n "${XLINGS_ACTIVE_SUBOS-}" ] && [ -n "${PS1-}" ]; then
         *"[xsubos:$XLINGS_ACTIVE_SUBOS]"*) ;;
         *)
             if [ -z "${NO_COLOR-}" ] && [ -n "${TERM-}" ] && [ "$TERM" != "dumb" ]; then
-                # Bold black fg on cyan bg — renders as a filled "tag" pill
-                # that sits visually apart from the rest of the prompt
-                # rather than blending in as another colored letter.
+                # Brackets / "xsubos:" label tinted gray (slate-400, the
+                # same `subos_ansi_::gray` used by the TUI renderers) so
+                # they recede; the subos name itself stays bold green so
+                # it's the visual focus.
                 _xlings_esc=$(printf '\033')
-                PS1="${_xlings_esc}[1;30;46m[xsubos:${XLINGS_ACTIVE_SUBOS}]${_xlings_esc}[0m ${PS1}"
-                unset _xlings_esc
+                _xlings_g="${_xlings_esc}[38;2;148;163;184m"
+                _xlings_n="${_xlings_esc}[1;32m"
+                _xlings_r="${_xlings_esc}[0m"
+                PS1="${_xlings_g}[xsubos:${_xlings_n}${XLINGS_ACTIVE_SUBOS}${_xlings_r}${_xlings_g}]${_xlings_r} ${PS1}"
+                unset _xlings_esc _xlings_g _xlings_n _xlings_r
             else
                 PS1="[xsubos:${XLINGS_ACTIVE_SUBOS}] ${PS1}"
             fi
@@ -106,7 +114,7 @@ fi
 )XPROFILE";
 
 export inline constexpr std::string_view fish =
-R"XPROFILE(# xlings-profile-version: 6
+R"XPROFILE(# xlings-profile-version: 8
 # Xlings Shell Profile (fish)
 
 set -l _script_dir (dirname (status filename))
@@ -135,10 +143,15 @@ if set -q XLINGS_ACTIVE_SUBOS
     function fish_prompt
         if set -q XLINGS_ACTIVE_SUBOS
             if not set -q NO_COLOR; and set -q TERM; and test "$TERM" != "dumb"
-                # Bold black on cyan background — "tag pill" style so the
-                # marker stands clearly apart from the rest of the prompt.
-                set_color --bold black --background cyan
-                echo -n "[xsubos:$XLINGS_ACTIVE_SUBOS]"
+                # Brackets / "xsubos:" label tinted slate-400 gray so they
+                # recede; subos name itself bold green so it's the focus.
+                set_color 94a3b8
+                echo -n "[xsubos:"
+                set_color --bold green
+                echo -n "$XLINGS_ACTIVE_SUBOS"
+                set_color normal
+                set_color 94a3b8
+                echo -n "]"
                 set_color normal
                 echo -n " "
             else
@@ -151,7 +164,7 @@ end
 )XPROFILE";
 
 export inline constexpr std::string_view pwsh =
-R"XPROFILE(# xlings-profile-version: 6
+R"XPROFILE(# xlings-profile-version: 8
 # Xlings Shell Profile (PowerShell)
 
 $env:XLINGS_HOME = (Resolve-Path "$PSScriptRoot\..\..").Path
@@ -176,10 +189,13 @@ if ($env:XLINGS_ACTIVE_SUBOS) {
     function global:prompt {
         $useColor = (-not $env:NO_COLOR) -and $env:TERM -ne 'dumb'
         if ($useColor) {
-            # Bold black fg on cyan bg — "tag pill" style so the marker
-            # stands clearly apart from the rest of the prompt.
+            # Brackets / "xsubos:" label tinted slate-400 gray so they
+            # recede; subos name itself bold green so it's the focus.
             $e = [char]27
-            Write-Host -NoNewline "$e[1;30;46m[xsubos:$($env:XLINGS_ACTIVE_SUBOS)]$e[0m "
+            $g = "$e[38;2;148;163;184m"
+            $n = "$e[1;32m"
+            $r = "$e[0m"
+            Write-Host -NoNewline "$g[xsubos:$n$($env:XLINGS_ACTIVE_SUBOS)$r$g]$r "
         } else {
             Write-Host -NoNewline "[xsubos:$($env:XLINGS_ACTIVE_SUBOS)] "
         }

--- a/src/ui/info_panel.cppm
+++ b/src/ui/info_panel.cppm
@@ -241,10 +241,14 @@ void print_subos_removed(const std::string& name) {
 // `▸ <verb> to subos <name>  (<modifier>)` template as `switched`; the
 // absence of a `[global]` tag is what tells the user this is a per-shell
 // action, not a persistent one.
+//
+// The subos NAME is rendered in bold green (matching the prompt marker
+// styling) so the user's eye lands on it; the rest of the line stays in
+// the magenta accent that distinguishes "spawn" from "switched" (cyan).
 void print_subos_entering(const std::string& name) {
     using namespace subos_ansi_;
-    std::println("{}  \xe2\x96\xb8 entering subos {}{}{}{}  (exit to leave){}",
-                 magenta, bold, name, reset, magenta, reset);
+    std::println("{}  \xe2\x96\xb8 entering subos {}{}{}{}{}  (exit to leave){}",
+                 magenta, green, bold, name, reset, magenta, reset);
 }
 
 // `xlings subos use <same>` while already in <same>: nothing happens, but

--- a/tests/e2e/subos_profile_upgrade_test.sh
+++ b/tests/e2e/subos_profile_upgrade_test.sh
@@ -28,11 +28,11 @@ run_xlings() {
 # ── 1. Fresh init produces a v2 profile ───────────────────────────────
 log "Scenario 1: fresh init writes v2 profile"
 run_xlings self init >/dev/null
-grep -q "^# xlings-profile-version: 6" "$HOME_DIR/config/shell/xlings-profile.sh" \
+grep -q "^# xlings-profile-version: 8" "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S1: bash profile missing version marker"
-grep -q "^# xlings-profile-version: 6" "$HOME_DIR/config/shell/xlings-profile.fish" \
+grep -q "^# xlings-profile-version: 8" "$HOME_DIR/config/shell/xlings-profile.fish" \
     || fail "S1: fish profile missing version marker"
-grep -q "^# xlings-profile-version: 6" "$HOME_DIR/config/shell/xlings-profile.ps1" \
+grep -q "^# xlings-profile-version: 8" "$HOME_DIR/config/shell/xlings-profile.ps1" \
     || fail "S1: pwsh profile missing version marker"
 
 # ── 2. Legacy profile (no marker) gets upgraded ───────────────────────
@@ -46,7 +46,7 @@ case ":$PATH:" in
 esac
 EOF
 run_xlings self init >/dev/null
-grep -q "^# xlings-profile-version: 6" "$HOME_DIR/config/shell/xlings-profile.sh" \
+grep -q "^# xlings-profile-version: 8" "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S2: legacy profile was not upgraded"
 grep -q 'XLINGS_ACTIVE_SUBOS' "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S2: upgraded profile missing env-fallback logic"
@@ -66,7 +66,7 @@ cat > "$HOME_DIR/config/shell/xlings-profile.sh" <<'EOF'
 export FOO=bar
 EOF
 run_xlings self init >/dev/null
-grep -q "^# xlings-profile-version: 6" "$HOME_DIR/config/shell/xlings-profile.sh" \
+grep -q "^# xlings-profile-version: 8" "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S4: v1-marked profile was not upgraded"
 
 log "PASS: subos profile upgrade (1-4)"

--- a/tests/e2e/subos_shell_level_test.sh
+++ b/tests/e2e/subos_shell_level_test.sh
@@ -41,8 +41,8 @@ run_xlings self init >/dev/null
 
 # ── 1. Profile contains version marker + env fallback logic ────────────
 log "Scenario 1: profile is v2 (has version marker + env fallback)"
-grep -q "^# xlings-profile-version: 6" "$HOME_DIR/config/shell/xlings-profile.sh" \
-    || fail "S1: missing 'xlings-profile-version: 6' marker"
+grep -q "^# xlings-profile-version: 8" "$HOME_DIR/config/shell/xlings-profile.sh" \
+    || fail "S1: missing 'xlings-profile-version: 8' marker"
 grep -q 'XLINGS_ACTIVE_SUBOS' "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S1: missing XLINGS_ACTIVE_SUBOS in bash profile"
 grep -q 'XLINGS_ACTIVE_SUBOS' "$HOME_DIR/config/shell/xlings-profile.fish" \
@@ -265,4 +265,31 @@ out=$(run_xlings_with_active web subos use infra </dev/null 2>&1 || true)
 echo "$out" | grep -q "nesting subos" \
     || fail "S13: expected 'nesting subos' note; got: $out"
 
-log "PASS: subos shell-level switching (1-13 + 6b + 11b)"
+# ── 14. anonymous-project dir + global-scope read does not mint subos/_ ──
+# Regression for: `xlings install -g <pkg>` invoked from inside an
+# anonymous-project directory (cwd has a `.xlings.json` that triggers
+# ProjectSubosMode::Anonymous) was composing the workspace save path from
+# paths_.activeSubos = "_", producing `~/.xlings/subos/_/.xlings.json`,
+# which doesn't exist. The save then failed with "Failed to write file".
+# Surfaced under `xlings self install` because its patchelf-runtime-dep
+# step explicitly spawns `xlings install xim:patchelf@0.18.0 -y -g`.
+#
+# We can't easily fake an `install -g` without fixture-index plumbing,
+# so we assert the necessary precondition: even when the user's CWD is
+# an anonymous project, no xlings command (here `config`) ever creates
+# state under `~/.xlings/subos/_/`. The fix in Config::save_workspace's
+# else branch composes the global path from env-or-globalActiveSubos_
+# rather than paths_.activeSubos, so anonymous "_" cannot leak into a
+# global write.
+log "Scenario 14: anonymous-project dir does not leak '_' into global subos path"
+mkdir -p "$RUNTIME_DIR/anon"
+echo '{}' > "$RUNTIME_DIR/anon/.xlings.json"
+(
+    cd "$RUNTIME_DIR/anon"
+    env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
+        "$XLINGS_BIN_PATH" config >/dev/null 2>&1 || true
+)
+[[ ! -d "$HOME_DIR/subos/_" ]] \
+    || fail "S14: \$XLINGS_HOME/subos/_ must never be created from anon project context"
+
+log "PASS: subos shell-level switching (1-14 + 6b + 11b)"


### PR DESCRIPTION
## Summary

Follow-up fix to 0.4.17 — caught by the user during their `xlings self install` 0.4.15 → 0.4.17 upgrade:

```
[error] internal error: Failed to write file: /home/speak/.xlings/subos/_/.xlings.json
[warn] [xlings:self] patchelf install failed (rc=1)
```

## Bug path

`xself/install.cppm:423` spawns `xlings install xim:patchelf@0.18.0 -y -g` as a runtime-deps step. When the user invokes `xlings self install` from inside any directory whose `.xlings.json` triggers `ProjectSubosMode::Anonymous` (file exists, no project subos name pinned), the subprocess loads `Config` with `paths_.activeSubos = "_"`. `cmd_install` then sets `forceGlobalScope_=true` via `-g`.

The previous PR #270 workspace-isolation fix made `save_workspace`'s `else` branch use `paths_.activeSubos` directly. So under `-g + anonymous project`, it composed `~/.xlings/subos/_/.xlings.json` — a path that doesn't exist on disk because `"_"` only ever names project-local locations, never the home tree. `write_string_to_file` then errored.

## Fix

`save_workspace`'s `else` branch handles `useProject=false`, which means either "no project config" OR "`forceGlobalScope_` overrides project mode". Both routes mean "act on global scope, ignore project". So we must NOT trust `paths_.activeSubos` here (it carries the project-mode value `_`). Resolve the global subos name explicitly:

1. `XLINGS_ACTIVE_SUBOS` env if set (per-shell override)
2. `globalActiveSubos_` (`~/.xlings.json activeSubos` snapshot) otherwise

Both yield names whose directories exist in `$XLINGS_HOME/subos/`.

## Verification

- e2e `subos_shell_level_test.sh` scenario 14 (new): running any `xlings` command from inside an anonymous-project directory must NOT create `$XLINGS_HOME/subos/_/`. Fails on previous main HEAD; passes after this fix.
- 216/220 unit tests pass (4 unrelated pre-existing skips)
- Existing e2e all pass: bootstrap_home, install_idempotent, remove_multi_version, subos_events, subos_payload_refcount, subos_profile_upgrade, subos_shell_level (1-14 + 6b + 11b)

## Release

`xlings::Info::VERSION` stays at 0.4.17. Intended to be re-released as 0.4.17 by deleting the existing tag/release and re-running `release.yml` against main HEAD after merge.
