### PR TITLE
perf(0.4.20): libarchive extract 37× faster (4 MiB block + skip NSS lookup)

### DIFF
--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -2,6 +2,20 @@
 
 ## 2026
 
+### 2026-05 (v0.4.20)
+
+- **大型 tarball 解压性能修复:libarchive read block 64 KiB → 4 MiB,跳过 NSS lookup**
+  - 用户报告:`xlings install local:musl-gcc@15.1.0`(847 MiB tarball)整个安装阶段挂在 "下载阶段" ~217 秒,实际是解压。raw `tar -xzf` 同一文件 9.2 秒,**xlings ~23×**。
+  - 实测定位(在用户原始 tarball 上跑):
+    - **read block 大小**:`archive_read_open_filename` 默认参数 65536 字节 → 每 GiB ~16k 次 read syscall。改成 4 MiB(GNU tar 内部用的量级)后,syscall 数掉一个数量级。
+    - **NSS lookup**:`archive_write_disk_set_standard_lookup` 给每个 unique uname/gname 调 `getpwnam_r`/`getgrnam_r`。在 LDAP / sssd / nscd 慢的环境下这一项可能挂秒级。xim-pkgindex tarball 一律 root:root,改成自定义 lookup callback 永远返回 0,绕掉整条 NSS 路径。
+  - **效果**(808 MiB musl-gcc tarball):
+    - 修复前(实测旧逻辑):**~217 s**
+    - 修复后(本 patch):**5.79 s**(比 `tar -xpf` 9.31 s 还快 60%,因为没有 subprocess 启动开销 + pipe IPC)
+    - 提速 **~37×**
+  - **不引入新代码路径**:之前考虑过加 `posix_spawn("tar -xpf")` 子进程方案,实测对比发现 Tier 1 单独已经超过了 subprocess 路径(在多数硬件上 zlib 单线程 + 4 MiB block 已经接近 IO 上限,subprocess 启动成本反而拖慢小 archive 4 倍)。因此**直接增强 libarchive 路径**,不加 fallback / dispatcher / env var。
+  - 改动量:`src/core/xim/extract.cppm` 改 ~30 行,无新模块、无新依赖、无新 escape hatch。
+
 ### 2026-05 (v0.4.19)
 
 - **subos `xlings install` / `remove` 跨 subos workspace 污染修复(0.4.19 critical)**

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.19";
+    static constexpr std::string_view VERSION = "0.4.20";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/extract.cppm
+++ b/src/core/xim/extract.cppm
@@ -82,6 +82,17 @@ std::string libarchive_error_(struct archive* a) {
     return "unknown libarchive error";
 }
 
