### PR TITLE
fix(0.4.22): subos new --sandbox-shell auto-installs + connects shell

### DIFF
--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -2,6 +2,28 @@
 
 ## 2026
 
+### 2026-05 (v0.4.22)
+
+- **subos sandbox 一步到位 + 真正能跑 elfpatched binary**
+  - V1.1(0.4.21)的痛点:`subos new <name> --sandbox-shell xim:fish` 只写 config,不装 shell,不连 binary。用户 `subos use` 报错"shell not found",**提示又让用户先 `subos use && xlings install`** —— 死循环。就算手动 `xlings install fish` 把 fish 装进默认 subos,fish 仍然不在 sandbox 自己的 `bin/`,**且进入 sandbox 后 elfpatched fish 找不到 loader**(绝对宿主路径在 proot rootfs 里指向空目录)。
+  - **V1.2 修复(`src/core/subos.cppm`)**:
+    1. **`subos new --sandbox-shell` 创建期 eager install + symlink**:写完 sandbox 目录布局后,把 `--sandbox-shell` 指定的 xpkg 通过 `xim::cmd_install` 装好(yes=true 静默),从 xvm DB 解析其 bindir,**symlink `<sandbox>/bin/<basename>` → `<xpkg-payload>/bin/<basename>`**。一行命令拿到可用的 sandbox。
+    2. **proot argv 加 `--bind=<home_dir>:<home_dir>` 自映射**。xim 装的 binary 经 elfpatch 后 interpreter / rpath 是宿主绝对路径(如 `/home/<user>/.xlings/data/xpkgs/xim-x-d2x/.../ld-linux-x86-64.so.2`)。proot `-R <sandbox>` 会把绝对路径路由到 `<sandbox>/<原路径>`(空目录 → loader 找不到 → 启动即死)。**自映射让那条绝对路径在 sandbox 内仍然指向宿主真实位置**,fish / bash / zsh 等动态链接的 elf 可执行原生跑起来。`/xlings` 那条 bind 是面向用户的便捷别名,这条自映射才是让 binary 真正能跑的关键。
+    3. **`subos use` lazy 自愈**:进入路径检查到 `<sandbox>/bin/<shell>` 缺失或 dangling(用户后来 `xlings remove xim:fish` 把 payload 删了)→ 直接复用 hydrate 流程重装 + 重连。原死循环错误提示删掉,换成可执行的 `xlings install <xpkg>`(没记 xpkg id 的兜底分支)。
+    4. **顺手修一个 dangling-pointer bug**:`Config::versions()` 是 by-value 返回临时 VersionDB,把它当 `get_vdata(Config::versions(), ...)` 的实参用,返回的 `VData*` 在表达式结束就指向已析构的临时对象 —— 落在 `vd->path` 上观察到一段乱码字符,导致 `fs::exists` 始终 false。**改成先 bind 到 local `auto db = Config::versions();`** 再传 `get_vdata(db, ...)`。这种坑全文件 grep 一遍,后续 PR 应该全 audit。
+  - 用户可见 UX:
+    ```
+    xlings subos new sb --sandbox-shell xim:fish    # 自动装 fish + 连进 sb/bin/fish
+    xlings subos use sb                              # proot 直接进,fish 真能用
+    xlings remove xim:fish && xlings subos use sb    # 自愈:重装 + 重连,继续进
+    ```
+  - **测试(`tests/e2e/subos_sandbox_test.sh`)**:`xim:sh` 改成本地 fixture xpkg(用宿主 busybox,无网络依赖),从 7 scenario 扩到 8 scenario:
+    - S1 加 symlink 验证(target 必须落在 `data/xpkgs/xim-x-sh` 下)
+    - S6 删掉手动 `cp busybox` 一步,验证 hydrate 流程交付的 binary 也能在 proot 里跑通
+    - **新增 S7**:rm 掉 sandbox 的 shell symlink,下一次 `subos use` 必须自动恢复 symlink
+    - 旧 S7 (remove cleanup) 改成 S8
+  - 改动量:subos.cppm +~150 LOC(helper + 2 调用点 + bind 一行);test +~80 LOC(fixture + S1/S6/S7 改写)。版本 0.4.21 → 0.4.22。
+
 ### 2026-05 (v0.4.21)
 
 - **subos sandbox 模式:proot 文件系统隔离,无 sudo,Linux 专属**

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.21";
+    static constexpr std::string_view VERSION = "0.4.22";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -24,6 +24,8 @@ import xlings.platform;
 import xlings.runtime;
 import xlings.core.utils;
 import xlings.core.xself;
