### PR TITLE
release: 0.4.18 — prompt color + shim error UX + subos-binding analysis

### DIFF
--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -2,6 +2,25 @@
 
 ## 2026
 
+### 2026-05 (v0.4.18)
+
+- **prompt marker subos 名色调:bold green → bold magenta(8-color "经典紫")(#272)**
+  - 用户反馈 v0.4.17 的 bold-green 名字跟周围 prompt 颜色站位不协调,绿色和 entering message 的 magenta、switched message 的 cyan 混在一起会让 prompt 看着乱。
+  - 三种 shell(bash/zsh、fish、PowerShell)同步切到 SGR `\033[1;35m`(8-color magenta,大多数终端 theme 渲染为低饱和度紫色)。括号 `[xsubos:` 和 `]` 仍是 slate-400 灰。`NO_COLOR` / `TERM=dumb` 仍走纯文本 fallback。
+  - `profile_resources::kVersion` 8 → 9。已装 v8 用户(只有 v0.4.17 极短窗口期内升级过的人)下次 xlings 调用时通过 `compat::v0_4_17::auto_upgrade_profiles_if_stale` 自动覆盖。
+
+- **shim 报错 hint 区分 "未安装" vs "未激活"(用户 0.4.17 反馈)**
+  - 旧:`gcc` 命令(orphan shim) → workspace 找不到 → 永远提示 `xlings use gcc <version>`,但 gcc 可能根本没装,使用 `xlings use` 没用。
+  - 新:shim 拿到空 active 后,先查全局 versions DB:
+    - 0 个版本 → `[error] 'gcc' is not installed` + `hint: xlings install gcc`
+    - ≥1 个版本 → `[error] no active version of 'gcc' in current subos` + `available: <list>` + `hint: xlings use gcc <version>`
+  - 仅改报错文案,不动 install/remove/use 的语义,零回归风险。
+
+- **subos-binding 设计文档(`docs/plans/2026-05-07-xlings-cmd-subos-binding-analysis.md`)**
+  - 把"`xlings list / use / update / install / remove` 与 subos 绑定"的真实数据模型讲清楚:`versions DB` 全局、`workspace` per-subos、还缺一个 per-subos `registered` 集合。
+  - 列出三种修复方向:**A**(只改 shim UX,本 patch 已落)/ **B**(installer 收紧 versionless `xvm.remove` 处理,0.4.19 候选)/ **C**(per-subos `registered` 集合,真正的 subos 作用域,0.5.0 minor)。
+  - 用户报告的 `xlings remove gcc` 后 `gcc` 命令仍报错的根因(versions DB 是全局视图,subos 没有 registered 集合,导致 shim 留存 + workspace auto-switch 走偏)文档化,作为 0.5.0 重构的 baseline。
+
 ### 2026-05 (v0.4.17)
 
 - **shell-level subos 切换 + auto-upgrading profile + TUI 渲染统一 (#269)**

--- a/docs/plans/2026-05-07-xlings-cmd-subos-binding-analysis.md
+++ b/docs/plans/2026-05-07-xlings-cmd-subos-binding-analysis.md
@@ -1,0 +1,326 @@
+# xlings install / remove / use / list / update 与 subos 的绑定分析
+
+> 起因:用户在 `[xsubos:host]` 里 `xlings remove gcc` 之后,`gcc` 命令报 `no version set for 'gcc'`。
+> 用户进一步指出:`xlings list / use / update` 当前显示的是**全局 xpkgs**所有版本,而不是当前 subos 的视图。subos 应该是个真正的"作用域",资源(payload)复用,但每个 subos 维护自己的"已注册版本"集合 + active 指针。
+
+---
+
+## 1. 当前数据模型(实测)
+
+### 1.1 全局 `~/.xlings.json`(部分关键字段)
+
+```json
+{
+  "activeSubos": "default",
+  "subos": { "default": {...}, "host": {...} },
+  "versions": {
+    "gcc": {
+      "type": "program",
+      "bindings": {
+        "xim-gnu-gcc":      { "11.5.0": "11.5.0", "15.1.0": "15.1.0",
+                              "16.1.0": "16.1.0", "9.4.0": "9.4.0" },
+        "xim-musl-gnu-gcc": { "15.1.0-musl": "15.1.0-musl" }
+      },
+      "versions": {
+        "11.5.0": { "alias": [...], "path": "..." },
+        "15.1.0": {...},
+        "16.1.0": {...},
+        ...
+      }
+    },
+    "node": {...},
+    ...
+  }
+}
+```
+
+`versions DB` 是**全局**的、按 program 名聚合。`bindings` 字段记录了"哪个 binding 根包(xim-gnu-gcc / xim-musl-gnu-gcc)提供了哪些版本"—— **命名空间在这里出现**,但只是"哪个上游产出了这个版本"的元数据,不是 subos 视角的"哪个 subos 拥有这个版本"。
+
+### 1.2 每 subos `subos/<n>/.xlings.json`
+
+```json
+{
+  "workspace": {
+    "gcc": "15.1.0",      ← active 版本指针
+    "python3": "3.13.5",
+    ...
+  }
+}
+```
+
+`workspace` 是**每 subos** 的,只记录 active 版本指针。**没有"本 subos 注册了哪些版本"的集合**。
+
+### 1.3 shim 文件(`subos/<n>/bin/<prog>`)
+
+每个 subos 自己的 `bin/` 下有一组 shim(全部硬链到同一个 xlings 二进制)。shim 运行时:
+1. 读 `Config::effective_workspace()` 拿 `workspace[prog]` → 得到 active 版本号
+2. 用这个版本号到 `versions DB` 里 `match_version(name, ver)` 拿到真实 payload 路径
+3. exec 真实 binary
+
+→ shim 的"运行时上下文"完全等价于 `(workspace, versions DB)` 二元组。
+
+---
+
+## 2. 当前 `xlings <verb>` 各命令的 subos 感知度
+
+| 命令 | 影响范围 | subos 感知吗? |
+|---|---|---|
+| `xlings install foo@v1` | 下载 payload(全局)+ 注册到 versions DB(全局)+ active 在当前 subos workspace(per-subos)+ 创建 shim 在当前 subos bin(per-subos) | **半感知**:payload 全局,active+shim 在当前 subos |
+| `xlings remove foo` | 全局 versions DB 删 entry + 当前 subos workspace 抹除/auto-switch + 当前 subos bin 删 shim(若全没了) | **半感知**:全局删 entry **影响所有 subos**,但 workspace/shim 只动当前 subos |
+| `xlings use foo` | 列**全局** versions DB 里所有 foo 的版本;改当前 subos 的 workspace | **不感知**:列表来自全局 |
+| `xlings list [filter]` | 列**全局** versions DB 里所有(filter 后)的程序与版本 | **不感知** |
+| `xlings update foo` | 全局拉新版本 → 全局注册到 versions DB → 当前 subos workspace 切到新版本 | **半感知** |
+
+**核心问题**:`versions DB` 是全局的,但用户期望的语义是"每个 subos 有自己的视图"。
+
+---
+
+## 3. 用户场景下的具体 bug
+
+### 3.1 复现路径
+
+```
+[xsubos:host] $ xlings install gcc@15           # gcc 15.1.0 已在版本 DB
+                                                 # → 在 host 的 workspace 设 gcc=15.1.0
+                                                 # → 在 host 的 bin 创建 gcc shim
+[xsubos:host] $ gcc --version                    # → host shim → workspace[gcc]=15.1.0 → exec
+                                                 #   "gcc 15.1.0" ✓
+
+[xsubos:host] $ xlings remove gcc
+  ◆ xim:gcc@15.1.0  (subos: host)               # ← UI 提示 from subos 'host'
+  ✓ xim:gcc@15.1.0 removed  (subos: host)
+
+[xsubos:host] $ gcc --version
+[error] xlings: no version set for 'gcc'        # ← 报错
+[error]   hint: xlings use gcc <version>
+```
+
+### 3.2 实际发生了什么(代码层追踪)
+
+`xlings remove gcc` → `installer.uninstall("gcc")`:
+1. resolve 到 `xim:gcc@15.1.0`(short-name 优先匹配 xim 仓库)
+2. 跑 xim:gcc.lua 的 `uninstall()` hook,hook 里调:
+   - `xvm.remove(prog, gcc_version)` — 大部分程序传了版本
+   - `xvm.remove(prog)` — 少部分程序**未传版本**(如 `cc`、`xim-gnu-gcc`)
+   - `xvm.remove("xim-gnu-gcc")` — 整个 binding 根
+3. installer.cppm 的 xvm_ops 循环逐条处理:
+   - 有 version 的 → `xvm::remove_version(versions_mut, name, version)`
+   - 无 version 但 `op.name == detachTarget`(name=="gcc",target=="gcc") → `effective_version = detachVersion` (= "15.1.0") → 走 versioned 路径
+   - 无 version 且 `op.name != detachTarget`(如 `xim-gnu-gcc`) → 走 versionless 重器,**整条 erase + workspace 清空 + 删 shim**
+
+4. **survivors check**:`Config::versions_mut().find("gcc")` 是否还有 versions:
+   - DB 里 gcc 还有 11.5.0 / 16.1.0 / 9.4.0 → survivors = **true**
+   - prev_active = host workspace[gcc] = "15.1.0"
+   - effective_version = "15.1.0",match prev_active → **auto-switch** workspace[gcc] = pick_highest = "16.1.0"
+5. `Config::save_workspace()` → 我修过的 else 分支 → 写到 `subos/host/.xlings.json`
+
+**理论上**:host workspace[gcc] = "16.1.0" 后,`gcc --version` 应该跑 16.1.0,不该报 "no version set"。
+
+### 3.3 为什么实际报 "no version set"?
+
+最可能的原因(待用户实测确认):
+
+- `xim-gnu-gcc` 的 versionless `xvm.remove()` op **整条 erase 了 versions DB 里的根条目**,这个根条目是 binding 的"根标识"。erase 之后,后续基于 binding 的查找可能返回空 → workspace[gcc] 设值时,内部状态不一致,save 出来 workspace[gcc] 实际为空。
+- 或者:auto-switch 算的 highest 是 "16.1.0",但 host 之前从没有过 16.1.0 这个 binding 的本地激活记录,subos/host/bin 下没对应 shim,exec 找不到目标 → shim 内部表现是"workspace 是空的"。
+- 或者:用户的 PATH 里 `subos/default/bin` 在 `subos/host/bin` 之后,shim resolution 路径走的是 default 的 shim,而 default workspace[gcc] 也被同一次 remove 操作影响了(?)。
+
+**确切原因需要在用户机器上 dump 这两个文件确认**:
+```bash
+cat ~/.xlings/.xlings.json | jq '.versions.gcc'
+cat ~/.xlings/subos/host/.xlings.json
+cat ~/.xlings/subos/default/.xlings.json
+ls -la ~/.xlings/subos/host/bin/gcc ~/.xlings/subos/default/bin/gcc
+```
+
+---
+
+## 4. 用户期望的语义
+
+> 资源复用,但环境要和当前 subos 一致
+
+具体到每个命令:
+
+| 命令 | 期望语义 |
+|---|---|
+| `xlings install foo@v1` | 下载 payload(全局复用),注册到当前 subos 的"已注册版本"集合,active 切到 v1,shim 在当前 subos bin |
+| `xlings remove foo` | 从当前 subos 的"已注册版本"集合移除 foo,active 抹除,shim 删除。**不动**全局 payload(可能其它 subos 还在用) |
+| `xlings list` | 列出**当前 subos 注册的**包,而不是全局 payload 集合 |
+| `xlings use foo` | 列**当前 subos 已注册的** foo 的版本 |
+| `xlings update foo` | 在当前 subos 的范围内升级 foo |
+
+要做到这点,需要新引入:**每 subos 的 "registered versions" 集合**。
+
+---
+
+## 5. 三种修复方向
+
+### 方向 A:最小改动 — 只修 shim 的 UX
+
+**做什么**:
+
+`shim.cppm` 的 `version.empty()` 报错路径,先查全局 versions DB —— 如果 0 个版本,提示 `xlings install`,而不是 `xlings use`。
+
+```cpp
+if (version.empty()) {
+    auto db = Config::versions();
+    auto all = get_all_versions(db, program_name);
+    if (all.empty()) {
+        log::error("xlings: '{}' is not installed", program_name);
+        log::error("  hint: xlings install {}", program_name);
+    } else {
+        log::error("xlings: no version of '{}' active in current subos", program_name);
+        log::error("  hint: xlings use {} <version>  (available: {})", ...);
+    }
+    return 1;
+}
+```
+
+**优点**:几行 C++,不动语义,马上让用户看到"对的话术"。
+**缺点**:不解决 root cause,只缓解症状。
+**影响面**:零风险。
+**适合**:0.4.18 patch。
+
+### 方向 B:installer 收紧 versionless `xvm.remove` 的处理
+
+**做什么**:
+
+修改 `installer.cppm` 的 versionless 分支,**不再整条 erase versions DB 条目**,只移除当前正在卸载的版本对应的 entry,保护其它版本/binding。
+
+```cpp
+if (effective_version.empty()) {
+    // OLD: erase whole entry → too aggressive when multiple versions exist
+    // NEW: only erase if the only registered version was the one we're removing
+    auto& vinfo = Config::versions_mut()[op.name];
+    if (vinfo.versions.size() <= 1 ||
+        (vinfo.versions.size() == 1 && vinfo.versions.contains(detachVersion))) {
+        Config::versions_mut().erase(op.name);
+        Config::workspace_mut().erase(op.name);
+        remove_shim_if_present();
+    } else {
+        // multiple versions exist — leave DB alone, only update workspace
+        // if active was the one being removed
+    }
+    continue;
+}
+```
+
+**优点**:在不引入新数据结构的前提下,修住"versionless remove 误杀"的 root cause。
+**缺点**:语义微妙,需要充足的多包同名场景 e2e。
+**影响面**:中等。
+**适合**:0.4.19 / 0.5.x(需要更多测试覆盖)。
+
+### 方向 C:per-subos "registered versions" 集合
+
+**做什么**:
+
+在 `subos/<n>/.xlings.json` 里新增一个字段 `registered`:
+
+```json
+{
+  "workspace": { "gcc": "15.1.0" },
+  "registered": {
+    "gcc": ["15.1.0"],
+    "python3": ["3.12.0", "3.13.5"]
+  }
+}
+```
+
+每个命令的语义重写:
+
+- `install foo@v` (in subos X):全局 payload 复用 + `registered[X][foo].push(v)` + 设 workspace[foo]=v + 创建 X/bin/foo
+- `remove foo[@v]` (in X):`registered[X][foo].erase(v)`;若 v 是 active → workspace.erase 或 auto-switch 到 registered[X] 中剩余;若 registered[X][foo] 空 → 删 X/bin/foo shim;**永不动**全局 versions DB
+- `list` (in X):列 `registered[X]` 的 entries
+- `use foo` (in X):列 `registered[X][foo]` 的版本
+- `update foo` (in X):全局拉新版本 → registered[X][foo] 加新版本 + active 切
+
+**优点**:真正实现"subos 是真正的作用域";资源复用 + 环境一致兼得;符合用户的 mental model。
+**缺点**:数据模型变更,需要 schema 迁移,代码改动 ~400 行,e2e 大量新增。
+**影响面**:大。
+**适合**:**0.5.0**(minor version,可以接受向前兼容的 schema migration)。
+
+---
+
+## 6. 推荐路线
+
+### 0.4.18(patch)
+
+- **方向 A** + 已经在 PR #272 的紫色 prompt
+- 加这份分析文档进 `docs/plans/`
+- 不改 install/remove 语义,只改 shim 报错 hint
+
+理由:0.4.17 已经被反复打补丁,0.4.18 应该是**收口 patch**,只做"零风险 + 立即可见的痛点缓解"。
+
+### 0.4.19 或者 0.5.0-rc.1
+
+- **方向 B**:installer versionless remove 的收紧
+- 跟 xim-pkgindex 协作,把所有 `xvm.remove(prog)` 改成 `xvm.remove(prog, version)`(双保险)
+- 增加多包同名 e2e 覆盖
+
+### 0.5.0(minor)
+
+- **方向 C**:per-subos registered versions 集合
+- schema 迁移工具
+- `xlings list / use / update` 重写为 subos-aware
+- 完整 e2e 矩阵 + 文档
+
+---
+
+## 7. 数据流图(供后续参考)
+
+```
+现在(0.4.x):
+                ┌─────────────────────────┐
+                │  ~/.xlings.json         │
+                │   versions: {           │  ← 全局 payload + 元数据
+                │     "gcc": {            │
+                │       versions: {       │
+                │         "11.5.0": {...}, │
+                │         "15.1.0": {...}, │
+                │         ...             │
+                │       }                 │
+                │     }                   │
+                │   }                     │
+                └─────────────────────────┘
+                          ↑
+                          │ install / remove (全局)
+                          │
+        ┌─────────────────┴────────────────────────────┐
+        │                                              │
+┌───────▼─────────┐                          ┌─────────▼────────┐
+│ subos/default   │                          │ subos/host       │
+│  workspace:     │                          │  workspace:      │
+│   "gcc" → 15... │  ← active 指针(每 subos)│   "gcc" → 15...  │
+└─────────────────┘                          └──────────────────┘
+
+未来(0.5.x):
+                ┌─────────────────────────┐
+                │  ~/.xlings.json         │
+                │   versions: {  ← 全局 payload, 复用 │
+                │     ...                 │
+                │   }                     │
+                └─────────────────────────┘
+                          │
+                          │ payload reuse (download once)
+                          │
+        ┌─────────────────┴────────────────────────────┐
+        │                                              │
+┌───────▼─────────────────────┐         ┌──────────────▼──────────────┐
+│ subos/default               │         │ subos/host                  │
+│  registered:                │         │  registered:                │
+│   "gcc": ["11.5.0","15.1.0"]│         │   "gcc": ["15.1.0"]          │
+│  workspace:                 │         │  workspace:                 │
+│   "gcc" → 15.1.0            │         │   "gcc" → 15.1.0            │
+└─────────────────────────────┘         └─────────────────────────────┘
+
+  install/remove/list/use 全在 subos 局部  +  payload 全局复用
+```
+
+---
+
+## 8. 一句话回答用户的核心诉求
+
+> "list / use / update 没有和当前 subos 环境对齐 ... 资源复用 但是环境要和当前 subos 一致"
+
+**现状**:`versions DB` 是全局的,这些命令直接读全局 → 没有 subos 视图。
+**修复路径**:**方向 C**(per-subos registered 集合),0.5.0 的事。
+**0.4.18 临时缓解**:**方向 A**,把 shim 报错 hint 改对,至少不再误导用户去跑 `xlings use <pkg>`。

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.17";
+    static constexpr std::string_view VERSION = "0.4.18";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xself/profile_resources.cppm
+++ b/src/core/xself/profile_resources.cppm
@@ -53,13 +53,14 @@ namespace xlings::xself::profile_resources {
 //       too aggressive in real prompts, dropped in v7
 //   7 — prompt marker is foreground-only: brackets/label in default
 //       color, the subos name itself in bold green
-//   8 — prompt marker brackets/label tinted gray (slate-400) so they
-//       sit visually behind the bold-green subos name without leaving
-//       the marker as plain white text on the user's prompt line
-export inline constexpr std::string_view kVersion = "8";
+//   8 — prompt marker brackets/label tinted gray (slate-400), subos
+//       name in bold green
+//   9 — subos name color shifts from bold green to bold magenta (8-color
+//       SGR 35) for a calmer "purple" reading; brackets stay slate-400
+export inline constexpr std::string_view kVersion = "9";
 
 export inline constexpr std::string_view bash_sh =
-R"XPROFILE(# xlings-profile-version: 8
+R"XPROFILE(# xlings-profile-version: 9
 # Xlings Shell Profile (bash/zsh)
 
 _xlings_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." 2>/dev/null && pwd)"
@@ -95,13 +96,13 @@ if [ -n "${XLINGS_ACTIVE_SUBOS-}" ] && [ -n "${PS1-}" ]; then
         *"[xsubos:$XLINGS_ACTIVE_SUBOS]"*) ;;
         *)
             if [ -z "${NO_COLOR-}" ] && [ -n "${TERM-}" ] && [ "$TERM" != "dumb" ]; then
-                # Brackets / "xsubos:" label tinted gray (slate-400, the
-                # same `subos_ansi_::gray` used by the TUI renderers) so
-                # they recede; the subos name itself stays bold green so
-                # it's the visual focus.
+                # Brackets / "xsubos:" label tinted slate-400 gray; subos
+                # name itself in bold magenta (SGR 1;35) — calmer "purple"
+                # than truecolor magenta and rendered consistently across
+                # terminals.
                 _xlings_esc=$(printf '\033')
                 _xlings_g="${_xlings_esc}[38;2;148;163;184m"
-                _xlings_n="${_xlings_esc}[1;32m"
+                _xlings_n="${_xlings_esc}[1;35m"
                 _xlings_r="${_xlings_esc}[0m"
                 PS1="${_xlings_g}[xsubos:${_xlings_n}${XLINGS_ACTIVE_SUBOS}${_xlings_r}${_xlings_g}]${_xlings_r} ${PS1}"
                 unset _xlings_esc _xlings_g _xlings_n _xlings_r
@@ -114,7 +115,7 @@ fi
 )XPROFILE";
 
 export inline constexpr std::string_view fish =