+// User/group lookup callbacks for archive_write_disk that always return
+// 0 (root). Wired into archive_write_disk_set_user_lookup so libarchive
+// never falls back to getpwnam_r/getgrnam_r — see the call site for the
+// rationale.
+//
+// Signature matches libarchive's `archive_write_disk_set_user_lookup` /
+// `set_group_lookup` callback type:
+//     la_int64_t (*lookup)(void* private_data, const char* name, la_int64_t id);
+la_int64_t const_root_lookup_uid_(void*, const char*, la_int64_t) { return 0; }
+la_int64_t const_root_lookup_gid_(void*, const char*, la_int64_t) { return 0; }
+
 // Read each block of an entry's payload from `src` and write to `dst`.
 std::expected<void, std::string>
 copy_entry_data_(struct archive* src, struct archive* dst) {
@@ -153,10 +164,30 @@ extract_archive(const std::filesystem::path& archive,
     ::archive_read_support_filter_all(src);
     ::archive_read_support_format_all(src);
     ::archive_write_disk_set_options(dst, detail_::kWriteFlags);
-    ::archive_write_disk_set_standard_lookup(dst);
 
-    // 64 KiB read block — same order of magnitude libarchive examples use.
-    if (::archive_read_open_filename(src, archive.string().c_str(), 65536) != ARCHIVE_OK) {
+    // Custom user/group lookup that always returns 0 (root). xim-pkgindex
+    // tarballs are packed root:root by convention, and even when they
+    // aren't, a non-root extractor can't honor non-root ownership anyway —
+    // libarchive silently ignores the chown. The default
+    // `archive_write_disk_set_standard_lookup` calls getpwnam_r/getgrnam_r
+    // per unique uname/gname, which can stall multi-second when NSS routes
+    // through LDAP / sssd / nscd that's misbehaving. Skipping that path
+    // entirely is a 0-LOC-of-runtime-cost win with no observable
+    // behavior change.
+    ::archive_write_disk_set_user_lookup(dst, nullptr,
+        &detail_::const_root_lookup_uid_, nullptr);
+    ::archive_write_disk_set_group_lookup(dst, nullptr,
+        &detail_::const_root_lookup_gid_, nullptr);
+
+    // 4 MiB read block (was 64 KiB pre-0.4.20). For the 808 MiB musl-gcc
+    // tarball that originally surfaced this, the change alone took
+    // wall-clock from 217 s → 5.8 s — even faster than `tar -xpf` at 9.3 s
+    // on the same input. Tiny block + one-syscall-per-block is the dominant
+    // cost on multi-GiB archives; 4 MiB matches what GNU tar uses
+    // internally and stays within libarchive's stack-friendly allocation
+    // envelope.
+    constexpr std::size_t kReadBlockSize = 4 * 1024 * 1024;
+    if (::archive_read_open_filename(src, archive.string().c_str(), kReadBlockSize) != ARCHIVE_OK) {
         std::string err = std::format("open {}: {}",
             archive.string(), detail_::libarchive_error_(src));
         cleanup();


### PR DESCRIPTION
## Summary

User-reported: `xlings install local:musl-gcc@15.1.0` (847 MiB tarball) hung in the "download phase" for **~217 seconds** — actually extraction. Same file via raw `tar -xzf` finished in 9.2 s on the same machine. Investigated and pinpointed two libarchive misconfigurations in `src/core/xim/extract.cppm`.

## Root cause

| Issue | Pre-fix | Fix |
|-------|---------|-----|
| `archive_read_open_filename` block size | 65536 (64 KiB) → ~16k read syscalls per GiB | **4 MiB** (matches GNU tar internal buffer) |
| `archive_write_disk_set_standard_lookup` | per-uname/gname `getpwnam_r`/`getgrnam_r` → can stall multi-sec on slow NSS (LDAP/sssd/nscd) | Custom lookup callback returns 0 (root). xim-pkgindex tarballs are root:root by convention; non-root extract can't honor non-root anyway |

## Measured impact

On the user's exact 808 MiB musl-gcc tarball:

```
before this patch:  ~217 s
after this patch:    5.79 s   (faster than `tar -xpf` at 9.31 s on same input)
speedup:            ~37×
```

## Why no `posix_spawn(tar)` fallback path

Prototyped Tier 2 (subprocess `tar -xpf`) before settling on minimum scope. Empirical comparison on the same hardware showed:

- Subprocess on small archives (50 MiB): **4× slower** than Tier 1 libarchive (subprocess startup overhead dominates)
- Subprocess on big archives (808 MiB): 9.3 s vs Tier 1's 5.8 s — Tier 1 still wins (no pipe IPC, no fork, single-thread zlib is fast enough at 4 MiB block)

So we keep just one code path. No dispatcher, no env-var escape hatch, no fallback.

## Test plan

- [x] Local build clean
- [x] All 5 existing `Extract.*` unit tests pass (`TarGzRoundTrip`, `ZipRoundTrip`, `TarXzRoundTrip`, `MissingArchiveReturnsError`, `RejectsPathTraversal`)
- [x] Full unit test suite (220 tests) passes
- [x] Manually verified: 808 MiB musl-gcc.tar.gz extraction wall-clock 5.79 s (was ~217 s)
- [ ] CI green on Linux / macOS / Windows

## Diff size

3 files, +49/-4 LOC. Truly minimal: no new module, no new dependency, no new escape hatch, no behavioral surface for the user to learn.