+import xlings.core.xvm.db;
+import xlings.core.xim.commands;
 
 namespace xlings::subos {
 
@@ -143,6 +145,15 @@ void write_etc_templates_(const fs::path& subos_dir) {
 // Initialize sandbox-specific directory layout in addition to the
 // regular subos dirs. /root is $HOME inside; /tmp is per-sandbox tmp.
 // /etc gets the templates above.
+// Forward declaration — definition lives in the second sandbox_detail_
+// block alongside locate_proot_ / build_proot_argv_, which it depends on.
+// create_impl_ (between the two blocks) calls this for the eager-install
+// path on `subos new --sandbox-shell`.
+int ensure_shell_installed_and_linked_(const fs::path& sandbox_dir,
+                                       const std::string& xpkg_id,
+                                       const std::string& shell_inside_path,
+                                       EventStream& stream);
+
 void init_sandbox_layout_(const fs::path& subos_dir) {
     fs::create_directories(subos_dir / "root");
     fs::create_directories(subos_dir / "tmp");
@@ -252,6 +263,21 @@ int create_impl_(const std::string& name, const fs::path& customDir,
     if (!json.contains("subos")) json["subos"] = nlohmann::json::object();
     json["subos"][name] = {{"dir", customDir.empty() ? "" : customDir.string()}};
     write_config_json_(configPath, json);
+
+    // Sandbox: install the configured shell xpkg and symlink its binary
+    // into <sandbox>/bin/<basename> so `subos use <name>` can exec it.
+    // Done at create time so the user's mental model holds:
+    // "I asked for a sandbox with this shell — it's ready."
+    if (sandboxShellXpkg.has_value()) {
+#if defined(__linux__)
+        auto bare = *sandboxShellXpkg;
+        if (auto colon = bare.rfind(':'); colon != std::string::npos)
+            bare = bare.substr(colon + 1);
+        auto rc = sandbox_detail_::ensure_shell_installed_and_linked_(
+            dir, *sandboxShellXpkg, "/bin/" + bare, stream);
+        if (rc != 0) return rc;
+#endif
+    }
 
     nlohmann::json payload;
     payload["name"] = name;
@@ -536,10 +562,153 @@ build_proot_argv_(const fs::path& proot_bin,
         std::format("--bind={}:/etc/hosts",        (etc / "hosts").string()),
         std::format("--bind={}:/etc/nsswitch.conf",(etc / "nsswitch.conf").string()),
         std::format("--bind={}:/xlings", home_dir.string()),
+        // Self-bind xlings home at its host absolute path. xim-installed
+        // binaries are elfpatched with the absolute host path of their
+        // loader / rpath libs (e.g. ld-linux from xim:d2x). Without this
+        // bind, those paths route to <rootfs>/<host-path> which is empty,
+        // and the shell fails to start with "no such file or directory".
+        // The /xlings bind above is for user-facing convenience; this
+        // self-bind is what makes elfpatched binaries actually run.
+        std::format("--bind={}:{}", home_dir.string(), home_dir.string()),
         "--cwd=/root",
         shell_path,
     };
     return argv;
+}
+
+// Ensure the configured sandbox shell binary is installed and present at
+// `<sandbox>/bin/<basename>` as a symlink to the xim-managed payload.
+// Idempotent — safe to re-run from `subos new --sandbox-shell` (eager
+// hydration) and from `subos use <sandbox>` (lazy self-heal when the
+// payload was removed or the symlink dangles).
+//
+// Strategy:
+//   1. If the destination exists and resolves to a real file, no-op.
+//   2. Otherwise, ensure the xpkg is installed (call xim::cmd_install
+//      with yes=true). The install registers a bindir in the xvm DB.
+//   3. Resolve <bindir>/<basename> from the xvm DB and symlink it into
+//      the sandbox's bin/.
+//
+// Returns 0 on success. On failure emits an ErrorEvent and returns 1.
+int ensure_shell_installed_and_linked_(const fs::path& sandbox_dir,
+                                       const std::string& xpkg_id,
+                                       const std::string& shell_inside_path,
+                                       EventStream& stream)
+{
+    namespace fs = std::filesystem;
+
+    // bare name = xpkg id with namespace prefix stripped (xim:fish → fish)
+    std::string bare = xpkg_id;
+    if (auto colon = bare.rfind(':'); colon != std::string::npos)
+        bare = bare.substr(colon + 1);
+
+    // shell_inside_path looks like "/bin/fish"; strip leading '/' to get
+    // the host-side path under <sandbox_dir>.
+    auto rel = shell_inside_path;
+    if (!rel.empty() && rel.front() == '/') rel.erase(0, 1);
+    auto shell_dst = sandbox_dir / rel;
+    auto basename  = fs::path(shell_inside_path).filename().string();
+
+    std::error_code ec;
+
+    // Already there and resolves to a real file → done.
+    if (fs::exists(shell_dst, ec) && !ec) return 0;
+    ec.clear();
+
+    // Dangling symlink (target gone) → remove so create_symlink can run.
+    if (fs::is_symlink(shell_dst, ec)) {
+        fs::remove(shell_dst, ec);
+        ec.clear();
+    }
+
+    // Look up the xpkg in the xvm DB. If no version is registered yet,
+    // run a full install pass — xim::cmd_install handles download +
+    // extract + install hook + xvm registration.
+    //
+    // Important: Config::versions() returns the merged DB BY VALUE, so
+    // the returned object is a temporary. We MUST bind it to a local
+    // variable before pulling pointers out of it (`get_vdata` returns
+    // a pointer into the DB). Calling Config::versions() inline as a
+    // function argument creates a temporary that dies at the end of
+    // the expression, leaving `vd` dangling — observed as a corrupted
+    // path string and a spurious "shell binary not found" error.
+    auto db = Config::versions();
+    auto resolved = xvm::match_version(db, bare, "");
+    if (resolved.empty()) {
+        std::vector<std::string> targets = { xpkg_id };
+        auto rc = xim::cmd_install(targets, /*yes=*/true,
+                                   /*noDeps=*/false, stream);
+        if (rc != 0) {
+            stream.emit(ErrorEvent{
+                .code = ErrorCode::NotFound,
+                .message = std::format(
+                    "failed to install sandbox shell xpkg '{}'", xpkg_id),
+                .recoverable = true,
+                .hint = std::format(
+                    "try manually: xlings install {} (then re-run subos use)",
+                    xpkg_id),
+            });
+            return 1;
+        }
+        db = Config::versions();
+        resolved = xvm::match_version(db, bare, "");
+        if (resolved.empty()) {
+            stream.emit(ErrorEvent{
+                .code = ErrorCode::NotFound,
+                .message = std::format(
+                    "xpkg '{}' installed but no version in xvm DB "
+                    "(unexpected — package may not register a binary)",
+                    xpkg_id),
+                .recoverable = false,
+            });
+            return 1;
+        }
+    }
+
+    auto* vd = xvm::get_vdata(db, bare, resolved);
+    if (!vd || vd->path.empty()) {
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::NotFound,
+            .message = std::format(
+                "xpkg '{}' has no bindir registered in xvm DB", xpkg_id),
+            .recoverable = false,
+        });
+        return 1;
+    }
+
+    auto bindir = fs::path(xvm::expand_path(
+        vd->path, Config::paths().homeDir.string()));
+    auto shell_src = bindir / basename;
+    if (!fs::exists(shell_src, ec)) {
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::NotFound,
+            .message = std::format(
+                "shell binary '{}' not found in xpkg payload (looked at {})",
+                basename, shell_src.string()),
+            .recoverable = false,
+            .hint = std::format(
+                "the xpkg '{}' may not provide a binary called '{}'",
+                xpkg_id, basename),
+        });
+        return 1;
+    }
+
+    fs::create_directories(shell_dst.parent_path(), ec);
+    ec.clear();
+    fs::create_symlink(shell_src, shell_dst, ec);
+    if (ec) {
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::Internal,
+            .message = std::format(
+                "failed to symlink {} -> {}: {}",
+                shell_dst.string(), shell_src.string(), ec.message()),
+            .recoverable = false,
+        });
+        return 1;
+    }
+    log::debug("[sandbox] hydrated shell {} -> {}",
+               shell_dst.string(), shell_src.string());
+    return 0;
 }
 
 } // namespace sandbox_detail_