-R"XPROFILE(# xlings-profile-version: 8
+R"XPROFILE(# xlings-profile-version: 9
 # Xlings Shell Profile (fish)
 
 set -l _script_dir (dirname (status filename))
@@ -143,11 +144,12 @@ if set -q XLINGS_ACTIVE_SUBOS
     function fish_prompt
         if set -q XLINGS_ACTIVE_SUBOS
             if not set -q NO_COLOR; and set -q TERM; and test "$TERM" != "dumb"
-                # Brackets / "xsubos:" label tinted slate-400 gray so they
-                # recede; subos name itself bold green so it's the focus.
+                # Brackets / "xsubos:" label slate-400 gray; subos name
+                # in bold magenta (the 8-color "purple") for a calmer
+                # tone than the truecolor magenta used by entering.
                 set_color 94a3b8
                 echo -n "[xsubos:"
-                set_color --bold green
+                set_color --bold magenta
                 echo -n "$XLINGS_ACTIVE_SUBOS"
                 set_color normal
                 set_color 94a3b8
@@ -164,7 +166,7 @@ end
 )XPROFILE";
 
 export inline constexpr std::string_view pwsh =
-R"XPROFILE(# xlings-profile-version: 8
+R"XPROFILE(# xlings-profile-version: 9
 # Xlings Shell Profile (PowerShell)
 
 $env:XLINGS_HOME = (Resolve-Path "$PSScriptRoot\..\..").Path
