### PR TITLE
feat(0.4.19): list / use / remove + shim become subos-aware

### DIFF
--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -4,6 +4,12 @@
 
 ### 2026-05 (v0.4.19)
 
+- **subos `xlings install` / `remove` 跨 subos workspace 污染修复(0.4.19 critical)**
+  - 报告:在 fresh subos `tmp` 里 `xlings install pkg@2.0.0 -y` 然后 `xlings remove pkg -y`,**tmp 的 workspace 被污染成 default subos 的版本(比如 `pkg: 1.0.0/[1.0.0]`)**,而 tmp 从未装过 1.0.0。tmp 的 shim 也跟着 active 错误版本残留。
+  - 根因:`installer.cppm` `uninstall()` 内联 xvm-ops loop(line ~1647)在 active 版本被卸时,fallback active pointer 用的是 **global versions DB** 的 `pick_highest_version`,subos-blind。具体说:tmp 卸 2.0.0 → detach 已正确清空 tmp.workspace[pkg],但接下来的 ops loop 看 global DB(还留着 default 用的 1.0.0)→ 把 1.0.0 写回 tmp.workspace。属于 0.4.18 之前就存在的旧 bug,但只有 C2 schema 落地、跨 subos 装不同版本之后才能稳定复现。
+  - 修复:fallback 改成只看**当前 subos 的 `installed[]`**,空就清掉 workspace pointer 并删 shim(不再"凭空"分配一个本 subos 没 opt-in 的版本)。同一个 loop 也补上 sibling op(比如 node 的 npm/npx)的 `installed[]` 同步删除。
+  - 锁住:新增 `subos_install_remove_isolation_test.sh`(default 装 1.0.0,tmp 装 2.0.0,tmp remove 后断言 6 项:tmp.workspace 空、default 不变、tmp shim 删、default shim 留、payload 2.0.0 物理删除、payload 1.0.0 保留),作为 E2E-23 加进 CI。
+
 - **`xlings list / use / remove` 全部 subos-aware (PR B,接 0.4.18 的 C2 schema)**
   - 0.4.18 落了 `installed[]` 数据,但 user-visible 的几个命令还是从全局 `versions` DB 读 —— 在新建的空 subos 里跑这些命令体感像啥都没改。这次把 shim + use + list + remove 全部改成读 `Config::workspace_installed()`。
   - **shim 错误提示**(`src/core/xvm/shim.cppm`)三态区分:

--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -2,6 +2,22 @@
 
 ## 2026
 
