### PR TITLE
fix(0.4.20): project discovery walk must not cross xlings-home boundary

### DIFF
--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -4,7 +4,19 @@
 
 ### 2026-05 (v0.4.20)
 
-- **大型 tarball 解压性能修复:libarchive read block 64 KiB → 4 MiB,跳过 NSS lookup**
+- **嵌套 xlings home 时 project discovery 越界污染修复 (#276)**
+  - 报告:用 xlings 安装 mcpp(mcpp 的 payload 里**包了一个独立的 xlings home** —— 内层 `XLINGS_HOME=$MCPP_HOME/registry`,`registry/` 落在 `~/.xlings/data/xpkgs/<repo>-x-mcpp/<ver>/registry`),内层 xlings 启动后,workspace / subos / install 路径全部跑偏到 `~/.xlings/.xlings/{subos,data,...}` 这种根本不存在的伪 project tree。下游所有 install/shim/workspace 操作的"现实"和 mcpp recipe 看到的"现实"分裂。
+  - 根因(`src/core/config.cppm` `load_project_config_()`):cwd 向上 walk 找 `.xlings.json` 时,只用 `curNorm != homeNorm` 跳过自家 home,**没有挡别家**。内层 walk 会越过自己的 home 之后,继续向上爬到外层 `~/.xlings/.xlings.json` —— 那个文件其实是另一个 xlings home 的全局配置,但 walk 把它当 project root 加载了。
+  - 修复:加 xlings-home 边界检测。任何同时含 `.xlings.json` **和** `subos/` **同级目录**的位置都识别为某个 xlings home(自家或别家),walk 在那里 break,绝不当 project 加载。可靠依据:project layout 的 subos 在 `<proj>/.xlings/subos/`(多一层 `.xlings/`),不会和 home 的 `<home>/subos/` 撞名。原 `curNorm != homeNorm` 检查被 break 取代(自家 home 也满足签名,break 已覆盖)。
+  - 同样的边界检测也加到 `XLINGS_PROJECT_DIR` env-var fallback 路径上 —— env 指向某个 xlings home 时也拒绝(否则等于绕过 walk 检查重新引入污染)。
+  - 锁住:新增 `nested_xlings_home_test.sh`(4 个 scenario,作为 E2E-24 加入 CI):
+    - S1:内层 xlings cwd 在 `registry/data/runtimedir` → 不进 project mode,XLINGS_HOME 报内层
+    - S2:常规 user project(不在任何 xlings home 下面)→ project mode 仍正确触发
+    - S3:cwd `/tmp` + XLINGS_HOME=内层 → 不会误把任何 home 当 project
+    - S4:`XLINGS_PROJECT_DIR=外层 home` 显式指过去 → 也被 boundary 检查拒绝
+  - 影响 LOC:`config.cppm` ~25 行,新增 e2e ~100 行。无 schema 变更,无 API 变更,纯 walk 逻辑收紧。
+
+- **大型 tarball 解压性能修复:libarchive read block 64 KiB → 4 MiB,跳过 NSS lookup (#275)**
   - 用户报告:`xlings install local:musl-gcc@15.1.0`(847 MiB tarball)整个安装阶段挂在 "下载阶段" ~217 秒,实际是解压。raw `tar -xzf` 同一文件 9.2 秒,**xlings ~23×**。
   - 实测定位(在用户原始 tarball 上跑):
     - **read block 大小**:`archive_read_open_filename` 默认参数 65536 字节 → 每 GiB ~16k 次 read syscall。改成 4 MiB(GNU tar 内部用的量级)后,syscall 数掉一个数量级。

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -253,6 +253,10 @@ jobs:
         run: |
           bash tests/e2e/subos_install_remove_isolation_test.sh
 
+      - name: "E2E-24: nested xlings home (project discovery boundary)"
+        run: |
+          bash tests/e2e/nested_xlings_home_test.sh
+
       - name: Attach artifact
         uses: actions/upload-artifact@v4
         if: success()

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -614,16 +614,44 @@ private:
         // whenever it loads a real project, so subprocesses can recover the
         // intended project context even when their cwd is outside the project
         // tree).
+        // 0.4.20+: xlings-home boundary detection.
+        //
+        // A directory that contains BOTH `.xlings.json` and a `subos/`
+        // sibling directory is an xlings home (ours or some other one) —
+        // never a user project. Project layouts have their state under
+        // `.xlings/subos/`, NOT a bare `subos/` at the same level as
+        // the manifest. Stop walking at any such boundary.
+        //
+        // Without this, a nested xlings home (e.g. mcpp packaged under
+        // ~/.xlings/data/xpkgs/<repo>-x-mcpp/<ver>/registry/, where the
+        // inner xlings sets XLINGS_HOME to the registry dir) would see
+        // its CWD walk skip the inner home (homeNorm match), continue
+        // upward through the package layers, and ultimately mis-load the
+        // OUTER ~/.xlings/.xlings.json as if it were a user project root.
+        // That polluted projectDir_ with the outer home and routed every
+        // subsequent install/shim/workspace path into a phantom
+        // ~/.xlings/.xlings/{subos,data,...} tree disjoint from where
+        // mcpp's recipe actually puts its files.
+        //
+        // The boundary check subsumes the previous `curNorm != homeNorm`
+        // gate: our own home also matches the signature, so the break
+        // covers it. Any directory that "looks like" an xlings home
+        // (regardless of whose) terminates the project walk.
+        auto looks_like_xlings_home = [&](const fs::path& dir) {
+            std::error_code lec;
+            return fs::is_directory(dir / "subos", lec);
+        };
+
         fs::path cur = startDir;
         while (!cur.empty()) {
             auto cfg = cur / ".xlings.json";
             if (fs::exists(cfg, ec) && fs::is_regular_file(cfg, ec)) {
-                auto curNorm = fs::weakly_canonical(cur, ec);
-                if (curNorm != homeNorm) {
-                    load_project_config_from_dir_(cur);
-                    if (hasProjectConfig_) return;     // real project loaded
-                    // else: projectScope:false skip — keep walking, then env fallback
+                if (looks_like_xlings_home(cur)) {
+                    break;                              // hit an xlings home — never project
                 }
+                load_project_config_from_dir_(cur);
+                if (hasProjectConfig_) return;          // real project loaded
+                // else: projectScope:false skip — keep walking, then env fallback
             }
             auto parent = cur.parent_path();
             if (parent == cur) break;
@@ -639,8 +667,12 @@ private:
                 auto dir = fs::path(env_project);
                 auto cfgFile = dir / ".xlings.json";
                 if (fs::exists(cfgFile, ec) && fs::is_regular_file(cfgFile, ec)) {
-                    auto dirNorm = fs::weakly_canonical(dir, ec);
-                    if (dirNorm != homeNorm) {
+                    // Same xlings-home boundary check as the CWD walk:
+                    // an env-var pointing at any xlings home (ours or a
+                    // different one) is rejected, since project mode
+                    // would derive paths that don't match the home's
+                    // actual layout.
+                    if (!looks_like_xlings_home(dir)) {
                         load_project_config_from_dir_(dir);
                     }
                 }

--- a/tests/e2e/nested_xlings_home_test.sh
+++ b/tests/e2e/nested_xlings_home_test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# nested_xlings_home_test.sh — regression for the project-discovery
+# boundary fix shipped in 0.4.20.
+#
+# Background: a package like mcpp ships its own xlings home as part of
+# its payload, with the inner XLINGS_HOME pointing at
+# `<outer-home>/data/xpkgs/<repo>-x-mcpp/<ver>/registry`. Pre-fix, the
+# inner xlings's load_project_config_() walk would skip its own home
+# (homeNorm match), continue walking upward through the package layers,
+# and ultimately mis-load the OUTER `<outer-home>/.xlings.json` as a
+# project root. That polluted projectDir_ with the outer home and
+# routed every install/shim/workspace path into a phantom
+# `<outer-home>/.xlings/{subos,data,...}` tree disjoint from the
+# inner home's actual layout.
+#
+# Fix: any directory containing `.xlings.json` AND a sibling `subos/`
+# directory is an xlings home (regardless of whose) — terminate the
+# project walk there, never load it as a project. Project layouts
+# nest subos under `.xlings/subos/`, not bare `subos/`, so this
+# signature has no false positives in real projects.
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/nested_xlings_home"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+OUTER_HOME="$RUNTIME_DIR/outer-home"
+INNER_HOME="$OUTER_HOME/data/xpkgs/xim-x-mcpp/0.0.1/registry"
+
+# ── Outer home: typical xlings home layout ───────────────────────────
+mkdir -p "$OUTER_HOME/subos/default/bin"
+cp "$XLINGS_BIN" "$OUTER_HOME/xlings"
+cat > "$OUTER_HOME/.xlings.json" <<JSON
+{ "activeSubos": "default", "mirror": "GLOBAL" }
+JSON
+
+# ── Inner home, packaged under outer's xpkgs (mimics mcpp/registry) ──
+mkdir -p "$INNER_HOME/subos/default/bin"
+mkdir -p "$INNER_HOME/data/runtimedir"
+cat > "$INNER_HOME/.xlings.json" <<JSON
+{ "activeSubos": "default", "mirror": "GLOBAL" }
+JSON
+
+run_config() {
+  local home="$1"; local cwd="$2"
+  ( cd "$cwd" && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$home" \
+      "$XLINGS_BIN" config 2>&1 | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' )
+}
+
+# Detect project mode by checking output for project-anonymous subos
+# path (.xlings/subos/) or the explicit XLINGS_DATA_PROJECT line.
+is_project_mode() {
+  echo "$1" | grep -qE "(\.xlings/subos/|XLINGS_DATA_PROJECT)"
+}
+
+# ── Scenario 1: inner xlings inside its own runtimedir ───────────────
+log "S1: inner xlings (cwd=runtimedir) must NOT cross into outer home"
+out="$(run_config "$INNER_HOME" "$INNER_HOME/data/runtimedir")"
+if is_project_mode "$out"; then
+  fail "S1: inner xlings entered project mode (likely mistook outer home as project)
+  output:
+$out"
+fi
+echo "$out" | grep -F "$INNER_HOME" >/dev/null \
+  || fail "S1: inner xlings did not report inner home"
+log "  ✓ inner xlings stayed in its own home, no project leak"
+
+# ── Scenario 2: regular project still detected (no false negative) ───
+log "S2: regular user project (NOT inside any xlings home) still loads"
+PROJECT_DIR="$RUNTIME_DIR/myproj"
+mkdir -p "$PROJECT_DIR/subdir"
+cat > "$PROJECT_DIR/.xlings.json" <<JSON
+{ "workspace": { "node": "22.0.0" } }
+JSON
+out="$(run_config "$OUTER_HOME" "$PROJECT_DIR/subdir")"
+is_project_mode "$out" \
+  || fail "S2: legitimate project should activate project mode
+  output:
+$out"
+log "  ✓ legitimate project mode still detected"
+
+# ── Scenario 3: bare cwd /tmp + XLINGS_HOME=inner — no project anywhere
+log "S3: cwd outside any project, XLINGS_HOME=inner — no project leak"
+out="$(run_config "$INNER_HOME" "/tmp")"
+if is_project_mode "$out"; then
+  fail "S3: should not find any project from /tmp
+  output:
+$out"
+fi
+log "  ✓ no project mode from /tmp"
+
+# ── Scenario 4: env var XLINGS_PROJECT_DIR pointing at an xlings home
+#                must be rejected (same boundary check applies)
+log "S4: XLINGS_PROJECT_DIR pointing at an xlings home is rejected"
+out="$(
+  cd /tmp && \
+  env -i HOME="$HOME" PATH=/usr/bin:/bin \
+    XLINGS_HOME="$INNER_HOME" \
+    XLINGS_PROJECT_DIR="$OUTER_HOME" \
+    "$XLINGS_BIN" config 2>&1 | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g'
+)"
+if is_project_mode "$out"; then
+  fail "S4: XLINGS_PROJECT_DIR pointing at an xlings home was accepted as project
+  output:
+$out"
+fi
+log "  ✓ env-var route honors the same boundary"
+
+log "PASS: nested xlings home — project discovery boundary holds"


### PR DESCRIPTION
## Summary

Companion PR to #275 (both target the **0.4.20** release). User-reported root cause when installing mcpp via xlings: mcpp ships its own xlings home as part of its payload (inner `XLINGS_HOME = $MCPP_HOME/registry`, where `registry/` lives under the outer xlings's xpkgs tree). The inner xlings's project-discovery walk would skip its own home (homeNorm match), continue walking up through the outer xlings home's directory layers, and **mis-load the OUTER home's `.xlings.json` as a project root**.

Result: `projectDir_` got set to the outer home, and every subsequent install/shim/workspace path routed into a phantom `<outer-home>/.xlings/{subos,data,...}` tree disjoint from where the inner mcpp recipe actually puts files. Downstream symptoms: empty dirs, missing bins, shim divergence between mcpp's view and inner xlings's view.

## Fix

Add an **xlings-home signature check** to `load_project_config_()`:
- Any directory containing both `.xlings.json` AND a sibling `subos/` directory is an xlings home (ours or another's) → **terminate the walk**, never load it as a project.
- Project layouts nest subos under `<proj>/.xlings/subos/` (extra `.xlings/` level), so the signature has no false positives in real projects.
- Old gate `curNorm != homeNorm` removed — boundary signature subsumes it (our own home also matches → break covers it).
- Same check applied to the `XLINGS_PROJECT_DIR` env-var fallback path.

## Test plan

New `tests/e2e/nested_xlings_home_test.sh` (wired in as **E2E-24**):

| Scenario | Verdict |
|----------|---------|
| S1: inner xlings cwd in `<inner>/data/runtimedir`, outer home above | must NOT enter project mode |
| S2: legitimate user project (NOT under any xlings home) | must STILL enter project mode (no false negative) |
| S3: cwd `/tmp` + XLINGS_HOME=inner | no project from anywhere |
| S4: `XLINGS_PROJECT_DIR=<another xlings home>` | rejected by same boundary check |

All 4 scenarios pass locally.

- [x] Local build clean
- [x] New e2e (4 scenarios) pass
- [x] Existing project_workspace_platform_test.sh + project_local_repo_test.sh continue to pass (real projects unaffected)
- [ ] CI green on Linux / macOS / Windows

## Diff size

4 files, +173/-8 LOC. Pure logic tightening — no schema change, no new module, no escape hatch.

## Co-shipped under 0.4.20

This PR + #275 together comprise the 0.4.20 release. Each is reviewable independently. VERSION bumped here too; merge order is irrelevant (both want 0.4.20).