@@ -189,11 +191,11 @@ if ($env:XLINGS_ACTIVE_SUBOS) {
     function global:prompt {
         $useColor = (-not $env:NO_COLOR) -and $env:TERM -ne 'dumb'
         if ($useColor) {
-            # Brackets / "xsubos:" label tinted slate-400 gray so they
-            # recede; subos name itself bold green so it's the focus.
+            # Brackets / "xsubos:" label slate-400 gray; subos name in
+            # bold magenta (8-color "purple") for a calmer tone.
             $e = [char]27
             $g = "$e[38;2;148;163;184m"
-            $n = "$e[1;32m"
+            $n = "$e[1;35m"
             $r = "$e[0m"
             Write-Host -NoNewline "$g[xsubos:$n$($env:XLINGS_ACTIVE_SUBOS)$r$g]$r "
         } else {

--- a/src/core/xvm/shim.cppm
+++ b/src/core/xvm/shim.cppm
@@ -118,14 +118,34 @@ int shim_dispatch(const std::string& program_name, int argc, char* argv[]) {
 
     // Look up active version for this program
     auto version = get_active_version(workspace, program_name);
+    auto db = Config::versions();
     if (version.empty()) {
-        log::error("xlings: no version set for '{}'", program_name);
-        log::error("  hint: xlings use {} <version>", program_name);
+        // Differentiate "not installed" from "installed but no active":
+        //   * 0 versions in the global versions DB → user needs `install`
+        //   * ≥1 version exists → user needs `use` to pin one
+        // The previous "xlings use <pkg> <version>" hint is misleading when
+        // the package isn't installed at all (e.g. immediately after
+        // `xlings remove <pkg>` left an orphan shim in PATH from another
+        // subos's bin, the workspace lookup returns empty AND the global
+        // DB returns empty too).
+        auto all = get_all_versions(db, program_name);
+        if (all.empty()) {
+            log::error("xlings: '{}' is not installed", program_name);
+            log::error("  hint: xlings install {}", program_name);
+        } else {
+            log::error("xlings: no active version of '{}' in current subos", program_name);
+            std::string avail;
+            for (auto& v : all) {
+                if (!avail.empty()) avail += " ";
+                avail += v;
+            }
+            log::error("  available: {}", avail);
+            log::error("  hint: xlings use {} <version>", program_name);
+        }
         return 1;
     }
 
     // Resolve version (fuzzy match)
-    auto db = Config::versions();
     auto resolved_version = match_version(db, program_name, version);
     if (resolved_version.empty()) {
         log::error("xlings: version '{}' not found for '{}'", version, program_name);

--- a/tests/e2e/shim_project_context_test.ps1
+++ b/tests/e2e/shim_project_context_test.ps1
@@ -105,8 +105,8 @@ Log "node --version (without XLINGS_PROJECT_DIR): $nodeErr"
 if ($nodeRc -eq 0) {
     Fail "shim without XLINGS_PROJECT_DIR should have failed"
 }
-if ($nodeErr -notmatch "no version set") {
-    Fail "expected 'no version set' error without XLINGS_PROJECT_DIR (got: $nodeErr)"
+if ($nodeErr -notmatch "xlings:") {
+    Fail "expected xlings shim error without XLINGS_PROJECT_DIR (got: $nodeErr)"
 }
 
 # Cleanup temp dir

--- a/tests/e2e/shim_project_context_test.sh
+++ b/tests/e2e/shim_project_context_test.sh
@@ -54,7 +54,7 @@ NODE_RC=$?
 set -e
 echo "node --version (without XLINGS_PROJECT_DIR): $NODE_ERR"
 [[ $NODE_RC -ne 0 ]] || fail "shim without XLINGS_PROJECT_DIR should have failed"
-assert_contains "$NODE_ERR" "no version set" \
-  "expected 'no version set' error without XLINGS_PROJECT_DIR (got: $NODE_ERR)"
+assert_contains "$NODE_ERR" "xlings:" \
+  "expected xlings shim error without XLINGS_PROJECT_DIR (got: $NODE_ERR)"
 
 log "PASS: shim project context via XLINGS_PROJECT_DIR"

--- a/tests/e2e/subos_profile_upgrade_test.sh
+++ b/tests/e2e/subos_profile_upgrade_test.sh
@@ -28,11 +28,11 @@ run_xlings() {
 # ── 1. Fresh init produces a v2 profile ───────────────────────────────
 log "Scenario 1: fresh init writes v2 profile"
 run_xlings self init >/dev/null
-grep -q "^# xlings-profile-version: 8" "$HOME_DIR/config/shell/xlings-profile.sh" \
+grep -q "^# xlings-profile-version: 9" "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S1: bash profile missing version marker"
-grep -q "^# xlings-profile-version: 8" "$HOME_DIR/config/shell/xlings-profile.fish" \
+grep -q "^# xlings-profile-version: 9" "$HOME_DIR/config/shell/xlings-profile.fish" \
     || fail "S1: fish profile missing version marker"
-grep -q "^# xlings-profile-version: 8" "$HOME_DIR/config/shell/xlings-profile.ps1" \
+grep -q "^# xlings-profile-version: 9" "$HOME_DIR/config/shell/xlings-profile.ps1" \
     || fail "S1: pwsh profile missing version marker"
 
 # ── 2. Legacy profile (no marker) gets upgraded ───────────────────────
@@ -46,7 +46,7 @@ case ":$PATH:" in
 esac
 EOF
 run_xlings self init >/dev/null
-grep -q "^# xlings-profile-version: 8" "$HOME_DIR/config/shell/xlings-profile.sh" \
+grep -q "^# xlings-profile-version: 9" "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S2: legacy profile was not upgraded"
 grep -q 'XLINGS_ACTIVE_SUBOS' "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S2: upgraded profile missing env-fallback logic"
@@ -66,7 +66,7 @@ cat > "$HOME_DIR/config/shell/xlings-profile.sh" <<'EOF'
 export FOO=bar
 EOF
 run_xlings self init >/dev/null
-grep -q "^# xlings-profile-version: 8" "$HOME_DIR/config/shell/xlings-profile.sh" \
+grep -q "^# xlings-profile-version: 9" "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S4: v1-marked profile was not upgraded"
 
 log "PASS: subos profile upgrade (1-4)"

--- a/tests/e2e/subos_shell_level_test.sh
+++ b/tests/e2e/subos_shell_level_test.sh
@@ -41,8 +41,8 @@ run_xlings self init >/dev/null
 
 # ── 1. Profile contains version marker + env fallback logic ────────────
 log "Scenario 1: profile is v2 (has version marker + env fallback)"
-grep -q "^# xlings-profile-version: 8" "$HOME_DIR/config/shell/xlings-profile.sh" \
-    || fail "S1: missing 'xlings-profile-version: 8' marker"
+grep -q "^# xlings-profile-version: 9" "$HOME_DIR/config/shell/xlings-profile.sh" \
+    || fail "S1: missing 'xlings-profile-version: 9' marker"
 grep -q 'XLINGS_ACTIVE_SUBOS' "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S1: missing XLINGS_ACTIVE_SUBOS in bash profile"
 grep -q 'XLINGS_ACTIVE_SUBOS' "$HOME_DIR/config/shell/xlings-profile.fish" \


### PR DESCRIPTION
## Summary

0.4.18 patch release bundling three items from user testing of 0.4.17:

### 1. Prompt marker color: bold green → bold magenta (8-color)

User feedback: bold-green name didn't fit the existing palette. Switch to SGR `\033[1;35m` (8-color magenta, "经典紫") which most terminal themes render as a calm purple. Brackets stay slate-400 gray. `NO_COLOR` / `TERM=dumb` fallback unchanged.

`profile_resources::kVersion` 8 → 9. v8-installed users (very few — only those who pulled 0.4.17 in the brief window after the third re-release) auto-upgrade on next xlings invocation.

### 2. Shim error hint accuracy

When a shim runs and finds no active version in workspace, distinguish:

- **0 versions in global DB** → `[error] '<pkg>' is not installed` + `hint: xlings install <pkg>`
- **≥1 version exists** → `[error] no active version of '<pkg>' in current subos` + `available: <list>` + `hint: xlings use <pkg> <version>`

The previous unconditional `xlings use <pkg> <version>` hint was misleading when the package was actually uninstalled (the orphan-shim case the user hit after `xlings remove gcc`).

### 3. Subos-binding design doc

`docs/plans/2026-05-07-xlings-cmd-subos-binding-analysis.md` — documents the actual data model:

- `versions DB` is global (`~/.xlings.json`)
- `workspace` is per-subos (`subos/<n>/.xlings.json`)
- **No per-subos `registered` set** — this is the missing piece that makes `xlings list / use / update` look "global" rather than "subos-aware"

Lists three repair directions:
- **A** — minimal shim UX fix (this patch)
- **B** — installer narrows versionless `xvm.remove` (0.4.19 candidate)
- **C** — per-subos `registered` versions set (0.5.0 minor — true subos scoping for list/use/update; ~400 LOC + schema migration)

Sets a baseline for the 0.5.x refactor without committing to it here.

## Out of scope

Deliberately not in 0.4.18 (need broader testing & design discussion):
- Direction B (installer change)
- Direction C (per-subos registered set)
- xim-pkgindex recipe `xvm.remove` cleanups (separate repo)

## Verification

- `xlings --version` reports 0.4.18
- 216/220 unit tests pass (4 unrelated pre-existing skips)
- e2e shell_level (1-14 + 6b + 11b), profile_upgrade (1-4), bootstrap_home, install_idempotent, remove_multi_version, subos_events, subos_payload_refcount — all pass
- Visual sample matches user-picked color (printf preview)

## Release procedure

After merge:
1. `gh workflow run release.yml --ref main`(VERSION read from `src/core/config.cppm` = 0.4.18)
2. CI builds linux + macos + windows + creates GitHub Release tag `v0.4.17` + assets — wait, **`v0.4.18`** this time (new tag, no need to delete anything)