+### 2026-05 (v0.4.19)
+
+- **`xlings list / use / remove` 全部 subos-aware (PR B,接 0.4.18 的 C2 schema)**
+  - 0.4.18 落了 `installed[]` 数据,但 user-visible 的几个命令还是从全局 `versions` DB 读 —— 在新建的空 subos 里跑这些命令体感像啥都没改。这次把 shim + use + list + remove 全部改成读 `Config::workspace_installed()`。
+  - **shim 错误提示**(`src/core/xvm/shim.cppm`)三态区分:
+    - 当前 subos `installed[]` 里有 program 但没 active → `no active version of '...' in current subos` + `available: <subos-scoped 列表>` + `hint: xlings use ...`
+    - 当前 subos 没有但全局 DB 有 → `'X' is not installed in current subos` + `hint: xlings install X`(payload 在别的 subos 装过,这个 subos 需要显式 opt-in)
+    - 全局也没有 → `'X' is not installed` + `hint: xlings install X`
+  - **`xlings use <pkg>`(无 version)** 默认只列当前 subos `installed[]` 里的版本,标题改成 `<pkg> versions (current subos)`;加 `--all` / `-a` flag 切回全局视图(`<pkg> versions (all subos)`)。subos `installed[]` 为空时报错并提示 `xlings install`,不再丢一个空 panel 让用户猜。
+  - **`xlings use <pkg> <ver>` auto-add 语义**:用户在 fresh subos 里 `use` 一个全局 versions DB 已知但当前 subos 没装的版本 → **自动把版本加进 `installed[]` 然后切 active**,不强迫用户先 `install`。payload 全局共享,这个操作零成本。
+  - **`xlings list`** 默认只列当前 subos `installed[]` 的包,标题 `Installed packages (current subos):`;加 `--all` / `-a` 看全局 (`Installed packages (all subos):`)。空时给 hint。
+  - **`xlings remove <pkg>` 拒绝 fresh subos 的"假 remove"**(`src/core/xim/commands.cppm`):pre-fix 的现象是 `xlings remove gcc` 在没装 gcc 的 subos 里也会"成功",因为 catalog resolve 到 latest declared version、active workspace 是空所以 detach no-op、跨 subos refcount 看到别的 subos 装了 gcc 就走"detach only"分支并报告 `✓ removed (subos: tmp)`。新逻辑在 cmd_remove 入口处先检查 `Config::workspace()` + `Config::workspace_installed()`,**不在当前 subos 直接报错** + 列出哪些 subos 装了这个包 + 给出切 subos 的命令。
+  - **`xlings update`** 不需要改 —— 它已经走 `effective_workspace` 拿 `currentActive`,空就报 not installed。已经 subos-aware 了。
+  - 影响:`shim.cppm` / `xvm/commands.cppm` / `xim/commands.cppm` / `cli.cppm`。新加 `cmd_list / cmd_list_versions(..., bool all = false)`。
+  - 后续:还可以再加 `xlings list <pkg>` 也支持(目前 list 是顶层包列表,不是某 pkg 的版本列表)、`xlings status` 显示 subos 的 installed[] 总览 —— 但这次先把用户报告的 case 全部修掉,别的小 polish 后续 patch 处理。
+
 ### 2026-05 (v0.4.18)
 
 - **subos workspace schema 升级:`{active, installed[]}` 形式 (Plan C2,PR A) (#273)**

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -249,6 +249,10 @@ jobs:
         run: |
           bash tests/e2e/subos_workspace_c2_schema_test.sh
 
+      - name: "E2E-23: subos install/remove isolation (no cross-subos workspace leak)"
+        run: |
+          bash tests/e2e/subos_install_remove_isolation_test.sh
+
       - name: Attach artifact
         uses: actions/upload-artifact@v4
         if: success()

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -928,13 +928,15 @@ export int run(int argc, char* argv[]) {
         // list
         .subcommand("list")
             .description("List installed packages")
+            .option(cmdline::Option("all").short_name('a').help("Show packages across all subos (default: current subos only)"))
             .arg("filter").help("Filter pattern")
             .action(wrap_rc([&stream](const cmdline::ParsedArgs& args) -> int {
                 apply_global_opts_(args);
                 std::string filter;
                 if (args.positional_count() > 0)
                     filter = std::string(args.positional(0));
-                return xim::cmd_list(filter, stream);
+                bool show_all = args.is_flag_set("all");
+                return xim::cmd_list(filter, stream, show_all);
             }))
 
         // info
@@ -951,9 +953,11 @@ export int run(int argc, char* argv[]) {
 
         // use — accepts both `<name> <ver>` (legacy form) and `<name>@<ver>`
         // (one-shot form, matching install/remove). Bare `<name>` lists
-        // installed versions.
+        // installed versions in the current subos; pass `--all` to widen
+        // to the global view (every version every subos has ever installed).
         .subcommand("use")
             .description("Switch tool version")
+            .option(cmdline::Option("all").short_name('a').help("Show versions across all subos (default: current subos only)"))
             .arg("target").required().help("Tool name (or name@ver one-shot)")
             .arg("version").help("Version to switch to (omit to list installed versions)")
             .action(wrap_rc([&stream](const cmdline::ParsedArgs& args) -> int {
@@ -968,11 +972,12 @@ export int run(int argc, char* argv[]) {
                     log::error("  hint: use `<name>@<version>` or `<name> <version>`");
                     return 1;
                 }
+                bool show_all = args.is_flag_set("all");
                 auto first = std::string(args.positional(0));
                 if (n == 1) {
                     auto at = first.find('@');
                     if (at == std::string::npos)
-                        return xvm::cmd_list_versions(first, stream);
+                        return xvm::cmd_list_versions(first, stream, show_all);
                     return xvm::cmd_use(first.substr(0, at),
                                         first.substr(at + 1), stream);
                 }

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.18";
+    static constexpr std::string_view VERSION = "0.4.19";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -12,6 +12,7 @@ import xlings.core.xim.downloader;
 import xlings.core.xim.installer;
 import xlings.core.log;
 import xlings.core.config;
+import xlings.core.profile;
 import xlings.runtime;
 import xlings.libs.json;
 import xlings.core.i18n;
@@ -403,6 +404,57 @@ int cmd_remove(const std::string& target, bool yes, EventStream& stream) {
     std::string displayVersion;
     std::string subos = Config::paths().activeSubos;
 
+    // 0.4.19+: subos-membership guard.
+    //
+    // Pre-fix: in a fresh (or pruned) subos, `xlings remove gcc` would
+    // reach the catalog, resolve to whatever version the recipe declared
+    // as "default", attempt detach (no-op since gcc is not in this
+    // subos's workspace), then succeed via the cross-subos refcount
+    // path because gcc IS installed in some OTHER subos. Net effect:
+    // confusing "✓ removed (subos: tmp)" output for a version the user
+    // never had. Refuse early and tell them where the package actually
+    // lives.
+    {
+        auto stripVer = [](const std::string& s) {
+            auto at = s.find('@');
+            return (at == std::string::npos) ? s : s.substr(0, at);
+        };
+        auto bareWithoutVer = stripVer(target);
+        auto bareName = bareWithoutVer.substr(bareWithoutVer.rfind(':') + 1);
+
+        const auto& ws  = Config::workspace();
+        const auto& wsi = Config::workspace_installed();
+        bool in_active    = ws.contains(bareName) && !ws.at(bareName).empty();
+        bool in_installed = wsi.contains(bareName) && !wsi.at(bareName).empty();
+
+        if (!in_active && !in_installed) {
+            // Idempotent no-op: matching the existing "remove what isn't
+            // there is success" convention (covered by S4 of
+            // remove_multi_version_test.sh — it explicitly asserts
+            // exit 0 + no `removed.*subos` summary). We exit 0 with a
+            // visible diagnostic so humans see what happened without
+            // breaking scripts that re-run `remove` defensively.
+            log::warn("xlings: '{}' is not installed in current subos '{}'",
+                      bareName, subos);
+
+            // Helpful diagnostic: which subos(es) DO have this package?
+            auto referencing = xlings::profile::find_subos_referencing(
+                Config::paths().homeDir, bareName);
+            std::erase(referencing, subos);
+            if (!referencing.empty()) {
+                std::string list;
+                for (auto& n : referencing) {
+                    if (!list.empty()) list += ", ";
+                    list += n;
+                }
+                log::warn("  installed in subos: {}", list);
+                log::warn("  hint: `xlings subos use {}` then `xlings remove {}`",
+                          referencing.front(), bareName);
+            }
+            return 0;
+        }
+    }
+
     std::string resolveTarget = target;
     if (target.find('@') == std::string::npos) {
         auto bareName = target.substr(target.rfind(':') + 1);
@@ -556,7 +608,17 @@ int cmd_search(const std::string& keyword, EventStream& stream) {
 }
 
 // === list command ===
-int cmd_list(const std::string& filter, EventStream& stream) {
+//
+// 0.4.19+: by default, list only packages opted into the **current
+// subos** (i.e. present in `Config::workspace_installed()`). Pass
+// `all=true` (CLI: `--all`) to widen back to "every package whose
+// payload exists on disk anywhere", which is the pre-0.4.19 default.
+//
+// `match.installed` (catalog-side) tracks "payload directory exists on
+// disk in xpkgs/" — that's *globally* installed and shared across
+// subos. The new C2 schema stores per-subos opt-in via
+// `workspace_installed`, so the subos-scoped list intersects the two.
+int cmd_list(const std::string& filter, EventStream& stream, bool all = false) {
     auto& catalog = get_catalog();
     if (!catalog.is_loaded()) {
         log::error("package index not available");
@@ -565,14 +627,30 @@ int cmd_list(const std::string& filter, EventStream& stream) {
 
     auto results = catalog.search(filter.empty() ? "" : filter, detect_platform());
 
-    // Filter to only installed packages
+    const auto& wsi = Config::workspace_installed();
+    auto in_current_subos = [&](const std::string& name, const std::string& version) {
+        auto it = wsi.find(name);
+        if (it == wsi.end()) return false;
+        for (auto& v : it->second) {
+            if (v == version || xvm::strip_namespace(v) == version) return true;
+        }
+        return false;
+    };
+
     std::vector<PackageMatch> installed;
     for (auto& match : results) {
-        if (match.installed) installed.push_back(std::move(match));
+        if (!match.installed) continue;
+        if (!all && !in_current_subos(match.name, match.version)) continue;
+        installed.push_back(std::move(match));
     }
 
     if (installed.empty()) {
-        log::println("no installed packages found");
+        if (all) {
+            log::println("no installed packages found");
+        } else {
+            log::println("no packages installed in current subos");
+            log::println("  hint: `xlings list --all` to see globally-installed packages");
+        }
         return 0;
     }
 
@@ -583,7 +661,8 @@ int cmd_list(const std::string& filter, EventStream& stream) {
         listItems.push_back({match.canonicalName + "@" + match.version, desc});
     }
     nlohmann::json listPayload;
-    listPayload["title"] = "Installed packages:";
+    listPayload["title"] = all ? "Installed packages (all subos):"
+                               : "Installed packages (current subos):";
     listPayload["items"] = std::move(listItems);
     listPayload["numbered"] = true;
     stream.emit(DataEvent{"styled_list", listPayload.dump()});

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -367,27 +367,32 @@ void remove_target_shims_(const std::string& target, const std::string& version)
 
     // A program's shim is a generic dispatcher to the bootstrap; the actual
     // version it routes to is the workspace pointer (read at runtime). So
-    // the shim is only stale when the *last* version of the name is being
-    // removed. With surviving versions still in the DB, the shim must stay
-    // — the uninstall path elsewhere auto-switches the workspace to the
-    // highest remaining version, and the shim resolves through that.
+    // the shim is only stale when **the current subos** has dropped its
+    // last version of the name. With surviving versions still in this
+    // subos's installed[], the shim must stay — auto-fallback in
+    // detach_current_subos_ updates `active` to the highest remaining
+    // version and the shim resolves through that.
     //
-    // Removing the shim too eagerly (the previous behavior) leaves PATH
-    // pointing nowhere even though the version DB still holds installs,
-    // surfacing as "command not found" for node/npm/npx/mdbook etc. after
-    // `xlings remove <pkg>@<one-version>`.
-    auto is_last_version_for = [&](const std::string& name,
-                                   const std::string& ver) {
-        auto* vi = xvm::get_vinfo(db, name);
-        if (!vi) return true;
-        for (auto& [v, _] : vi->versions) {
-            if (v != ver) return false;
-        }
-        return true;
+    // 0.4.19+: this check is now scoped to the **current subos's
+    // installed[]**, not the global versions DB. Pre-0.4.19 the gate
+    // was `is_last_version_for(global)`, which under-removed: subos A
+    // could drain its installed[] for a target while subos B still had
+    // some other version of it, leaving a stale shim in A's bin/. With
+    // C2 schema each subos's bin/ is independent — so is each subos's
+    // shim-lifetime decision.
+    //
+    // Caller contract: detach_current_subos_ has already pruned
+    // `version` from this subos's installed[] before calling us. So
+    // checking "is the post-removal installed[] empty?" gives the
+    // correct answer.
+    const auto& wsi = Config::workspace_installed();
+    auto subos_has_any_version_of = [&](const std::string& name) {
+        auto it = wsi.find(name);
+        return it != wsi.end() && !it->second.empty();
     };
 
     auto mainName = (vinfo && !vinfo->filename.empty()) ? vinfo->filename : target;
-    if (is_last_version_for(target, version)) {
+    if (!subos_has_any_version_of(target)) {
         auto mainShim = binDir / mainName;
         if (fs::exists(mainShim, ec) || fs::is_symlink(mainShim, ec)) {
             ec.clear();
@@ -399,7 +404,7 @@ void remove_target_shims_(const std::string& target, const std::string& version)
     for (auto& [bindingName, vermap] : vinfo->bindings) {
         auto vit = vermap.find(version);
         if (vit == vermap.end()) continue;
-        if (!is_last_version_for(bindingName, vit->second)) continue;
+        if (subos_has_any_version_of(bindingName)) continue;  // still in use here
         auto bindPath = binDir / bindingName;
         ec.clear();
         if (fs::exists(bindPath, ec) || fs::is_symlink(bindPath, ec)) {
@@ -1605,32 +1610,89 @@ public:
 
                 xvm::remove_version(Config::versions_mut(), op.name, effective_version);
 
-                // Decide the new active binding for this op.name.
+                // 0.4.19+: also drop `effective_version` from this subos's
+                // installed[] (detach_current_subos_ already pruned it for
+                // op.name == detachTarget, but sibling ops emitted by the
+                // recipe — e.g. xvm.remove("npm") when uninstalling node —
+                // never went through detach).
+                {
+                    auto& wsi_mut = Config::workspace_installed_mut();
+                    if (auto it = wsi_mut.find(op.name); it != wsi_mut.end()) {
+                        auto erased = std::remove_if(it->second.begin(),
+                                                     it->second.end(),
+                            [&](const std::string& v) {
+                                return v == effective_version
+                                    || xvm::strip_namespace(v) == effective_version;
+                            });
+                        it->second.erase(erased, it->second.end());
+                        if (it->second.empty()) wsi_mut.erase(it);
+                    }
+                }
+
                 auto dit = Config::versions_mut().find(op.name);
+
+                // Decide the new active binding for this op.name.
+                //
+                // 0.4.19+: fallback candidates come from the **current subos's
+                // installed[]** set, not the global versions DB. Pre-fix the
+                // auto-switch picked the highest remaining version across
+                // ALL subos (`pick_highest_version(dit->second.versions)`) —
+                // which leaked another subos's choices into this one. Concrete
+                // case: subos A has rm-fixture@1.0.0, subos B has rm-fixture@2.0.0.
+                // `xlings remove rm-fixture` in B would auto-set B.workspace[rm-fixture]
+                // to "1.0.0" — a version B never opted into. With C2 schema
+                // each subos has its own opt-in set, so the fallback must
+                // come from the same set; if it's empty, clear the pointer
+                // (and drop the shim) instead of inventing one.
+                const auto& wsi_view = Config::workspace_installed();
+                auto subos_pick_highest = [&](const std::string& name) -> std::string {
+                    auto wit = wsi_view.find(name);
+                    if (wit == wsi_view.end() || wit->second.empty()) return {};
+                    // installed[] is stored sorted ascending → back() is highest
+                    return wit->second.back();
+                };
+
                 bool survivors = (dit != Config::versions_mut().end()
                                   && !dit->second.versions.empty());
                 if (!survivors) {
-                    // Package fully gone — clear workspace binding and drop
-                    // the PATH shim with it.
+                    // Package fully gone from the global DB — clear workspace
+                    // binding and drop the PATH shim with it. (subos's
+                    // installed[] is already empty by construction.)
                     Config::workspace_mut().erase(op.name);
                     remove_shim_if_present();
                 } else if (prev_active.empty() || prev_active == effective_version) {
-                    // We just removed the active version (or detach already cleared the
-                    // slot for detachTarget). Auto-switch to the highest remaining
-                    // semver so leftover versions stay reachable. Keep the shim —
-                    // it dispatches to the bootstrap, which resolves the active
-                    // version at runtime via the workspace pointer we just updated.
-                    Config::workspace_mut()[op.name] =
-                        xvm::pick_highest_version(dit->second.versions);
-                } else {
-                    // A non-active version was removed; keep the previous active if still
-                    // present, otherwise fall back to highest remaining. Shim survives
-                    // for the same reason as above.
-                    if (dit->second.versions.contains(prev_active)) {
-                        Config::workspace_mut()[op.name] = prev_active;
+                    // We just removed the active version (or detach already cleared
+                    // the slot for detachTarget). Auto-switch to highest version
+                    // this subos has opted into; if none, clear pointer + shim.
+                    auto fallback = subos_pick_highest(op.name);
+                    if (!fallback.empty()) {
+                        Config::workspace_mut()[op.name] = fallback;
                     } else {
-                        Config::workspace_mut()[op.name] =
-                            xvm::pick_highest_version(dit->second.versions);
+                        Config::workspace_mut().erase(op.name);
+                        remove_shim_if_present();
+                    }
+                } else {
+                    // A non-active version was removed; keep the previous active
+                    // if it's still in this subos's installed[], otherwise pick
+                    // highest remaining (or clear).
+                    auto fallback = subos_pick_highest(op.name);
+                    bool prev_still_in_subos = false;
+                    if (auto wit = wsi_view.find(op.name); wit != wsi_view.end()) {
+                        for (auto& v : wit->second) {
+                            if (v == prev_active
+                                || xvm::strip_namespace(v) == xvm::strip_namespace(prev_active)) {
+                                prev_still_in_subos = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (prev_still_in_subos) {
+                        Config::workspace_mut()[op.name] = prev_active;
+                    } else if (!fallback.empty()) {
+                        Config::workspace_mut()[op.name] = fallback;
+                    } else {
+                        Config::workspace_mut().erase(op.name);
+                        remove_shim_if_present();
                     }
                 }
             } else if (op.op == "remove_headers") {

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -118,6 +118,33 @@ void remove_libdir(const std::string& libdir, const fs::path& sysroot_lib) {
     }
 }
 
+// Helper: filter a list of version keys (`ns:ver` or bare) down to those
+// that appear in the current subos's installed[] for `target`. Tolerant
+// of bare-vs-namespaced mismatch the same way detach_current_subos_ is —
+// the stored form is namespaced for non-primary repos but callers may
+// pass bare versions.
+inline std::vector<std::string>
+filter_to_subos_installed_(const std::string& target,
+                           const std::vector<std::string>& candidates) {
+    const auto& wsi = Config::workspace_installed();
+    auto it = wsi.find(target);
+    if (it == wsi.end()) return {};
+    const auto& installed = it->second;
+
+    auto in_installed = [&](const std::string& v) {
+        for (auto& sv : installed) {
+            if (sv == v || strip_namespace(sv) == v) return true;
+        }
+        return false;
+    };
+
+    std::vector<std::string> out;
+    for (auto& v : candidates) {
+        if (in_installed(v)) out.push_back(v);
+    }
+    return out;
+}
+
 // xlings use <target> <version>
 // Updates the active subos workspace and creates/updates bin/ hardlinks
 int cmd_use(const std::string& target, const std::string& version, EventStream& stream) {
@@ -221,9 +248,24 @@ int cmd_use(const std::string& target, const std::string& version, EventStream& 
 
     collect_bindings(target, resolved);
 
-    // Update workspace for all nodes in the binding tree
+    // Update workspace for all nodes in the binding tree, and opt this
+    // subos into the version's installed[] set if it wasn't already.
+    //
+    // The auto-add semantics (0.4.19+): if the user does `xlings use gcc 11.5.0`
+    // in a fresh subos that doesn't have 11.5.0 in `installed[]` but the
+    // payload IS registered in the global versions DB (e.g. another subos
+    // installed it), we add 11.5.0 to this subos's installed[] silently
+    // — payload is shared, so this is a free operation. Without this,
+    // `use` in a fresh subos would always have to be preceded by
+    // `install`, making subos creation feel heavier than it is.
+    auto& wsi = Config::workspace_installed_mut();
     for (auto& [name, ver] : to_switch) {
         Config::workspace_mut()[name] = ver;
+        auto& list = wsi[name];
+        if (std::find(list.begin(), list.end(), ver) == list.end()) {
+            list.push_back(ver);
+            log::debug("auto-add to installed[]: {} += {}", name, ver);
+        }
         log::debug("binding sync: {} -> {}", name, ver);
     }
     Config::save_workspace();
@@ -290,8 +332,20 @@ int cmd_use(const std::string& target, const std::string& version, EventStream& 
     return 0;
 }
 
-// List versions for a target (used by `xlings use <target>` without version)
-int cmd_list_versions(const std::string& target, EventStream& stream) {
+// List versions for a target.
+//
+// Used by `xlings use <target>` (no version) — output drives the
+// interactive picker / info panel. 0.4.19+: defaults to **current
+// subos scope** (only versions in `installed[]`), so a fresh subos
+// shows an empty / minimal list rather than every version every other
+// subos has ever installed. Pass `all=true` to opt back into the
+// pre-0.4.19 global view (CLI exposes this via `--all`).
+//
+// When `all=false` and the current subos has no installed[] entries
+// for the target, we fall back to global with an explanatory hint —
+// otherwise the user would just see an empty panel and not know what
+// to do next.
+int cmd_list_versions(const std::string& target, EventStream& stream, bool all = false) {
     auto db = Config::versions();
 
     if (!has_target(db, target)) {
@@ -301,10 +355,40 @@ int cmd_list_versions(const std::string& target, EventStream& stream) {
 
     auto workspace = Config::effective_workspace();
     auto active = get_active_version(workspace, target);
-    auto all = get_all_versions(db, target);
+    auto global_all = get_all_versions(db, target);
+
+    std::vector<std::string> versions;
+    std::string title;
+    if (all) {
+        versions = global_all;
+        title = target + " versions (all subos)";
+    } else {
+        versions = filter_to_subos_installed_(target, global_all);
+        if (versions.empty()) {
+            // Empty subos installed[] for this target — show a hint
+            // instead of an empty panel. The global list is informational
+            // so the user can pick a version to install.
+            log::error("'{}' is not installed in current subos", target);
+            if (!global_all.empty()) {
+                std::string avail;
+                for (auto& v : global_all) {
+                    if (!avail.empty()) avail += " ";
+                    avail += v;
+                }
+                log::error("  globally available: {}", avail);
+                log::error("  hint: xlings install {}@<version>"
+                           " (or `xlings use {} --all` to see global view)",
+                           target, target);
+            } else {
+                log::error("  hint: xlings install {}", target);
+            }
+            return 1;
+        }
+        title = target + " versions (current subos)";
+    }
 
     nlohmann::json fieldsJson = nlohmann::json::array();
-    for (auto& ver : all) {
+    for (auto& ver : versions) {
         auto vdata = get_vdata(db, target, ver);
         std::string path_info;
         if (vdata && !vdata->path.empty()) path_info = vdata->path;
@@ -312,7 +396,7 @@ int cmd_list_versions(const std::string& target, EventStream& stream) {
         fieldsJson.push_back({{"label", ver}, {"value", path_info}, {"highlight", highlight}});
     }
     nlohmann::json payload;
-    payload["title"] = target + " versions";
+    payload["title"] = title;
     payload["fields"] = std::move(fieldsJson);
     stream.emit(DataEvent{"info_panel", payload.dump()});
 

--- a/src/core/xvm/shim.cppm
+++ b/src/core/xvm/shim.cppm
@@ -120,22 +120,38 @@ int shim_dispatch(const std::string& program_name, int argc, char* argv[]) {
     auto version = get_active_version(workspace, program_name);
     auto db = Config::versions();
     if (version.empty()) {
-        // Differentiate "not installed" from "installed but no active":
-        //   * 0 versions in the global versions DB → user needs `install`
-        //   * ≥1 version exists → user needs `use` to pin one
-        // The previous "xlings use <pkg> <version>" hint is misleading when
-        // the package isn't installed at all (e.g. immediately after
-        // `xlings remove <pkg>` left an orphan shim in PATH from another
-        // subos's bin, the workspace lookup returns empty AND the global
-        // DB returns empty too).
-        auto all = get_all_versions(db, program_name);
-        if (all.empty()) {
-            log::error("xlings: '{}' is not installed", program_name);
-            log::error("  hint: xlings install {}", program_name);
+        // Tri-state diagnostic, scoped to the CURRENT subos's installed[]
+        // (NOT the global versions DB — pre-0.4.19 the "available" list
+        // showed every version every subos had ever installed, which was
+        // misleading from inside a fresh / pruned subos):
+        //
+        //   * installed[] empty + global DB empty       → never installed
+        //   * installed[] empty + global DB has entries → installed in
+        //     another subos, current subos has no view of it (suggest
+        //     `xlings install` — payload is shared, but this subos
+        //     needs to opt in)
+        //   * installed[] non-empty                     → some versions
+        //     are opted-in but no active pointer; list THOSE versions
+        //     and tell the user to `xlings use` one of them
+        const auto& subos_installed = Config::workspace_installed();
+        std::vector<std::string> here;
+        if (auto it = subos_installed.find(program_name); it != subos_installed.end()) {
+            here = it->second;
+        }
+
+        if (here.empty()) {
+            auto global_all = get_all_versions(db, program_name);
+            if (global_all.empty()) {
+                log::error("xlings: '{}' is not installed", program_name);
+                log::error("  hint: xlings install {}", program_name);
+            } else {
+                log::error("xlings: '{}' is not installed in current subos", program_name);
+                log::error("  hint: xlings install {}", program_name);
+            }
         } else {
             log::error("xlings: no active version of '{}' in current subos", program_name);
             std::string avail;
-            for (auto& v : all) {
+            for (auto& v : here) {
                 if (!avail.empty()) avail += " ";
                 avail += v;
             }

--- a/tests/e2e/subos_install_remove_isolation_test.sh
+++ b/tests/e2e/subos_install_remove_isolation_test.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# subos_install_remove_isolation_test.sh — regression for the 0.4.19
+# subos-blind workspace pollution: pre-fix `xlings remove pkg` in subos
+# A would auto-set A.workspace[pkg] to whatever highest version EXISTED
+# IN ANY SUBOS'S global versions DB, including ones A had never opted
+# into.
+#
+# Concrete scenario that surfaced the bug:
+#
+#   subos default has rm-fixture@1.0.0
+#   subos tmp     has rm-fixture@2.0.0
+#   $ XLINGS_ACTIVE_SUBOS=tmp xlings remove rm-fixture
+#
+#   Pre-fix:  tmp.workspace[rm-fixture] = "1.0.0"  ← wrong! tmp never had 1.0.0
+#             tmp/bin/rm-fixture        = stale shim
+#   Post-fix: tmp.workspace             = {} (empty)
+#             tmp/bin/rm-fixture        = removed
+#
+# Root cause was in installer.cppm uninstall()'s xvm-ops loop, where the
+# auto-switch fallback after removing the active version picked from the
+# global versions DB instead of the current subos's installed[] set.
+#
+# Asserts the post-fix invariants on a clean isolated XLINGS_HOME.
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/subos_install_remove_isolation"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+FIXTURE_PKG="$LOCAL_INDEX_DIR/pkgs/r/rm-fixture.lua"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+RUN_IN() {
+  local subos="$1"; shift
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin \
+      XLINGS_HOME="$HOME_DIR" XLINGS_ACTIVE_SUBOS="$subos" \
+      "$XLINGS_BIN" "$@" )
+}
+RUN() {
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
+      "$XLINGS_BIN" "$@" )
+}
+
+mkdir -p "$HOME_DIR"
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$(dirname "$FIXTURE_PKG")"
+cat > "$FIXTURE_PKG" <<'LUA'
+package = {
+    spec = "1", name = "rm-fixture",
+    description = "isolation-test fixture",
+    authors = {"xlings-ci"}, licenses = {"MIT"}, type = "package",
+    archs = {"x86_64"}, status = "stable", categories = {"test-fixture"},
+    xpm = {
+        linux   = { ["1.0.0"] = {}, ["2.0.0"] = {}, ["3.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {}, ["2.0.0"] = {}, ["3.0.0"] = {} },
+        windows = { ["1.0.0"] = {}, ["2.0.0"] = {}, ["3.0.0"] = {} },
+    },
+}
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+function install()
+    local d = pkginfo.install_dir()
+    os.tryrm(d); os.mkdir(d)
+    io.writefile(path.join(d, "VERSION"), pkginfo.version())
+    return true
+end
+function config()
+    xvm.add("rm-fixture", { bindir = pkginfo.install_dir() })
+    return true
+end
+function uninstall()
+    xvm.remove("rm-fixture")
+    return true
+end
+LUA
+
+mkdir -p "$HOME_DIR/subos/default/bin"
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+cat > "$HOME_DIR/.xlings.json" <<JSON
+{ "mirror": "GLOBAL",
+  "index_repos": [{ "name": "xim", "url": "$LOCAL_INDEX_DIR" }] }
+JSON
+
+log "init sandbox"
+RUN self init >/dev/null 2>&1
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+# ── Setup: default has 1.0.0, tmp has 2.0.0 (different versions per subos)
+log "Setup: default installs 1.0.0; tmp installs 2.0.0 (different versions)"
+RUN subos new tmp >/dev/null
+RUN_IN default install rm-fixture@1.0.0 -y >/dev/null 2>&1 || fail "default install failed"
+RUN_IN tmp     install rm-fixture@2.0.0 -y >/dev/null 2>&1 || fail "tmp install failed"
+
+read_active() {
+  python3 - "$1" "$2" <<'PY'
+import json, sys, pathlib
+data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+entry = (data.get("workspace") or {}).get(sys.argv[2])
+if isinstance(entry, dict): print(entry.get("active", "<none>"))
+elif isinstance(entry, str): print(entry)
+else: print("<none>")
+PY
+}
+
+# Sanity-check pre-state
+[[ "$(read_active "$HOME_DIR/subos/default/.xlings.json" rm-fixture)" == "1.0.0" ]] \
+  || fail "setup: default active should be 1.0.0"
+[[ "$(read_active "$HOME_DIR/subos/tmp/.xlings.json" rm-fixture)" == "2.0.0" ]] \
+  || fail "setup: tmp active should be 2.0.0"
+
+# ── Action: remove in tmp
+log "Action: 'xlings remove rm-fixture -y' in tmp"
+RUN_IN tmp remove rm-fixture -y >/dev/null 2>&1 || fail "remove failed"
+
+# ── Critical assertions: tmp must be clean, default untouched
+TMP_ACTIVE="$(read_active "$HOME_DIR/subos/tmp/.xlings.json" rm-fixture)"
+DEF_ACTIVE="$(read_active "$HOME_DIR/subos/default/.xlings.json" rm-fixture)"
+
+[[ "$TMP_ACTIVE" == "<none>" ]] \
+  || fail "REGRESSION: tmp.workspace[rm-fixture] should be empty, got '$TMP_ACTIVE' (likely leaked from default's installed[])"
+log "  ✓ tmp workspace is clean (no leak from default)"
+
+[[ "$DEF_ACTIVE" == "1.0.0" ]] \
+  || fail "default.workspace[rm-fixture] should still be 1.0.0, got '$DEF_ACTIVE'"
+log "  ✓ default workspace untouched"
+
+[[ ! -e "$HOME_DIR/subos/tmp/bin/rm-fixture" ]] \
+  || fail "REGRESSION: tmp/bin/rm-fixture shim still present after remove (subos installed[] is empty)"
+log "  ✓ tmp shim removed (per-subos installed[] is empty)"
+
+[[ -e "$HOME_DIR/subos/default/bin/rm-fixture" ]] \
+  || fail "default/bin/rm-fixture shim was removed (default still has 1.0.0)"
+log "  ✓ default shim preserved"
+
+# Payload accounting: 2.0.0 should be physically gone, 1.0.0 retained
+[[ ! -d "$HOME_DIR/data/xpkgs/xim-x-rm-fixture/2.0.0" ]] \
+  || fail "rm-fixture@2.0.0 payload should be physically removed (no subos uses it)"
+[[ -d "$HOME_DIR/data/xpkgs/xim-x-rm-fixture/1.0.0" ]] \
+  || fail "rm-fixture@1.0.0 payload should be retained (default still uses it)"
+log "  ✓ payload GC: 2.0.0 deleted, 1.0.0 preserved"
+
+# Global versions DB: 2.0.0 dropped, 1.0.0 retained
+DB_VERS="$(python3 -c "
+import json
+d = json.load(open('$HOME_DIR/.xlings.json'))
+v = d.get('versions',{}).get('rm-fixture',{}).get('versions',{})
+print(','.join(sorted(v.keys())))
+")"
+[[ "$DB_VERS" == "1.0.0" ]] \
+  || fail "global versions DB should only have 1.0.0, got: '$DB_VERS'"
+log "  ✓ global versions DB: only 1.0.0 remains"
+
+log "PASS: subos_install_remove_isolation"


### PR DESCRIPTION
## Summary

Follow-up to 0.4.18's C2 schema migration (#273). 0.4.18 stored `installed[]` per subos but the user-visible commands still read from the global versions DB, so creating a fresh subos and running `xlings use gcc` / `xlings remove gcc` produced confusing global-leaning output.

## Reported case

In a fresh subos `tmp`:

```
[xsubos:tmp] $ xlings remove gcc
  ✓ xim:gcc@15.1.0 removed  (subos: tmp)   ← but tmp never had gcc

[xsubos:tmp] $ gcc --version
[error] xlings: no active version of 'gcc' in current subos
[error]   available: 11.5.0 15.1.0 15.1.0-musl 16.1.0 9.4.0   ← global, not tmp's
[error]   hint: xlings use gcc <version>                       ← `use` would also list global
```

## What changed

**shim.cppm** — Tri-state diagnostic scoped to current subos:
- subos `installed[]` non-empty but no active → list **this subos's** versions
- subos installed[] empty but global has it → `'X' is not installed in current subos` + install hint
- global also empty → `'X' is not installed` + install hint

**`xvm/commands.cppm`**:
- `cmd_list_versions(target, --all)` — default current subos; `--all` opts to global
- `cmd_use <pkg> <ver>` — auto-add to `installed[]` when payload exists globally (payload is shared, so this is a free operation; users don't need to `install` first)

**`xim/commands.cppm`**:
- `cmd_list(filter, --all)` — default current subos; `--all` for global
- `cmd_remove` — subos-membership guard at entry: if not in current subos's workspace, exit 0 (idempotent, matches S4 regression test) with a clear "not installed in current subos" diagnostic and pointer to which subos DOES have the package

**`cli.cppm`**:
- Wire `--all` / `-a` to both `xlings list` and `xlings use`

`xlings update` already used `effective_workspace` for `currentActive`, so it was already subos-aware.

## Test plan
- [x] Local build clean
- [x] 4-scenario smoke test (T1-T4) of subos isolation passes
- [x] 6 schema-touching e2e tests still pass (remove_multi_version regression-fixed after exit-code tweak)
- [ ] CI green on Linux / macOS / Windows

## Out of scope
- `xlings update` already correct — no change needed
- `xlings status` overview command — possible future polish