@@ -598,9 +767,13 @@ int use_sandbox_(const std::string& name, EventStream& stream) {
         return 1;
     }
 
-    // Sanity: shell binary exists in subos. If not, the user probably
-    // hasn't run `xlings install <shell-xpkg>` yet (V1.1 doesn't
-    // auto-install at create-time). Print a helpful hint.
+    // Self-heal: shell binary may be missing because the user removed
+    // the underlying xpkg (`xlings remove ...`) after creating the
+    // sandbox, leaving a dangling symlink. Re-run the hydrate path,
+    // which is idempotent and reinstalls the xpkg if needed. Eager
+    // install at `subos new` is the primary path; this is the
+    // recovery path so users never get stuck in chicken-and-egg
+    // (can't `subos use` to install, can't install without entering).
     auto host_shell_path = subos_dir / shell_path.substr(
         shell_path.front() == '/' ? 1 : 0);  // strip leading "/"
     if (!fs::exists(host_shell_path)) {
@@ -610,21 +783,27 @@ int use_sandbox_(const std::string& name, EventStream& stream) {
         {
             xpkg_id = subos_config["sandbox-shell-xpkg"].get<std::string>();
         }
-        std::string hint = xpkg_id.empty()
-            ? std::format("install a shell into subos '{}' first", name)
-            : std::format(
-                "install the configured shell first:\n"
-                "    xlings subos use {} && xlings install {}",
-                name, xpkg_id);
-        stream.emit(ErrorEvent{
-            .code = ErrorCode::NotFound,
-            .message = std::format(
-                "sandbox shell '{}' not found in subos '{}' (expected at {})",
-                shell_path, name, host_shell_path.string()),
-            .recoverable = true,
-            .hint = std::move(hint),
-        });
-        return 1;
+        if (xpkg_id.empty()) {
+            stream.emit(ErrorEvent{
+                .code = ErrorCode::NotFound,
+                .message = std::format(
+                    "sandbox shell '{}' not found in subos '{}' (expected at {})",
+                    shell_path, name, host_shell_path.string()),
+                .recoverable = false,
+                .hint = std::format(
+                    "no sandbox-shell-xpkg recorded — recreate the subos: "
+                    "xlings subos remove {} && xlings subos new {} --sandbox-shell <xpkg>",
+                    name, name),
+            });
+            return 1;
+        }
+        log::info("[sandbox] shell missing — rehydrating from xpkg '{}'",
+                  xpkg_id);
+        if (auto rc = sandbox_detail_::ensure_shell_installed_and_linked_(
+                subos_dir, xpkg_id, shell_path, stream); rc != 0)
+        {
+            return rc;
+        }
     }
 
     nlohmann::json payload;

--- a/tests/e2e/subos_sandbox_test.sh
+++ b/tests/e2e/subos_sandbox_test.sh
@@ -1,21 +1,31 @@
 #!/usr/bin/env bash
-# subos_sandbox_test.sh — verifies the 0.4.21 sandbox subos type:
-# `subos new --sandbox-shell` creates the right layout, /etc/* templates
-# end up where expected, .xlings.json carries the sandbox-shell field,
-# and `subos use` correctly enters the proot-based sandbox shell.
+# subos_sandbox_test.sh — verifies the sandbox subos type:
+#
+#   * `subos new --sandbox-shell <xpkg>` creates the right layout, /etc/*
+#     templates land where expected, .xlings.json carries the sandbox-shell
+#     fields, AND eagerly installs the configured shell xpkg + symlinks the
+#     binary into <sandbox>/bin/<basename> so `subos use` can run it
+#     (added in 0.4.22).
+#   * `subos use <sandbox>` correctly enters the proot-based sandbox shell.
+#   * If the symlink dangles (e.g. user removed the underlying xpkg), the
+#     next `subos use` self-heals by re-running hydration.
 #
 # Sandbox is Linux-only by design (proot uses ptrace + Linux syscall
-# semantics); this test is gated on Linux. macOS / Windows variants
-# only verify that --sandbox-shell at create time is rejected with
-# a clear error.
+# semantics); this test is gated on Linux. macOS / Windows variants only
+# verify that --sandbox-shell at create time is rejected with a clear
+# error.
 #
 # Design ref: docs/plans/2026-05-09-subos-sandbox-design.md
 set -euo pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
 
+require_fixture_index
+
 RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/subos_sandbox"
 HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+FIXTURE_PKG="$LOCAL_INDEX_DIR/pkgs/s/sh.lua"
 
 cleanup() { rm -rf "$RUNTIME_DIR"; }
 trap cleanup EXIT
@@ -24,8 +34,79 @@ cleanup
 XLINGS_BIN="$(find_xlings_bin)"
 
 mkdir -p "$HOME_DIR/subos/default/bin" "$HOME_DIR/runtimedir"
+
+# Private copy of the shared fixture index, neutralise sub-index repos.
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$(dirname "$FIXTURE_PKG")"
+
+# Fixture xpkg `sh`: drops a tiny static-ish shell at
+# <install_dir>/bin/sh and registers via xvm.add. The install
+# hook prefers the system busybox (statically linked on most distros),
+# falling back to /bin/sh otherwise — in either case the binary
+# delivered through the xim install path is what we want the eager
+# hydrate flow to symlink into the sandbox bin.
+cat > "$FIXTURE_PKG" <<'LUA'
+package = {
+    spec = "1",
+    name = "sh",
+    description = "Local fixture for tests/e2e/subos_sandbox_test.sh",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+    xpm = {
+        linux   = { ["1.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {} },
+        windows = { ["1.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(bindir)
+    -- Prefer system busybox (static, dispatches by argv[0] so the
+    -- "sh" applet is available when invoked as bin/sh). Otherwise
+    -- copy /bin/sh. The hydrate flow symlinks <install_dir>/bin/sh
+    -- into <sandbox>/bin/sh for the sandbox shell.
+    local src = "/bin/busybox"
+    if not os.isfile(src) then src = "/bin/sh" end
+    if os.isfile(src) then
+        os.cp(src, path.join(bindir, "sh"))
+    else
+        io.writefile(path.join(bindir, "sh"),
+                     "#!/bin/sh\nexec /bin/sh \"$@\"\n")
+    end
+    os.exec("chmod +x " .. path.join(bindir, "sh"))
+    return true
+end
+
+function config()
+    xvm.add("sh", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+
+function uninstall()
+    xvm.remove("sh")
+    return true
+end
+LUA
+
 cat > "$HOME_DIR/.xlings.json" <<JSON
-{ "activeSubos": "default" }
+{
+  "activeSubos": "default",
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
 JSON
 
 run_x() {
@@ -38,9 +119,9 @@ run_x() {
 # ─────────────────────────────────────────────────────────────────────
 if [[ "$(uname -s)" == "Linux" ]]; then
 
-# ── S1: subos new --sandbox-shell creates correct layout
-log "S1: subos new --sandbox-shell creates expected directory layout"
-run_x subos new mybox --sandbox-shell xim:sh >/dev/null
+# ── S1: subos new --sandbox-shell creates layout + auto-hydrates shell
+log "S1: subos new --sandbox-shell mybox xim:sh"
+run_x subos new mybox --sandbox-shell xim:sh >/dev/null 2>&1
 
 [[ -d "$HOME_DIR/subos/mybox" ]]              || fail "S1: subos dir not created"
 [[ -d "$HOME_DIR/subos/mybox/bin" ]]          || fail "S1: bin/ missing"
@@ -48,11 +129,19 @@ run_x subos new mybox --sandbox-shell xim:sh >/dev/null
 [[ -d "$HOME_DIR/subos/mybox/root" ]]         || fail "S1: root/ missing (expected for sandbox subos)"
 [[ -d "$HOME_DIR/subos/mybox/tmp" ]]          || fail "S1: tmp/ missing (expected for sandbox subos)"
 [[ -f "$HOME_DIR/subos/mybox/.xlings.json" ]] || fail "S1: .xlings.json missing"
-log "  ✓ directories: bin/, etc/, root/, tmp/ all present"
+
+# Eager hydration: shell binary must be present at <sandbox>/bin/sh
+# (created as a symlink to the xim payload's binary).
+shell_link="$HOME_DIR/subos/mybox/bin/sh"
+[[ -L "$shell_link" ]] || fail "S1: shell symlink missing at $shell_link"
+[[ -f "$shell_link" ]] || fail "S1: shell symlink dangling at $shell_link"
+target="$(readlink "$shell_link")"
+[[ "$target" == *"data/xpkgs/xim-x-sh"* ]] \
+  || fail "S1: shell symlink target unexpected: $target"
+log "  ✓ layout + auto-installed shell (symlink: $target)"
 
 # ── S2: /etc/* templates have correct content
 log "S2: /etc/{passwd,group,hosts,nsswitch.conf} populated correctly"
-
 grep -q "^root:x:0:0:root:/root:/bin/sh" "$HOME_DIR/subos/mybox/etc/passwd" \
   || fail "S2: /etc/passwd missing root entry"
 grep -q "^root:x:0:" "$HOME_DIR/subos/mybox/etc/group" \
@@ -71,7 +160,6 @@ data = json.loads(open(sys.argv[1]).read())
 print(data.get("sandbox-shell", "<missing>"))
 print(data.get("sandbox-shell-xpkg", "<missing>"))
 ' "$HOME_DIR/subos/mybox/.xlings.json")"
-echo "$shell_value"
 [[ "$shell_value" == "/bin/sh"$'\n'"xim:sh" ]] \
   || fail "S3: sandbox-shell fields wrong: '$shell_value'"
 log "  ✓ sandbox-shell=/bin/sh, sandbox-shell-xpkg=xim:sh"
@@ -102,17 +190,10 @@ log "S6: subos use enters proot session (requires network for proot fetch)"
 if curl -fsLo "$HOME_DIR/runtimedir/proot" \
      https://proot.gitlab.io/proot/bin/proot 2>/dev/null; then
   chmod +x "$HOME_DIR/runtimedir/proot"
-  # Use static busybox as the shell stand-in (mimics what xim:sh would
-  # deliver — a static-musl POSIX shell). System busybox on most distros
-  # is statically linked; we can copy it directly into the subos's bin.
   if [[ -x /bin/busybox ]] && file /bin/busybox 2>/dev/null | grep -q "statically linked"; then
-    cp /bin/busybox "$HOME_DIR/subos/mybox/bin/sh"
-
     out_inside="$(echo 'echo "I_AM_$(whoami)_UID_$(id -u)"; echo "PASSWD_FIRST=$(head -1 /etc/passwd)"; ls /xlings 2>/dev/null | head -3 | tr "\n" " "; echo "<-- /xlings"; exit' | \
       ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
         timeout 10 "$XLINGS_BIN" subos use mybox ) 2>&1 || true)"
-    echo "$out_inside"
-
     echo "$out_inside" | grep -q "I_AM_root_UID_0" \
       || fail "S6: sandbox didn't fake root (expected I_AM_root_UID_0):
 $out_inside"
@@ -121,19 +202,30 @@ $out_inside"
 $out_inside"
     log "  ✓ inside sandbox: whoami=root, /etc/passwd matches sandbox template"
   else
-    log "  (skip: no static /bin/busybox to use as shell stand-in)"
+    log "  (skip: no static /bin/busybox to invoke as sandbox shell)"
   fi
 else
   log "  (skip: cannot fetch proot from gitlab.io; offline or restricted)"
 fi
 
-# ── S7: subos remove sandbox cleans up everything
-log "S7: subos remove sandbox removes the directory tree"
+# ── S7: self-heal — manually break the symlink, next `subos use` rehydrates
+log "S7: subos use self-heals when shell symlink is missing"
+rm -f "$shell_link"
+[[ ! -e "$shell_link" ]] || fail "S7: setup failed — shell still present"
+# Trigger use; it'll fail on proot probe (or shell exec), but the
+# rehydrate path runs BEFORE proot exec and should restore the symlink.
+run_x subos use mybox >/dev/null 2>&1 || true
+[[ -L "$shell_link" ]] || fail "S7: symlink not restored after self-heal"
+[[ -f "$shell_link" ]] || fail "S7: symlink still dangling after self-heal"
+log "  ✓ rehydrate restored shell symlink without recreating subos"
+
+# ── S8: subos remove sandbox cleans up everything
+log "S8: subos remove sandbox removes the directory tree"
 run_x subos remove mybox >/dev/null 2>&1 || true
-[[ ! -d "$HOME_DIR/subos/mybox" ]] || fail "S7: subos dir not removed"
+[[ ! -d "$HOME_DIR/subos/mybox" ]] || fail "S8: subos dir not removed"
 log "  ✓ sandbox subos removed cleanly"
 
-log "PASS: subos sandbox (Linux) — 7 scenarios"
+log "PASS: subos sandbox (Linux) — 8 scenarios"
 
 else
 # ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

V1.1 (0.4.21) shipped subos sandbox but `subos new <name> --sandbox-shell xim:fish` only wrote config — left the user with three layered failures:

1. Shell xpkg never installed → `subos use` reports "shell not found"
2. Error hint was self-defeating: `xlings subos use <name> && xlings install <xpkg>` — the very command that's failing
3. Even if user manually fixed (1)+(2), elfpatched ELF binaries (interpreter / rpath set to absolute host paths) couldn't run inside proot — paths route to `<rootfs>/<host>` which is empty

V1.2 closes the loop with three fixes + one drive-by:

- **Eager hydrate at create**: `create_impl_` calls `xim::cmd_install(yes=true)` for the configured xpkg, resolves its bindir from xvm DB, symlinks `<sandbox>/bin/<basename>` → `<xpkg-payload>/bin/<basename>`. One-shot.
- **proot self-bind `<home>:<home>`**: makes elfpatched binaries' absolute host paths resolve correctly inside the sandbox. The existing `<home>:/xlings` bind is the user-facing alias; this self-bind is what actually lets dynamic ELFs run.
- **Lazy self-heal at use**: if `<sandbox>/bin/<shell>` missing or dangling (e.g. user `xlings remove xim:fish` after create), re-run the hydrate helper. Old chicken-and-egg hint replaced with actionable `xlings install <xpkg>`.
- **Drive-by**: fixes dangling-pointer bug — `Config::versions()` returns by value, so `xvm::get_vdata(Config::versions(), ...)` returned a pointer into a temporary destroyed at end-of-expression. Bind to a local `auto db = Config::versions();` first.

User-visible UX:

```
xlings subos new sb --sandbox-shell xim:fish     # auto-installs + connects
xlings subos use sb                               # proot enters with fish working
xlings remove xim:fish && xlings subos use sb    # self-heals, re-enters
```

## Test plan

E2E `tests/e2e/subos_sandbox_test.sh` rewritten with local fixture xpkg (busybox-backed, no network), 7 → 8 scenarios:

- [x] S1: layout + auto-installed shell symlink (target under `data/xpkgs/xim-x-sh/...`)
- [x] S2: /etc/* templates content
- [x] S3: `.xlings.json` carries sandbox-shell + sandbox-shell-xpkg
- [x] S4: regular subos unchanged (no sandbox leak)
- [x] S5: `proot not found` error before exec
- [x] S6: real proot fetch + entry into sandbox (whoami=root, /etc/passwd from template) — no manual `cp /bin/busybox` step (hydrate now delivers it)
- [x] S7 (new): self-heal — rm shell symlink, next `subos use` restores it
- [x] S8: subos remove cleanup

Local: 8/8 pass on Linux. macOS / Windows path: rejection still verified.

CI will exercise all 3 platforms.