### PR TITLE
feat(0.4.18): subos workspace gets {active, installed[]} schema (Plan C2)

### DIFF
--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -2,6 +2,26 @@
 
 ## 2026
 
+### 2026-05 (v0.4.19)
+
+- **subos workspace schema 升级:`{active, installed[]}` 形式 (Plan C2,PR A)**
+  - 0.4.18 `2026-05-07-xlings-cmd-subos-binding-analysis.md` 里的 C 系方案落地第一步:**subos** 的 `.xlings.json` 中 `workspace` 每个 target 的 value 从原本的 `"<version>"` 字符串升级为对象形式 `{ "active": "X", "installed": ["X","Y","Z"] }`。**project** `.xlings.json` 不动 —— 它是声明意图(`xxx = { linux = "..." }` 平台条件式)而非运行时状态,无需 `installed`。
+  - **解析层(`xvm::subos_workspace_from_json`)三种 value 形态都接收**:
+    1. 字符串 `"1.2.3"`(0.4.19 之前的旧文件,自动当作 `active`,`installed[]` 留空,下次 save 自动改写)。
+    2. 对象 `{active, installed}`(新形式)。
+    3. 对象 `{linux: ..., windows: ..., default: ...}`(平台条件式 fallback,subos 文件本来不会出现这个形态,但用户手编时容忍掉)。
+  - **形态 (2) vs (3) 的歧义靠保留 key 区分**(C2 design 里的 Plan 1):object 出现 `active` 或 `installed` 这两个 key → 当作新形式;否则按平台条件解析。两套 schema 永远不会撞到同一份文件里。
+  - **写入层(`xvm::subos_workspace_to_json`)永远输出新形式**,且强制不变量:`active` 出现在序列化结果里时,一定也出现在 `installed[]` 里(serializer 自动补)。`installed[]` 排序稳定,降低 git diff 噪音。
+  - **GC refcount 修正(`installer::is_version_referenced_anywhere_`)**:之前只检查"某 subos 的 active == version"。新形式下,某 subos 可能保留 X 在 `installed[]` 但 active 是别的版本,这种 case 之前会被误判为"无人用",触发 GC 把 payload 删掉。现在跨 subos refcount 同时遍历 active 和 `installed[]`,**两者任一命中就视为被引用**。
+  - **install / remove 维护 `installed[]`**:
+    - `process_xvm_operations_` add(program 类型) → 把 `ver_key` 加进当前 subos 的 `installed[]`(去重);active pointer 仍按旧规则(无 active 或 `--use` 时切到新版本)。
+    - `process_xvm_operations_` remove(无论是 user-initiated remove 还是 install-time upgrade) → 同步从 `installed[]` 抹掉 `ver_key`(再次防御:detach_current_subos_ 通常已经先抹了,但 install upgrade 路径不走 detach)。
+    - `detach_current_subos_` → 永远先把 `version` 从 `installed[]` 移除;如果它正好是 active,则做 sysroot 拆除并**自动 fallback 到 `installed[]` 里剩余最高版本**(列表是 sorted ascending,`back()` 即最高);剩余为空才清空 active pointer。**避免"删了 active 之后命令就完全报错"的硬中断**。
+  - 影响范围:`config.cppm`、`xvm/db.cppm`、`xvm/types.cppm`(新增 `WorkspaceInstalled` 类型 + `SubosWorkspace` 结构)、`xim/installer.cppm`、`profile.cppm`(GC scan 同时看两边)。**没有 schema 强制升级步骤** —— 旧文件第一次 save 才被改写。
+  - **compat 入口**:`xself::compat::v0_4_19::kSchemaForm` 是空 sentinel,文档化此次 schema migration,挂在 `removal_target: 0.6.0`(到时把 `subos_workspace_from_json` 里支持字符串形态的分支也一起删掉)。
+  - 测试:新增 `subos_workspace_c2_schema_test.sh`(4 个 scenario,覆盖 lazy migration、active+installed 并存、save invariant、active-less object 的容忍读取)。原 `remove_self_guard_test.sh` 里把 workspace value 当字符串读的 python helper 升级为兼容 dict / str 两种。
+  - **下一步(PR B,后续 release)**:`xlings list / use / update` 加 subos-aware 过滤(只显示当前 subos 的 `installed[]` 视图),把这次落下来的数据模型用起来。
+
 ### 2026-05 (v0.4.18)
 
 - **prompt marker subos 名色调:bold green → bold magenta(8-color "经典紫")(#272)**

--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -23,6 +23,11 @@
   - 测试:新增 `subos_workspace_c2_schema_test.sh`(4 个 scenario,覆盖 lazy migration、active+installed 并存、save invariant、active-less object 的容忍读取);**原 7 个 e2e 测试**里把 workspace value 当字符串读的 python helper 全部升级成兼容 dict / str 两种(`remove_self_guard`、`remove_multi_version`、`xlings_self_replace`、`self_doctor`、`update_package`、`cli_target_compat`、`install_idempotent`)。
   - **下一步(后续 release)**:`xlings list / use / update` 加 subos-aware 过滤(只显示当前 subos 的 `installed[]` 视图),把这次落下来的数据模型用起来。
 
+- **Windows CI / release xrepo 缓存路径修复 (#273)**
+  - 现象:Linux / macOS 的 `Cache xrepo packages` 步骤缓存命中正常(每次 ~5MB / ~3MB),但 **Windows 这个缓存从来没有上传过**(`gh api repos/.../actions/caches` 里 `xmake-pkgs-Windows-*` 一条都没有)。导致 Windows 每次 PR / release 都从源码重编 libarchive + zstd + bzip2 + lz4 + zlib via MSVC,**`Configure xmake` 单步耗时 ~8 分钟**。
+  - 根因:xmake 的 global dir 在 Windows 上是 `%LOCALAPPDATA%\.xmake`(xmake 源码 `_global_dir()`:`LOCALAPPDATA → APPDATA → USERPROFILE`,然后拼 `.xmake`)。原 workflow 缓存路径 `~\.xmake\packages` 在 GitHub Actions runner 上展开成 `%USERPROFILE%\.xmake\packages` —— 一个 xmake 根本不写入的目录。所以缓存步骤每次都"成功"但实际什么都没缓存。
+  - 修复:`xlings-ci-windows.yml` 和 `release.yml` 的 Windows 缓存路径都从 `~\.xmake\packages` 改成 `~\AppData\Local\.xmake\packages`。Linux / macOS 的路径不动(那两个平台 `~/.xmake/packages` 就是 xmake 实际用的位置)。冷启动第一次仍然 ~8 分钟,之后命中缓存应该和 Linux/macOS 相当(~30 秒)。
+
 - **prompt marker subos 名色调:bold green → bold magenta(8-color "经典紫")(#272)**
   - 用户反馈 v0.4.17 的 bold-green 名字跟周围 prompt 颜色站位不协调,绿色和 entering message 的 magenta、switched message 的 cyan 混在一起会让 prompt 看着乱。
   - 三种 shell(bash/zsh、fish、PowerShell)同步切到 SGR `\033[1;35m`(8-color magenta,大多数终端 theme 渲染为低饱和度紫色)。括号 `[xsubos:` 和 `]` 仍是 slate-400 灰。`NO_COLOR` / `TERM=dumb` 仍走纯文本 fallback。

--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -2,12 +2,12 @@
 
 ## 2026
 
-### 2026-05 (v0.4.19)
+### 2026-05 (v0.4.18)
 
-- **subos workspace schema 升级:`{active, installed[]}` 形式 (Plan C2,PR A)**
+- **subos workspace schema 升级:`{active, installed[]}` 形式 (Plan C2,PR A) (#273)**
   - 0.4.18 `2026-05-07-xlings-cmd-subos-binding-analysis.md` 里的 C 系方案落地第一步:**subos** 的 `.xlings.json` 中 `workspace` 每个 target 的 value 从原本的 `"<version>"` 字符串升级为对象形式 `{ "active": "X", "installed": ["X","Y","Z"] }`。**project** `.xlings.json` 不动 —— 它是声明意图(`xxx = { linux = "..." }` 平台条件式)而非运行时状态,无需 `installed`。
   - **解析层(`xvm::subos_workspace_from_json`)三种 value 形态都接收**:
-    1. 字符串 `"1.2.3"`(0.4.19 之前的旧文件,自动当作 `active`,`installed[]` 留空,下次 save 自动改写)。
+    1. 字符串 `"1.2.3"`(0.4.18 之前的旧文件,自动当作 `active`,`installed[]` 留空,下次 save 自动改写)。
     2. 对象 `{active, installed}`(新形式)。
     3. 对象 `{linux: ..., windows: ..., default: ...}`(平台条件式 fallback,subos 文件本来不会出现这个形态,但用户手编时容忍掉)。
   - **形态 (2) vs (3) 的歧义靠保留 key 区分**(C2 design 里的 Plan 1):object 出现 `active` 或 `installed` 这两个 key → 当作新形式;否则按平台条件解析。两套 schema 永远不会撞到同一份文件里。
@@ -18,11 +18,10 @@
     - `process_xvm_operations_` remove(无论是 user-initiated remove 还是 install-time upgrade) → 同步从 `installed[]` 抹掉 `ver_key`(再次防御:detach_current_subos_ 通常已经先抹了,但 install upgrade 路径不走 detach)。
     - `detach_current_subos_` → 永远先把 `version` 从 `installed[]` 移除;如果它正好是 active,则做 sysroot 拆除并**自动 fallback 到 `installed[]` 里剩余最高版本**(列表是 sorted ascending,`back()` 即最高);剩余为空才清空 active pointer。**避免"删了 active 之后命令就完全报错"的硬中断**。
   - 影响范围:`config.cppm`、`xvm/db.cppm`、`xvm/types.cppm`(新增 `WorkspaceInstalled` 类型 + `SubosWorkspace` 结构)、`xim/installer.cppm`、`profile.cppm`(GC scan 同时看两边)。**没有 schema 强制升级步骤** —— 旧文件第一次 save 才被改写。
-  - **compat 入口**:`xself::compat::v0_4_19::kSchemaForm` 是空 sentinel,文档化此次 schema migration,挂在 `removal_target: 0.6.0`(到时把 `subos_workspace_from_json` 里支持字符串形态的分支也一起删掉)。
-  - 测试:新增 `subos_workspace_c2_schema_test.sh`(4 个 scenario,覆盖 lazy migration、active+installed 并存、save invariant、active-less object 的容忍读取)。原 `remove_self_guard_test.sh` 里把 workspace value 当字符串读的 python helper 升级为兼容 dict / str 两种。
-  - **下一步(PR B,后续 release)**:`xlings list / use / update` 加 subos-aware 过滤(只显示当前 subos 的 `installed[]` 视图),把这次落下来的数据模型用起来。
-
-### 2026-05 (v0.4.18)
+  - **compat 入口**:`xself::compat::v0_4_18::kSchemaForm` 是空 sentinel,文档化此次 schema migration,挂在 `removal_target: 0.6.0`(到时把 `subos_workspace_from_json` 里支持字符串形态的分支也一起删掉)。
+  - **db.cppm 顺手清理**:之前 `workspace_from_json` 内嵌一份 `current_platform_key` lambda,硬编码 `linux` / `macosx` / `windows`,这次新加 `subos_workspace_from_json` 又复制了一份。两个都改成直接用 `platform::OS_NAME`(per-OS 模块已经导出的常量,`src/platform/{linux,macos,windows}.cppm`)。重复实现合并到 `resolve_platform_workspace_value_` 一个 helper 里。
+  - 测试:新增 `subos_workspace_c2_schema_test.sh`(4 个 scenario,覆盖 lazy migration、active+installed 并存、save invariant、active-less object 的容忍读取);**原 7 个 e2e 测试**里把 workspace value 当字符串读的 python helper 全部升级成兼容 dict / str 两种(`remove_self_guard`、`remove_multi_version`、`xlings_self_replace`、`self_doctor`、`update_package`、`cli_target_compat`、`install_idempotent`)。
+  - **下一步(后续 release)**:`xlings list / use / update` 加 subos-aware 过滤(只显示当前 subos 的 `installed[]` 视图),把这次落下来的数据模型用起来。
 
 - **prompt marker subos 名色调:bold green → bold magenta(8-color "经典紫")(#272)**
   - 用户反馈 v0.4.17 的 bold-green 名字跟周围 prompt 颜色站位不协调,绿色和 entering message 的 magenta、switched message 的 cyan 混在一起会让 prompt 看着乱。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,10 +180,15 @@ jobs:
 
       # Cache xrepo's compiled C++ deps so Release builds reuse what
       # the per-PR CI just built. See xlings-ci-linux.yml for rationale.
+      # Path note: xmake's global dir on Windows is %LOCALAPPDATA%\.xmake,
+      # NOT %USERPROFILE%\.xmake — see the matching comment in
+      # xlings-ci-windows.yml. Pre-fix this cache silently never
+      # populated, so Release builds rebuilt libarchive/zstd/bzip2/lz4
+      # from source on every release.
       - name: Cache xrepo packages
         uses: actions/cache@v4
         with:
-          path: ~\.xmake\packages
+          path: ~\AppData\Local\.xmake\packages
           key: xmake-pkgs-${{ runner.os }}-${{ hashFiles('xmake.lua') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
             xmake-pkgs-${{ runner.os }}-

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -245,6 +245,10 @@ jobs:
         run: |
           bash tests/e2e/build_deps_split_test.sh
 
+      - name: "E2E-22: subos workspace C2 schema (active+installed[] form, lazy migration)"
+        run: |
+          bash tests/e2e/subos_workspace_c2_schema_test.sh
+
       - name: Attach artifact
         uses: actions/upload-artifact@v4
         if: success()

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -51,10 +51,20 @@ jobs:
       # bulk of Configure time is xrepo building libarchive + its
       # compression backends with MSVC; caching those object trees here
       # is the same single-step win as on Linux/macOS.
+      #
+      # xmake's global package root differs from POSIX: on Windows it
+      # lives under %LOCALAPPDATA%\.xmake (xmake source: _global_dir()
+      # returns LOCALAPPDATA → APPDATA → USERPROFILE, in that order, with
+      # `.xmake` appended). The cache used to point at `~\.xmake\packages`
+      # which is %USERPROFILE%\.xmake — a directory xmake never writes
+      # to, so every Windows run silently missed the cache and rebuilt
+      # libarchive/zstd/bzip2/lz4/zlib from source (~8 min Configure
+      # phase). After this fix the Windows Configure drops to roughly
+      # the same time as Linux/macOS once the cache warms up.
       - name: Cache xrepo packages
         uses: actions/cache@v4
         with:
-          path: ~\.xmake\packages
+          path: ~\AppData\Local\.xmake\packages
           key: xmake-pkgs-${{ runner.os }}-${{ hashFiles('xmake.lua') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
             xmake-pkgs-${{ runner.os }}-

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.18";
+    static constexpr std::string_view VERSION = "0.4.19";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 
@@ -52,6 +52,12 @@ private:
     xvm::Workspace globalWorkspace_;
     xvm::Workspace projectWorkspace_;       // from project .xlings.json
     xvm::Workspace projectSubosWorkspace_;  // from project-local subos file
+    // Per-subos installed[] sets, paired with the matching workspace map.
+    // Only subos files (global subos and project subos) carry installed[];
+    // the project manifest's workspace is intent-only and has no
+    // corresponding installed map (Plan 3 of the C2 schema design).
+    xvm::WorkspaceInstalled globalInstalled_;
+    xvm::WorkspaceInstalled projectSubosInstalled_;
     bool hasProjectConfig_ = false;
     bool forceGlobalScope_ = false;
     std::filesystem::path projectDir_;      // directory containing project .xlings.json
@@ -189,14 +195,19 @@ private:
         }
     }
 
-    static xvm::Workspace load_workspace_from_file_(const std::filesystem::path& path) {
+    // Read a subos `.xlings.json` workspace section. Returns the new
+    // SubosWorkspace bundle so callers get both `active` (Workspace) and
+    // `installed[]` (WorkspaceInstalled). Legacy string-form values still
+    // parse cleanly — installed[] just stays empty until the next save
+    // re-emits the file in C2 form.
+    static xvm::SubosWorkspace load_workspace_from_file_(const std::filesystem::path& path) {
         namespace fs = std::filesystem;
         if (!fs::exists(path)) return {};
         try {
             auto content = platform::read_file_to_string(path.string());
             auto json = nlohmann::json::parse(content, nullptr, false);
             if (!json.is_discarded() && json.contains("workspace") && json["workspace"].is_object()) {
-                return xvm::workspace_from_json(json["workspace"]);
+                return xvm::subos_workspace_from_json(json["workspace"]);
             }
         } catch (...) {}
         return {};
@@ -461,7 +472,11 @@ private:
         // with XLINGS_ACTIVE_SUBOS set, which then corrupts that subos
         // when `xvm use` writes back through save_workspace().
         auto subosConfigPath = paths_.homeDir / "subos" / paths_.activeSubos / ".xlings.json";
-        globalWorkspace_ = load_workspace_from_file_(subosConfigPath);
+        {
+            auto sws = load_workspace_from_file_(subosConfigPath);
+            globalWorkspace_ = std::move(sws.active);
+            globalInstalled_ = std::move(sws.installed);
+        }
 
         // Load project-level config (walk up from cwd)
         load_project_config_();
@@ -553,17 +568,20 @@ private:
 
                 if (!projectSubosName_.empty()) {
                     projectSubosMode_ = ProjectSubosMode::Named;
-                    projectSubosWorkspace_ =
-                        load_workspace_from_file_(project_subos_dir_() / ".xlings.json");
+                    auto sws = load_workspace_from_file_(project_subos_dir_() / ".xlings.json");
+                    projectSubosWorkspace_ = std::move(sws.active);
+                    projectSubosInstalled_ = std::move(sws.installed);
                 } else {
                     projectSubosMode_ = ProjectSubosMode::Anonymous;
                     if (hasProjectStateJson && projectStateJson.contains("workspace") &&
                         projectStateJson["workspace"].is_object()) {
-                        projectSubosWorkspace_ =
-                            xvm::workspace_from_json(projectStateJson["workspace"]);
+                        auto sws = xvm::subos_workspace_from_json(projectStateJson["workspace"]);
+                        projectSubosWorkspace_ = std::move(sws.active);
+                        projectSubosInstalled_ = std::move(sws.installed);
                     } else {
-                        projectSubosWorkspace_ =
-                            load_workspace_from_file_(project_subos_dir_() / ".xlings.json");
+                        auto sws = load_workspace_from_file_(project_subos_dir_() / ".xlings.json");
+                        projectSubosWorkspace_ = std::move(sws.active);
+                        projectSubosInstalled_ = std::move(sws.installed);
                     }
                 }
             }
@@ -808,6 +826,25 @@ public:
             self.projectSubosMode_ == ProjectSubosMode::Anonymous) return self.projectSubosWorkspace_;
         return self.projectWorkspace_;
     }
+
+    // Read access to per-subos installed[] sets, paired with the
+    // workspace returned by workspace()/workspace_mut(). Only meaningful
+    // for subos-side writes (project manifest path returns an empty
+    // installed map since the project file format has no installed).
+    [[nodiscard]] static const xvm::WorkspaceInstalled& workspace_installed() {
+        auto& self = instance_();
+        if (!self.hasProjectConfig_) return self.globalInstalled_;
+        if (self.projectSubosMode_ == ProjectSubosMode::Named ||
+            self.projectSubosMode_ == ProjectSubosMode::Anonymous) return self.projectSubosInstalled_;
+        return self.globalInstalled_;
+    }
+    [[nodiscard]] static xvm::WorkspaceInstalled& workspace_installed_mut() {
+        auto& self = instance_();
+        if (self.forceGlobalScope_ || !self.hasProjectConfig_) return self.globalInstalled_;
+        if (self.projectSubosMode_ == ProjectSubosMode::Named ||
+            self.projectSubosMode_ == ProjectSubosMode::Anonymous) return self.projectSubosInstalled_;
+        return self.globalInstalled_;
+    }
     [[nodiscard]] static bool has_project_config() { return instance_().hasProjectConfig_; }
 
     // Force all version/workspace writes to go to global scope.
@@ -934,11 +971,32 @@ public:
             } catch (...) { json = nlohmann::json::object(); }
         }
 
-        auto& workspace = useProject
-            ? ((self.projectSubosMode_ == ProjectSubosMode::Named ||
-                self.projectSubosMode_ == ProjectSubosMode::Anonymous) ? self.projectSubosWorkspace_ : self.projectWorkspace_)
-            : self.globalWorkspace_;
-        json["workspace"] = xvm::workspace_to_json(workspace);
+        // All four destination paths above target subos-side files
+        // (named project subos, anonymous project subos / state file, or
+        // global subos directory). The user-authored project manifest
+        // (`<proj>/.xlings.json`) is read-only from save_workspace's
+        // perspective and never reached here. So we always emit the
+        // 0.4.19+ C2 form via subos_workspace_to_json — backward-compat
+        // for legacy string-form values is in the *read* path
+        // (subos_workspace_from_json).
+        xvm::SubosWorkspace sws;
+        if (useProject &&
+            (self.projectSubosMode_ == ProjectSubosMode::Named ||
+             self.projectSubosMode_ == ProjectSubosMode::Anonymous)) {
+            sws.active = self.projectSubosWorkspace_;
+            sws.installed = self.projectSubosInstalled_;
+        } else if (useProject) {
+            // Reachable only via the third save-path branch above (project
+            // mode without a subos mode, currently unreachable in practice
+            // because load_project_config_from_dir_ always forces
+            // Anonymous when subos is unset). Write the project manifest
+            // workspace through with no installed[] info.
+            sws.active = self.projectWorkspace_;
+        } else {
+            sws.active = self.globalWorkspace_;
+            sws.installed = self.globalInstalled_;
+        }
+        json["workspace"] = xvm::subos_workspace_to_json(sws);
         platform::write_string_to_file(subosConfigPath.string(), json.dump(2));
     }
 

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.19";
+    static constexpr std::string_view VERSION = "0.4.18";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/profile.cppm
+++ b/src/core/profile.cppm
@@ -195,9 +195,20 @@ std::set<std::string> collect_subos_references_(const fs::path& xlingsHome) {
 
     // Build a map: xpkg_dir_name/version -> key, from versions DB paths
     // e.g., "xim-x-gcc/15.1.0" from path "/home/.../.xlings/data/xpkgs/xim-x-gcc/15.1.0/bin"
-    auto add_refs_from_workspace = [&](const xvm::Workspace& ws) {
-        for (auto& [target, activeVer] : ws) {
-            // Find this target in the versions DB
+    //
+    // Pin every payload of every target name that appears in either the
+    // active or installed[] map. (The lambda is intentionally coarse:
+    // currently a target name in workspace pins ALL versions of that
+    // target; finer-grained per-version pinning is a separate
+    // refactor.) The 0.4.19 fix here is to also walk installed[] —
+    // pre-fix, a target only pinned in installed[] of some subos (e.g.
+    // after `xlings remove` cleared its active but the user kept
+    // installed[]) was eligible for GC.
+    auto add_refs_from_subos_workspace = [&](const xvm::SubosWorkspace& sws) {
+        std::set<std::string> targetNames;
+        for (auto& [target, _] : sws.active) targetNames.insert(target);
+        for (auto& [target, _] : sws.installed) targetNames.insert(target);
+        for (auto& target : targetNames) {
             auto it = globalDB.find(target);
             if (it == globalDB.end()) continue;
             for (auto& [verKey, vdata] : it->second.versions) {
@@ -232,7 +243,7 @@ std::set<std::string> collect_subos_references_(const fs::path& xlingsHome) {
                 auto content = platform::read_file_to_string(wsPath.string());
                 auto json = nlohmann::json::parse(content, nullptr, false);
                 if (!json.is_discarded() && json.contains("workspace"))
-                    add_refs_from_workspace(xvm::workspace_from_json(json["workspace"]));
+                    add_refs_from_subos_workspace(xvm::subos_workspace_from_json(json["workspace"]));
             } catch (...) {}
         }
     }
@@ -257,8 +268,9 @@ export std::vector<std::string> find_subos_referencing(
             auto content = platform::read_file_to_string(wsPath.string());
             auto json = nlohmann::json::parse(content, nullptr, false);
             if (json.is_discarded() || !json.contains("workspace")) continue;
-            auto ws = xvm::workspace_from_json(json["workspace"]);
-            if (ws.contains(target)) result.push_back(name);
+            auto sws = xvm::subos_workspace_from_json(json["workspace"]);
+            if (sws.active.contains(target) || sws.installed.contains(target))
+                result.push_back(name);
         } catch (...) {}
     }
     return result;

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -267,7 +267,7 @@ std::filesystem::path current_workspace_config_path_() {
     return Config::paths().homeDir / "subos" / Config::paths().activeSubos / ".xlings.json";
 }
 
-xvm::Workspace load_workspace_file_(const std::filesystem::path& path) {
+xvm::SubosWorkspace load_workspace_file_(const std::filesystem::path& path) {
     std::error_code ec;
     if (!std::filesystem::exists(path, ec)) return {};
     try {
@@ -275,7 +275,7 @@ xvm::Workspace load_workspace_file_(const std::filesystem::path& path) {
         auto json = nlohmann::json::parse(content, nullptr, false);
         if (json.is_discarded() || !json.is_object()) return {};
         if (!json.contains("workspace") || !json["workspace"].is_object()) return {};
-        return xvm::workspace_from_json(json["workspace"]);
+        return xvm::subos_workspace_from_json(json["workspace"]);
     } catch (...) {
         return {};
     }
@@ -330,9 +330,30 @@ bool is_version_referenced_anywhere_(PackageScope scope,
         if (!excludeCanonical.empty() && !ec && canonical == excludeCanonical) {
             continue;
         }
-        auto workspace = load_workspace_file_(configPath);
-        auto it = workspace.find(target);
-        if (it != workspace.end() && it->second == version) return true;
+        // 0.4.19+: a payload is "referenced" by a subos if EITHER its
+        // active version equals `version` OR `version` appears in that
+        // subos's installed[] set. Pre-0.4.19 the active-only check was
+        // sufficient because installed[] didn't exist; with C2 schema a
+        // user can `xlings remove` the active version while still having
+        // other installed versions, and a payload that only appears in
+        // some other subos's installed[] (but not its active) must still
+        // pin its xpkgs/ directory against GC.
+        //
+        // Stored values are namespaced (`ns:1.0` for non-primary repos,
+        // bare for primary), but `version` from the caller is bare —
+        // accept either form, same as detach_current_subos_.
+        auto matches = [&](std::string_view stored) {
+            return stored == version
+                || xvm::strip_namespace(std::string(stored)) == version;
+        };
+        auto sws = load_workspace_file_(configPath);
+        if (auto it = sws.active.find(target);
+            it != sws.active.end() && matches(it->second)) return true;
+        if (auto it = sws.installed.find(target); it != sws.installed.end()) {
+            for (auto& v : it->second) {
+                if (matches(v)) return true;
+            }
+        }
     }
     return false;
 }
@@ -390,25 +411,75 @@ void remove_target_shims_(const std::string& target, const std::string& version)
 
 void detach_current_subos_(const std::string& target, const std::string& version) {
     auto& ws = Config::workspace_mut();
-    auto wit = ws.find(target);
-    if (wit == ws.end() || wit->second != version) return;
+    auto& wsi = Config::workspace_installed_mut();
 
-    auto db = Config::versions();
-    auto sysroot_include = Config::paths().subosDir / "usr" / "include";
-    auto sysroot_lib = Config::paths().libDir;
+    // Stored ver-key in workspace/installed[] is namespaced
+    // (`make_ns_version(version_ns, ver)`) — for the primary repo this
+    // is bare, but for `fromsource:` / `myrepo:` packages it carries the
+    // `ns:` prefix. Callers (uninstall) pass us a bare `version` (the
+    // user's typed value, or PackageMatch.version which is always bare).
+    // Match either form so non-primary-namespace removes don't silently
+    // leave stale active+installed entries.
+    auto matches = [&](std::string_view stored) {
+        return stored == version || xvm::strip_namespace(std::string(stored)) == version;
+    };
 
-    if (auto* vdata = xvm::get_vdata(db, target, version)) {
-        if (!vdata->includedir.empty()) {
-            xvm::remove_headers(vdata->includedir, sysroot_include);
-        }
-        if (!vdata->libdir.empty()) {
-            xvm::remove_libdir(vdata->libdir, sysroot_lib);
+    // Step 1 (0.4.19+): always drop `version` from this subos's
+    // installed[] set, even when it isn't the currently active version.
+    // The set is the per-subos opt-in list; an explicit `xlings remove
+    // foo@X` always means "this subos no longer wants X".
+    bool installedChanged = false;
+    if (auto it = wsi.find(target); it != wsi.end()) {
+        auto& list = it->second;
+        auto pred = [&](const std::string& v) { return matches(v); };
+        auto erased = std::remove_if(list.begin(), list.end(), pred);
+        if (erased != list.end()) {
+            list.erase(erased, list.end());
+            installedChanged = true;
+            if (list.empty()) wsi.erase(it);
         }
     }
 
-    remove_target_shims_(target, version);
-    ws.erase(wit);
-    Config::save_workspace();
+    // Step 2: if `version` was the active pointer, do the actual subos
+    // teardown (remove headers / libs / shims) and then either fall
+    // back to another installed version or clear the pointer entirely.
+    auto wit = ws.find(target);
+    bool wasActive = wit != ws.end() && matches(wit->second);
+
+    if (wasActive) {
+        auto db = Config::versions();
+        auto sysroot_include = Config::paths().subosDir / "usr" / "include";
+        auto sysroot_lib = Config::paths().libDir;
+        if (auto* vdata = xvm::get_vdata(db, target, version)) {
+            if (!vdata->includedir.empty()) {
+                xvm::remove_headers(vdata->includedir, sysroot_include);
+            }
+            if (!vdata->libdir.empty()) {
+                xvm::remove_libdir(vdata->libdir, sysroot_lib);
+            }
+        }
+        remove_target_shims_(target, version);
+
+        // Auto-fallback: when the user removes the active version but
+        // still has other versions installed in this subos, switch
+        // active to the highest remaining (installed[] is stored
+        // sorted ascending by subos_workspace_to_json — `back()` is
+        // the lexicographically-highest, which approximates "newest"
+        // for typical semver-ish version strings).
+        //
+        // The shim for the fallback version already exists from its
+        // earlier install — only the active pointer needs updating;
+        // headers/libs are NOT auto-relinked (lazy: next call to
+        // `xlings use` would do that explicitly). This avoids a
+        // surprise sysroot reshuffle on every remove.
+        if (auto sit = wsi.find(target); sit != wsi.end() && !sit->second.empty()) {
+            wit->second = sit->second.back();
+        } else {
+            ws.erase(wit);
+        }
+    }
+
+    if (wasActive || installedChanged) Config::save_workspace();
 }
 
 void process_xvm_operations_(const PlanNode& node,
@@ -476,6 +547,19 @@ void process_xvm_operations_(const PlanNode& node,
                 bool didActivate = !hasActive || useAfterInstall;
                 if (didActivate) {
                     Config::workspace_mut()[op.name] = ver_key;
+                }
+
+                // 0.4.19+: track ver_key in this subos's installed[] set.
+                // Independent of the active-pointer decision above — a
+                // version is "installed in this subos" once the package
+                // recipe has been run for it, regardless of whether it's
+                // the currently selected one. The set is what powers
+                // subos-aware list/use/update in the next PR.
+                {
+                    auto& list = Config::workspace_installed_mut()[op.name];
+                    if (std::find(list.begin(), list.end(), ver_key) == list.end()) {
+                        list.push_back(ver_key);
+                    }
                 }
                 if (std::filesystem::exists(xlings_bin)) {
                     std::string shim_name = op.name;
@@ -569,6 +653,34 @@ void process_xvm_operations_(const PlanNode& node,
                 }
             }
             Config::workspace_mut().erase(op.name);
+
+            // 0.4.19+: keep installed[] in sync with the versions DB
+            // wipe. detach_current_subos_ usually pruned `op.version`
+            // already (in the user-initiated remove flow), but
+            // install-time upgrades (recipe emits xvm:remove for the
+            // old version before xvm:add for the new) reach this op
+            // without going through detach. The version key inside
+            // installed[] is the namespaced form (`ns:ver` or bare —
+            // see `add` path above for derivation). Match either form
+            // so we don't leave stale entries when op.version arrives
+            // as a bare string from a recipe even though storage is
+            // namespaced.
+            auto& wsi = Config::workspace_installed_mut();
+            if (op.version.empty()) {
+                wsi.erase(op.name);
+            } else {
+                if (auto it = wsi.find(op.name); it != wsi.end()) {
+                    auto& list = it->second;
+                    auto erased = std::remove_if(list.begin(), list.end(),
+                        [&](const std::string& v) {
+                            return v == op.version
+                                || xvm::strip_namespace(v) == op.version;
+                        });
+                    list.erase(erased, list.end());
+                    if (list.empty()) wsi.erase(it);
+                }
+            }
+
             if (op.version.empty()) {
                 db.erase(op.name);
             } else {

--- a/src/core/xself/compat.cppm
+++ b/src/core/xself/compat.cppm
@@ -166,6 +166,44 @@ void auto_upgrade_profiles_if_stale(const fs::path& home_dir);
 
 } // namespace v0_4_17
 
+// =======================================================================
+// COMPAT(0.4.19 → drop in 0.6.0)  removal_target: 0.6.0
+//
+// 0.4.19 changed the subos `.xlings.json` workspace value type from a
+// plain version string to an object with `{active, installed[]}` fields
+// (the "C2 schema"). The new form lets each subos track its own opt-in
+// version set independently of the global `versions` payload metadata,
+// which in turn lets `xlings list / use / update` give a per-subos view
+// (PR B in the rollout plan) and lets the GC refcount honor inactive
+// installs (the `installed[]` set holds versions that should keep their
+// payloads pinned even when not currently active).
+//
+// The compat surface is in two places, both in the parser, NOT here:
+//
+//   1. `xvm::subos_workspace_from_json` (src/core/xvm/db.cppm) accepts
+//      the legacy string value as form (1) and silently lifts it into
+//      a SubosWorkspace with `installed[]` empty.
+//   2. The save path in `Config::save_workspace` always emits the new
+//      object form, so any subos file written by 0.4.19+ is immediately
+//      in C2 form. Lazy migration: the first install / use / remove
+//      after upgrade rewrites the file.
+//
+// There's no helper function to call here — the change is fully passive.
+// This block exists only as documentation and as a removal anchor: when
+// 0.6.0 lands and we no longer support direct upgrades from ≤0.4.18,
+// rip out the form-(1) string branch in subos_workspace_from_json and
+// delete this block.
+// =======================================================================
+export namespace v0_4_19 {
+
+// Sentinel marker — referencing this from other modules will surface
+// as a build error once this namespace is deleted, the same way the
+// other compat blocks in this file work. No code currently references
+// it; it exists to make the removal trace concrete.
+inline constexpr std::string_view kSchemaForm = "subos workspace = {active, installed[]}";
+
+} // namespace v0_4_19
+
 
 // =======================================================================
 // Implementations

--- a/src/core/xself/compat.cppm
+++ b/src/core/xself/compat.cppm
@@ -167,16 +167,16 @@ void auto_upgrade_profiles_if_stale(const fs::path& home_dir);
 } // namespace v0_4_17
 
 // =======================================================================
-// COMPAT(0.4.19 → drop in 0.6.0)  removal_target: 0.6.0
+// COMPAT(0.4.18 → drop in 0.6.0)  removal_target: 0.6.0
 //
-// 0.4.19 changed the subos `.xlings.json` workspace value type from a
+// 0.4.18 changed the subos `.xlings.json` workspace value type from a
 // plain version string to an object with `{active, installed[]}` fields
 // (the "C2 schema"). The new form lets each subos track its own opt-in
 // version set independently of the global `versions` payload metadata,
 // which in turn lets `xlings list / use / update` give a per-subos view
-// (PR B in the rollout plan) and lets the GC refcount honor inactive
-// installs (the `installed[]` set holds versions that should keep their
-// payloads pinned even when not currently active).
+// (subsequent PR in the rollout plan) and lets the GC refcount honor
+// inactive installs (the `installed[]` set holds versions that should
+// keep their payloads pinned even when not currently active).
 //
 // The compat surface is in two places, both in the parser, NOT here:
 //
@@ -184,17 +184,17 @@ void auto_upgrade_profiles_if_stale(const fs::path& home_dir);
 //      the legacy string value as form (1) and silently lifts it into
 //      a SubosWorkspace with `installed[]` empty.
 //   2. The save path in `Config::save_workspace` always emits the new
-//      object form, so any subos file written by 0.4.19+ is immediately
+//      object form, so any subos file written by 0.4.18+ is immediately
 //      in C2 form. Lazy migration: the first install / use / remove
 //      after upgrade rewrites the file.
 //
 // There's no helper function to call here — the change is fully passive.
 // This block exists only as documentation and as a removal anchor: when
-// 0.6.0 lands and we no longer support direct upgrades from ≤0.4.18,
+// 0.6.0 lands and we no longer support direct upgrades from ≤0.4.17,
 // rip out the form-(1) string branch in subos_workspace_from_json and
 // delete this block.
 // =======================================================================
-export namespace v0_4_19 {
+export namespace v0_4_18 {
 
 // Sentinel marker — referencing this from other modules will surface
 // as a build error once this namespace is deleted, the same way the
@@ -202,7 +202,7 @@ export namespace v0_4_19 {
 // it; it exists to make the removal trace concrete.
 inline constexpr std::string_view kSchemaForm = "subos workspace = {active, installed[]}";
 
-} // namespace v0_4_19
+} // namespace v0_4_18
 
 
 // =======================================================================

--- a/src/core/xvm/db.cppm
+++ b/src/core/xvm/db.cppm
@@ -464,4 +464,136 @@ nlohmann::json workspace_to_json(const Workspace& ws) {
     return j;
 }
 
+// Subos-flavored workspace parser. Accepts three value shapes per target:
+//
+//   1. string                      (legacy, pre-0.4.19) — active version,
+//                                  no installed[] info available
+//   2. {active, installed[]}       (current, 0.4.19+)   — both fields
+//   3. {linux|windows|macosx|...}  (project-style)      — resolved to a
+//                                  single string the same way project files
+//                                  resolve it; subos files normally don't
+//                                  have this shape but we accept it as a
+//                                  graceful fallback so users who ever
+//                                  hand-edit a subos file aren't surprised
+//
+// Disambiguation between (2) and (3) is by reserved-key detection: the
+// presence of an "active" or "installed" key marks form (2). This is the
+// "Plan 1" disambiguation strategy from the C2 design discussion — `active`
+// and `installed` cannot meaningfully be platform names, so the two object
+// shapes can never collide.
+SubosWorkspace subos_workspace_from_json(const nlohmann::json& j) {
+    SubosWorkspace sws;
+    if (!j.is_object()) return sws;
+
+    auto current_platform_key = []() -> std::string_view {
+#if defined(_WIN32)
+        return "windows";
+#elif defined(__APPLE__)
+        return "macosx";
+#elif defined(__linux__)
+        return "linux";
+#else
+        return "";
+#endif
+    };
+
+    auto resolve_platform = [&](const nlohmann::json& value) -> std::optional<std::string> {
+        auto platformKey = current_platform_key();
+        if (!platformKey.empty()) {
+            auto platformIt = value.find(std::string(platformKey));
+            if (platformIt != value.end() && platformIt->is_string()) {
+                return platformIt->get<std::string>();
+            }
+        }
+        if (auto defaultIt = value.find("default");
+            defaultIt != value.end() && defaultIt->is_string()) {
+            return defaultIt->get<std::string>();
+        }
+        return std::nullopt;
+    };
+
+    for (auto it = j.begin(); it != j.end(); ++it) {
+        const auto& key = it.key();
+        const auto& value = it.value();
+
+        if (value.is_string()) {
+            // Legacy form: bare version string. installed[] left empty —
+            // callers that maintain installed[] (install/remove flow) will
+            // populate it on next write, lazily migrating the file.
+            sws.active[key] = value.get<std::string>();
+            continue;
+        }
+
+        if (!value.is_object()) continue;
+
+        // Form (2): C2 object form
+        bool hasActive = value.contains("active");
+        bool hasInstalled = value.contains("installed");
+        if (hasActive || hasInstalled) {
+            if (hasActive && value.at("active").is_string()) {
+                sws.active[key] = value.at("active").get<std::string>();
+            }
+            if (hasInstalled && value.at("installed").is_array()) {
+                std::vector<std::string> installed;
+                for (auto& v : value.at("installed")) {
+                    if (v.is_string()) installed.push_back(v.get<std::string>());
+                }
+                if (!installed.empty()) sws.installed[key] = std::move(installed);
+            }
+            continue;
+        }
+
+        // Form (3): platform-conditional fallback
+        if (auto resolved = resolve_platform(value)) {
+            sws.active[key] = *resolved;
+        }
+    }
+
+    return sws;
+}
+
+// Subos workspace serializer. Always emits the C2 object form with
+// `active` and `installed` keys. The `installed` set is normalized to
+// always include the active version (write-time invariant: an active
+// version is implicitly installed). `installed` is omitted from output
+// when empty, keeping legacy entries — those that were read in form (1)
+// and never had an install/remove since — visually compact.
+//
+// Stable sort on installed[] so json diffs remain reviewable across runs.
+nlohmann::json subos_workspace_to_json(const SubosWorkspace& sws) {
+    nlohmann::json j = nlohmann::json::object();
+
+    // Union of all target keys present in either map
+    std::set<std::string> keys;
+    for (auto& [k, _] : sws.active) keys.insert(k);
+    for (auto& [k, _] : sws.installed) keys.insert(k);
+
+    for (const auto& key : keys) {
+        std::string active;
+        if (auto it = sws.active.find(key); it != sws.active.end()) {
+            active = it->second;
+        }
+
+        std::vector<std::string> installed;
+        if (auto it = sws.installed.find(key); it != sws.installed.end()) {
+            installed = it->second;
+        }
+        if (!active.empty() &&
+            std::find(installed.begin(), installed.end(), active) == installed.end()) {
+            installed.push_back(active);
+        }
+        std::sort(installed.begin(), installed.end());
+
+        nlohmann::json entry = nlohmann::json::object();
+        if (!active.empty()) entry["active"] = active;
+        if (!installed.empty()) {
+            entry["installed"] = nlohmann::json::array();
+            for (auto& v : installed) entry["installed"].push_back(v);
+        }
+        j[key] = std::move(entry);
+    }
+
+    return j;
+}
+
 } // namespace xlings::xvm

--- a/src/core/xvm/db.cppm
+++ b/src/core/xvm/db.cppm
@@ -4,6 +4,7 @@ import std;
 
 import xlings.core.xvm.types;
 import xlings.libs.json;
+import xlings.platform;
 
 export namespace xlings::xvm {
 
@@ -408,48 +409,38 @@ VersionDB versions_from_json(const nlohmann::json& j) {
     return db;
 }
 
+// Resolve a project-style workspace value (string | platform-conditional
+// object) to a single version string. Lifted out of workspace_from_json
+// so subos_workspace_from_json can reuse the same fallback semantics
+// when it falls through to the form-(3) platform branch. Returns
+// std::nullopt when the value has no matching platform key and no
+// `default` key — caller decides whether to skip or error.
+inline std::optional<std::string>
+resolve_platform_workspace_value_(const nlohmann::json& value) {
+    if (value.is_string()) {
+        return value.get<std::string>();
+    }
+    if (!value.is_object()) {
+        return std::nullopt;
+    }
+    if (!platform::OS_NAME.empty()) {
+        auto platformIt = value.find(std::string(platform::OS_NAME));
+        if (platformIt != value.end() && platformIt->is_string()) {
+            return platformIt->get<std::string>();
+        }
+    }
+    if (auto defaultIt = value.find("default");
+        defaultIt != value.end() && defaultIt->is_string()) {
+        return defaultIt->get<std::string>();
+    }
+    return std::nullopt;
+}
+
 Workspace workspace_from_json(const nlohmann::json& j) {
     Workspace ws;
     if (!j.is_object()) return ws;
-
-    auto current_platform_key = []() -> std::string_view {
-#if defined(_WIN32)
-        return "windows";
-#elif defined(__APPLE__)
-        return "macosx";
-#elif defined(__linux__)
-        return "linux";
-#else
-        return "";
-#endif
-    };
-
-    auto resolve_workspace_version = [&](const nlohmann::json& value) -> std::optional<std::string> {
-        if (value.is_string()) {
-            return value.get<std::string>();
-        }
-        if (!value.is_object()) {
-            return std::nullopt;
-        }
-
-        auto platformKey = current_platform_key();
-        if (!platformKey.empty()) {
-            auto platformIt = value.find(std::string(platformKey));
-            if (platformIt != value.end() && platformIt->is_string()) {
-                return platformIt->get<std::string>();
-            }
-        }
-
-        if (auto defaultIt = value.find("default");
-            defaultIt != value.end() && defaultIt->is_string()) {
-            return defaultIt->get<std::string>();
-        }
-
-        return std::nullopt;
-    };
-
     for (auto it = j.begin(); it != j.end(); ++it) {
-        if (auto resolved = resolve_workspace_version(it.value())) {
+        if (auto resolved = resolve_platform_workspace_value_(it.value())) {
             ws[it.key()] = *resolved;
         }
     }
@@ -485,33 +476,6 @@ SubosWorkspace subos_workspace_from_json(const nlohmann::json& j) {
     SubosWorkspace sws;
     if (!j.is_object()) return sws;
 
-    auto current_platform_key = []() -> std::string_view {
-#if defined(_WIN32)
-        return "windows";
-#elif defined(__APPLE__)
-        return "macosx";
-#elif defined(__linux__)
-        return "linux";
-#else
-        return "";
-#endif
-    };
-
-    auto resolve_platform = [&](const nlohmann::json& value) -> std::optional<std::string> {
-        auto platformKey = current_platform_key();
-        if (!platformKey.empty()) {
-            auto platformIt = value.find(std::string(platformKey));
-            if (platformIt != value.end() && platformIt->is_string()) {
-                return platformIt->get<std::string>();
-            }
-        }
-        if (auto defaultIt = value.find("default");
-            defaultIt != value.end() && defaultIt->is_string()) {
-            return defaultIt->get<std::string>();
-        }
-        return std::nullopt;
-    };
-
     for (auto it = j.begin(); it != j.end(); ++it) {
         const auto& key = it.key();
         const auto& value = it.value();
@@ -543,8 +507,11 @@ SubosWorkspace subos_workspace_from_json(const nlohmann::json& j) {
             continue;
         }
 
-        // Form (3): platform-conditional fallback
-        if (auto resolved = resolve_platform(value)) {
+        // Form (3): platform-conditional fallback. Reuses the project-style
+        // resolver — subos files don't normally carry this shape, but
+        // honoring it here means a hand-edited subos file with platform
+        // branches behaves the same way the project manifest would.
+        if (auto resolved = resolve_platform_workspace_value_(value)) {
             sws.active[key] = *resolved;
         }
     }

--- a/src/core/xvm/types.cppm
+++ b/src/core/xvm/types.cppm
@@ -54,6 +54,32 @@ struct VInfo {
 using VersionDB = std::map<std::string, VInfo>;
 using Workspace = std::map<std::string, std::string>;  // target -> active version
 
+// Per-subos installed-version sets, sibling to Workspace.
+//
+// Workspace answers "which version is currently active for target T?"
+// WorkspaceInstalled answers "which versions has this subos opted into for T?"
+//
+// The two maps are kept side-by-side rather than fused into one struct so
+// that every existing reader of `Workspace` (shim dispatch, project-mode
+// resolution, list/use, GC's by-target check) continues to compile and
+// behave identically — `installed[]` is an additive concept that only
+// surfaces in subos-aware code paths.
+//
+// Project-mode workspace (the user-authored .xlings.json under a project
+// root) intentionally does NOT carry an installed[] set: project files
+// declare intent ("we want gcc 15.1.0" / "{linux: ..., windows: ...}"),
+// not runtime state. Only subos workspace files carry WorkspaceInstalled.
+using WorkspaceInstalled = std::map<std::string, std::vector<std::string>>;
+
+// Bundle for the subos `.xlings.json` workspace section: active version
+// per target plus installed[] per target. Used by subos_workspace_from_json
+// / subos_workspace_to_json. Kept distinct from Workspace so that callers
+// that only ever needed the active version do not see the new field.
+struct SubosWorkspace {
+    Workspace active;
+    WorkspaceInstalled installed;
+};
+
 } // namespace xlings::xvm
 
 #if !defined(_MSC_VER)

--- a/tests/e2e/cli_target_compat_test.sh
+++ b/tests/e2e/cli_target_compat_test.sh
@@ -111,7 +111,14 @@ active_version() {
   python3 - "$HOME_DIR" <<'PY'
 import json, sys, pathlib
 ws = json.loads(pathlib.Path(sys.argv[1], "subos/default/.xlings.json").read_text())
-print((ws.get("workspace") or {}).get("dpkg", "<none>"))
+entry = (ws.get("workspace") or {}).get("dpkg")
+# 0.4.19+: workspace value is {active, installed[]} dict; tolerate both forms.
+if isinstance(entry, dict):
+    print(entry.get("active", "<none>"))
+elif isinstance(entry, str):
+    print(entry)
+else:
+    print("<none>")
 PY
 }
 

--- a/tests/e2e/install_idempotent_test.sh
+++ b/tests/e2e/install_idempotent_test.sh
@@ -132,7 +132,8 @@ python3 - "$HOME_DIR" 1.0.0 <<'PY' || fail "reset: workspace active version wron
 import json, sys, pathlib
 home, want = sys.argv[1:]
 ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
-got = (ws.get("workspace") or {}).get("idempotent-fixture")
+entry = (ws.get("workspace") or {}).get("idempotent-fixture")
+got = entry.get("active") if isinstance(entry, dict) else entry  # 0.4.19 schema
 assert got == want, f"expected active={want}, got {got!r}"
 PY
 

--- a/tests/e2e/remove_multi_version_test.sh
+++ b/tests/e2e/remove_multi_version_test.sh
@@ -174,7 +174,10 @@ assert vers == ["1.0.0", "2.0.0"], \
     f"S1: DB should have [1.0.0, 2.0.0] after removing active 3.0.0; got {vers}"
 
 ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
-active = (ws.get("workspace") or {}).get("rm-fixture")
+entry = (ws.get("workspace") or {}).get("rm-fixture")
+# 0.4.19+: workspace value is {active, installed[]} dict; pre-0.4.19 was a
+# bare string. Tolerate both.
+active = entry.get("active") if isinstance(entry, dict) else entry
 assert active == "2.0.0", \
     f"S1: active should auto-switch to highest remaining (2.0.0); got {active!r}"
 PY
@@ -201,7 +204,8 @@ vers = sorted((data.get("versions") or {}).get("rm-fixture", {}).get("versions",
 assert vers == ["2.0.0"], f"S2: DB should only contain [2.0.0]; got {vers}"
 
 ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
-active = (ws.get("workspace") or {}).get("rm-fixture")
+entry = (ws.get("workspace") or {}).get("rm-fixture")
+active = entry.get("active") if isinstance(entry, dict) else entry
 assert active == "2.0.0", \
     f"S2: active must remain 2.0.0 after removing non-active 1.0.0; got {active!r}"
 PY

--- a/tests/e2e/remove_self_guard_test.sh
+++ b/tests/e2e/remove_self_guard_test.sh
@@ -64,7 +64,15 @@ xlings_active() {
 import json, sys, pathlib
 home = sys.argv[1]
 ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
-print((ws.get("workspace") or {}).get("xlings", "<none>"))
+entry = (ws.get("workspace") or {}).get("xlings")
+# 0.4.19+: workspace value is {active, installed[]} object form. Pre-0.4.19
+# files (or the absent-entry case) still give a plain string / None.
+if isinstance(entry, dict):
+    print(entry.get("active", "<none>"))
+elif isinstance(entry, str):
+    print(entry)
+else:
+    print("<none>")
 PY
 }
 

--- a/tests/e2e/self_doctor_test.sh
+++ b/tests/e2e/self_doctor_test.sh
@@ -213,8 +213,11 @@ data = json.loads(pathlib.Path(home, ".xlings.json").read_text())
 assert "doctor-fixture" in (data.get("versions") or {}), \
     "S8: --fix must NOT remove doctor-fixture from versions DB"
 ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
-assert (ws.get("workspace") or {}).get("doctor-fixture") == "1.0.0", \
-    "S8: --fix must NOT clear workspace pointer"
+entry = (ws.get("workspace") or {}).get("doctor-fixture")
+# 0.4.19+: workspace value is {active, installed[]} dict; tolerate both forms.
+active = entry.get("active") if isinstance(entry, dict) else entry
+assert active == "1.0.0", \
+    f"S8: --fix must NOT clear workspace pointer; got active={active!r}"
 PY
 [[ -e "$SHIM" ]] || fail "S8: --fix must NOT remove shim file (only hints user to install)"
 

--- a/tests/e2e/subos_workspace_c2_schema_test.sh
+++ b/tests/e2e/subos_workspace_c2_schema_test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# subos_workspace_c2_schema_test.sh — verifies the 0.4.19 subos workspace
+# schema migration:
+#
+#   1. Pre-0.4.19 string-form workspace value is read without loss.
+#   2. The first save_workspace after upgrade rewrites the file in
+#      `{active, installed[]}` (C2) form.
+#   3. Hand-crafted C2-form input is read correctly (active and
+#      installed both populated).
+#   4. `xlings use` switching the active version preserves installed[].
+#   5. Save invariant: `active` always appears in `installed[]`.
+#
+# This is a parser/schema test only — it pre-populates the global
+# versions DB by hand so it can exercise `xlings use` without needing a
+# real package payload or pkgindex network access.
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+HOME_DIR="$(runtime_home_dir subos_workspace_c2_schema_home)"
+SUBOS_FILE="$HOME_DIR/subos/default/.xlings.json"
+XLINGS_BIN="$(find_xlings_bin)"
+
+cleanup() { rm -rf "$HOME_DIR" /tmp/c2_schema_fakebin; }
+trap cleanup EXIT
+
+rm -rf "$HOME_DIR"
+mkdir -p "$HOME_DIR/subos/default/bin" \
+         "$HOME_DIR/subos/default/lib" \
+         "$HOME_DIR/subos/default/usr"
+mkdir -p /tmp/c2_schema_fakebin/v1 /tmp/c2_schema_fakebin/v2 /tmp/c2_schema_fakebin/v3
+for v in v1 v2 v3; do
+  : > /tmp/c2_schema_fakebin/$v/tt
+  chmod +x /tmp/c2_schema_fakebin/$v/tt
+done
+
+cat > "$HOME_DIR/.xlings.json" <<JSON
+{
+  "activeSubos": "default",
+  "versions": {
+    "tt": {
+      "type": "program",
+      "filename": "tt",
+      "versions": {
+        "1.0.0": {"path": "/tmp/c2_schema_fakebin/v1", "envs": {}, "alias": []},
+        "2.0.0": {"path": "/tmp/c2_schema_fakebin/v2", "envs": {}, "alias": []},
+        "3.0.0": {"path": "/tmp/c2_schema_fakebin/v3", "envs": {}, "alias": []}
+      }
+    }
+  }
+}
+JSON
+
+run_x() {
+  (
+    unset XLINGS_PROJECT_DIR XLINGS_ACTIVE_SUBOS
+    XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@"
+  )
+}
+
+# Tiny python helper — read the workspace value for "tt" out of the
+# subos file as JSON. Robust to either shape.
+read_tt() {
+  python3 - "$SUBOS_FILE" <<'PY'
+import json, sys, pathlib
+data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+print(json.dumps((data.get("workspace") or {}).get("tt")))
+PY
+}
+
+# ------------------------------------------------------------------ Test 1
+log "T1: legacy string-form input survives load + lazy-migrates on save"
+cat > "$SUBOS_FILE" <<JSON
+{
+  "workspace": {
+    "tt": "1.0.0"
+  }
+}
+JSON
+
+run_x use tt 2.0.0 >/dev/null
+RAW="$(read_tt)"
+echo "  after use 2.0.0: $RAW"
+case "$RAW" in
+  '{"active": "2.0.0", "installed": ["2.0.0"]}'|\
+  '{"active":"2.0.0","installed":["2.0.0"]}')
+    ;;
+  *)
+    fail "T1: expected {active:2.0.0, installed:[2.0.0]} after lazy migration; got: $RAW" ;;
+esac
+
+# ------------------------------------------------------------------ Test 2
+log "T2: hand-crafted C2 input parses; switching active preserves installed[]"
+cat > "$SUBOS_FILE" <<JSON
+{
+  "workspace": {
+    "tt": {
+      "active": "2.0.0",
+      "installed": ["1.0.0", "2.0.0", "3.0.0"]
+    }
+  }
+}
+JSON
+
+run_x use tt 1.0.0 >/dev/null
+RAW="$(read_tt)"
+echo "  after use 1.0.0: $RAW"
+ACTIVE="$(echo "$RAW" | python3 -c 'import sys,json; print(json.loads(sys.stdin.read())["active"])')"
+INSTALLED="$(echo "$RAW" | python3 -c 'import sys,json; print(",".join(json.loads(sys.stdin.read())["installed"]))')"
+[[ "$ACTIVE" == "1.0.0" ]] || fail "T2: active should be 1.0.0, got '$ACTIVE'"
+[[ "$INSTALLED" == "1.0.0,2.0.0,3.0.0" ]] \
+  || fail "T2: installed[] should preserve all three versions, got '$INSTALLED'"
+
+# ------------------------------------------------------------------ Test 3
+log "T3: save invariant — active is always present in installed[]"
+# Hand-craft a file where active is NOT in installed[]. After save, the
+# serializer should add it back.
+cat > "$SUBOS_FILE" <<JSON
+{
+  "workspace": {
+    "tt": {
+      "active": "3.0.0",
+      "installed": ["1.0.0"]
+    }
+  }
+}
+JSON
+
+run_x use tt 3.0.0 >/dev/null
+RAW="$(read_tt)"
+echo "  after use 3.0.0 (re-saving): $RAW"
+INSTALLED="$(echo "$RAW" | python3 -c 'import sys,json; print(",".join(json.loads(sys.stdin.read())["installed"]))')"
+case "$INSTALLED" in
+  *3.0.0*) ;;
+  *) fail "T3: active 3.0.0 should be present in installed[] after save; got: $INSTALLED" ;;
+esac
+
+# ------------------------------------------------------------------ Test 4
+log "T4: read path tolerates a 'bare object' (no active, only installed[])"
+cat > "$SUBOS_FILE" <<JSON
+{
+  "workspace": {
+    "tt": {
+      "installed": ["1.0.0", "2.0.0"]
+    }
+  }
+}
+JSON
+
+# `xlings use tt 2.0.0` should set active without erroring on the
+# missing-active-on-load case.
+run_x use tt 2.0.0 >/dev/null
+RAW="$(read_tt)"
+echo "  after use 2.0.0 from active-less input: $RAW"
+ACTIVE="$(echo "$RAW" | python3 -c 'import sys,json; print(json.loads(sys.stdin.read())["active"])')"
+[[ "$ACTIVE" == "2.0.0" ]] || fail "T4: expected active=2.0.0, got '$ACTIVE'"
+
+log "PASS: subos_workspace_c2_schema"

--- a/tests/e2e/update_package_test.sh
+++ b/tests/e2e/update_package_test.sh
@@ -120,7 +120,8 @@ python3 - "$HOME_DIR" 1.0.0 <<'PY' || fail "S2 setup: workspace active version w
 import json, sys, pathlib
 home, want = sys.argv[1:]
 ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
-got = (ws.get("workspace") or {}).get("upgrade-fixture")
+entry = (ws.get("workspace") or {}).get("upgrade-fixture")
+got = entry.get("active") if isinstance(entry, dict) else entry  # 0.4.19 schema
 assert got == want, f"expected active={want}, got {got!r}"
 PY
 
@@ -138,7 +139,8 @@ python3 - "$HOME_DIR" 2.0.0 <<'PY' || fail "S2 DB state wrong"
 import json, sys, pathlib
 home, want = sys.argv[1:]
 ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
-got = (ws.get("workspace") or {}).get("upgrade-fixture")
+entry = (ws.get("workspace") or {}).get("upgrade-fixture")
+got = entry.get("active") if isinstance(entry, dict) else entry  # 0.4.19 schema
 assert got == want, f"S2: active should switch to {want}, got {got!r}"
 PY
 

--- a/tests/e2e/xlings_self_replace_test.sh
+++ b/tests/e2e/xlings_self_replace_test.sh
@@ -54,7 +54,15 @@ active_version() {
 import json, sys, pathlib
 home = sys.argv[1]
 ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
-print((ws.get("workspace") or {}).get("xlings", "<none>"))
+entry = (ws.get("workspace") or {}).get("xlings")
+# 0.4.19+: workspace value is {active, installed[]} dict; pre-0.4.19 was a
+# bare string. Tolerate both.
+if isinstance(entry, dict):
+    print(entry.get("active", "<none>"))
+elif isinstance(entry, str):
+    print(entry)
+else:
+    print("<none>")
 PY
 }
 


### PR DESCRIPTION
## Summary

First PR in the **C2 schema rollout** discussed earlier — subos `.xlings.json` workspace value upgrades from a plain version string to `{active, installed[]}` object form. Project workspace stays unchanged (string or platform-conditional) since project files declare intent, not runtime state.

This PR is the **schema layer + GC correctness** only. PR B (separate, later) will make `xlings list / use / update` subos-aware via the new `installed[]` field — per the [binding-analysis design doc](../blob/main/docs/plans/2026-05-07-xlings-cmd-subos-binding-analysis.md) shipped in 0.4.18.

## What changed

**Schema**
- `xvm::SubosWorkspace` + `WorkspaceInstalled` types
- `subos_workspace_from_json` accepts three value shapes:
  1. string (legacy <0.4.19, lazy-migrated on next save)
  2. `{active, installed[]}` (new C2 form)
  3. `{linux|windows|macosx|default}` (platform fallback, tolerated)
- `subos_workspace_to_json` always emits new form, with invariant: `active` is always present in `installed[]`
- Disambiguation between (2) and (3) is by reserved-key detection — `active`/`installed` cannot be platform names

**Maintenance**
- `process_xvm_operations_` add → appends `ver_key` to current subos's `installed[]`
- `detach_current_subos_` → drops from `installed[]` always; if `version` was active, auto-fallbacks to highest remaining (or clears)
- Both `detach_current_subos_` and `is_version_referenced_anywhere_` tolerate bare-vs-namespaced version mismatch by stripping `ns:` from stored values

**GC correctness**
- `is_version_referenced_anywhere_` walks `installed[]` in addition to `active`. Pre-fix: a payload only present in some other subos's `installed[]` was eligible for GC after `xlings remove` cleared its active there.
- `profile.cppm collect_subos_references_` unions `active` + `installed[]` target names so bulk GC honors the same pinning rule.

**Compat**
- `xself::compat::v0_4_19::kSchemaForm` sentinel documents the migration. `removal_target: 0.6.0`.

## Test plan
- [x] Local build clean (no new warnings)
- [x] New `subos_workspace_c2_schema_test.sh` passes (4 scenarios)
- [x] Existing `remove_self_guard_test.sh` passes after python helper update
- [ ] CI: 3 platforms green
- [ ] Manual smoke: lazy migration of legacy file → C2 form
- [ ] Manual smoke: install / use / remove preserves installed[]

## Out of scope (PR B)
- `xlings list` filtered to subos's `installed[]` view
- `xlings use` validates target version is in `installed[]` before switching
- `xlings update` operates on subos's `installed[]` set