### PR TITLE
fix(0.4.23): sandbox V4 — --sandbox is a use-time modifier

### DIFF
--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -2,6 +2,35 @@
 
 ## 2026
 
+### 2026-05 (v0.4.23)
+
+- **subos sandbox 真正可用:`/root` 不再被宿主 `/root` 遮蔽 + POSIX 工具齐全**
+  - 0.4.22 用户实测 `xlings subos use sandbox-test`(shell 是 fish):
+    1. `/root/.config/fish` 创建报 `Permission denied (os error 13)`
+    2. `/root/.local/share/fish` 同样写不进
+    3. `mkdir`、`uname` 全部 `Unknown command`
+    4. fish embedded config 整段 fail,sandbox 进去就是个半瘫的 shell
+  - **根因 1(关键)**:proot 的 `-R` 是 `-r + 一堆 -b`,文档里那串"sane defaults" **包括 `--bind=$HOME`** ── 把宿主 `$HOME` 自动 bind 到 guest 的 `$HOME` 同一路径。我们在 `use_sandbox_` 里 `setenv("HOME", "/root")` 后 exec proot,proot 读到 `$HOME=/root` 就把**宿主 `/root`**(典型权限 `drwx------ root root`)bind 到了 sandbox 的 `/root`,直接遮蔽我们 `<sandbox>/root`。fish 写 `/root/.config/fish` 实际是写宿主 `/root`,真实 uid 是 `speak`,kernel 一看 owner=root mode=700 → EACCES。proot `-0` 是用户态 ptrace 假 root,**不能绕过 kernel 的真实 perm 检查**。
+  - **根因 2**:sandbox `/bin` 只有那一条 shell symlink,`/usr/bin` 不存在,fish 跑 `mkdir -p ~/.config/fish/{...}` 立刻 ENOENT。整个 POSIX userland 缺席。
+  - **修复(`src/core/subos.cppm` `build_proot_argv_`)**:
+    1. **`-R` → `-r`**:换成裸 chroot,自己掌控所有 bind,不让 proot 偷塞 `$HOME`、`/tmp`、`/run` 这些。
+    2. **显式 `--bind=/etc/ld.so.cache:/etc/ld.so.cache`**:loader 缓存,不带的话 `ld-linux` 找库要遍历整个目录树。
+    3. **`--bind=/usr:/usr` + `/usr/lib:/lib` + `/usr/lib64:/lib64`**:把宿主整个 POSIX userland(coreutils / sh / loader / 共享库)挂进来。usrmerge 主流发行版(Ubuntu 22+ / Fedora / Arch / 近期 Debian)的 `/lib` `/lib64` 在宿主上本来就是 `usr/lib*` 的 symlink,这套挂法跟它们的真实 layout 一致。非 usrmerge 的老发行版会少 `/bin/<tool>`(如果 `/usr/bin` 没有),先放着,有用户报再处理。
+    4. **`/etc/{passwd,group,hosts,nsswitch.conf}` 显式 bind 保留**:proot `-r` 不会自动 bind,所以这几条原本就是必须显式给的(0.4.21 已经在那);改用 `-r` 之后行为反而更"如实",再没有 proot kompat 默认 bind 跟我们抢。
+    5. **`<home>:<home>` 自映射保留**(0.4.22 加的):elfpatched ELF 的 absolute interpreter / rpath 路径靠这条 bind 在 sandbox 内仍能 resolve。
+  - **没动但相关的设计点**:`/tmp` 现在是 sandbox 私有(不再 bind 宿主 `/tmp`)── 跟 sandbox 语义一致(进程产生的临时文件不污染宿主)。`/run`、`/var/log` 同样不挂,绝大多数交互式 shell + 普通工具不需要,需要时再单独 bind。
+  - **用户可见 UX**:
+    ```
+    xlings subos new sandbox-test --sandbox-shell fish    # 创建 + 自动装 fish + 联通
+    xlings subos use sandbox-test
+    sandbox> mkdir -p /root/.config/myapp                  # ✓
+    sandbox> ls /root/.config/                              # 看到 fish + myapp,sandbox 私有
+    sandbox> uname -a                                       # ✓ 宿主 /usr/bin/uname
+    sandbox> cat /etc/passwd                                # 只有 root: 行(sandbox 模板),宿主用户不外泄
+    ```
+  - **测试(`tests/e2e/subos_sandbox_test.sh` S6 加强)**:进入 sandbox 后 `touch /root/.sandbox_marker_S6` + 跳出后断言文件**确实落在 `<sandbox>/root/`**(不是宿主 `/root`)── 这条 assert 是 0.4.22 那个 bind-shadow bug 的 regression guard,如果以后又有人不小心引回 `-R` 或 bind `$HOME`,S6 立刻挂。
+  - 改动量:subos.cppm `build_proot_argv_` ~30 行(注释占大头);test S6 +6 行 assert;版本 0.4.22 → 0.4.23。
+
 ### 2026-05 (v0.4.22)
 
 - **subos sandbox 一步到位 + 真正能跑 elfpatched binary**

--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -2,34 +2,54 @@
 
 ## 2026
 
-### 2026-05 (v0.4.23)
+### 2026-05 (v0.4.23) — Sandbox V4 重设计 (BREAKING)
 
-- **subos sandbox 真正可用:`/root` 不再被宿主 `/root` 遮蔽 + POSIX 工具齐全**
-  - 0.4.22 用户实测 `xlings subos use sandbox-test`(shell 是 fish):
-    1. `/root/.config/fish` 创建报 `Permission denied (os error 13)`
-    2. `/root/.local/share/fish` 同样写不进
-    3. `mkdir`、`uname` 全部 `Unknown command`
-    4. fish embedded config 整段 fail,sandbox 进去就是个半瘫的 shell
-  - **根因 1(关键)**:proot 的 `-R` 是 `-r + 一堆 -b`,文档里那串"sane defaults" **包括 `--bind=$HOME`** ── 把宿主 `$HOME` 自动 bind 到 guest 的 `$HOME` 同一路径。我们在 `use_sandbox_` 里 `setenv("HOME", "/root")` 后 exec proot,proot 读到 `$HOME=/root` 就把**宿主 `/root`**(典型权限 `drwx------ root root`)bind 到了 sandbox 的 `/root`,直接遮蔽我们 `<sandbox>/root`。fish 写 `/root/.config/fish` 实际是写宿主 `/root`,真实 uid 是 `speak`,kernel 一看 owner=root mode=700 → EACCES。proot `-0` 是用户态 ptrace 假 root,**不能绕过 kernel 的真实 perm 检查**。
-  - **根因 2**:sandbox `/bin` 只有那一条 shell symlink,`/usr/bin` 不存在,fish 跑 `mkdir -p ~/.config/fish/{...}` 立刻 ENOENT。整个 POSIX userland 缺席。
-  - **修复(`src/core/subos.cppm` `build_proot_argv_`)**:
-    1. **`-R` → `-r`**:换成裸 chroot,自己掌控所有 bind,不让 proot 偷塞 `$HOME`、`/tmp`、`/run` 这些。
-    2. **显式 `--bind=/etc/ld.so.cache:/etc/ld.so.cache`**:loader 缓存,不带的话 `ld-linux` 找库要遍历整个目录树。
-    3. **`--bind=/usr:/usr` + `/usr/lib:/lib` + `/usr/lib64:/lib64`**:把宿主整个 POSIX userland(coreutils / sh / loader / 共享库)挂进来。usrmerge 主流发行版(Ubuntu 22+ / Fedora / Arch / 近期 Debian)的 `/lib` `/lib64` 在宿主上本来就是 `usr/lib*` 的 symlink,这套挂法跟它们的真实 layout 一致。非 usrmerge 的老发行版会少 `/bin/<tool>`(如果 `/usr/bin` 没有),先放着,有用户报再处理。
-    4. **`/etc/{passwd,group,hosts,nsswitch.conf}` 显式 bind 保留**:proot `-r` 不会自动 bind,所以这几条原本就是必须显式给的(0.4.21 已经在那);改用 `-r` 之后行为反而更"如实",再没有 proot kompat 默认 bind 跟我们抢。
-    5. **`<home>:<home>` 自映射保留**(0.4.22 加的):elfpatched ELF 的 absolute interpreter / rpath 路径靠这条 bind 在 sandbox 内仍能 resolve。
-  - **没动但相关的设计点**:`/tmp` 现在是 sandbox 私有(不再 bind 宿主 `/tmp`)── 跟 sandbox 语义一致(进程产生的临时文件不污染宿主)。`/run`、`/var/log` 同样不挂,绝大多数交互式 shell + 普通工具不需要,需要时再单独 bind。
-  - **用户可见 UX**:
-    ```
-    xlings subos new sandbox-test --sandbox-shell fish    # 创建 + 自动装 fish + 联通
-    xlings subos use sandbox-test
-    sandbox> mkdir -p /root/.config/myapp                  # ✓
-    sandbox> ls /root/.config/                              # 看到 fish + myapp,sandbox 私有
-    sandbox> uname -a                                       # ✓ 宿主 /usr/bin/uname
-    sandbox> cat /etc/passwd                                # 只有 root: 行(sandbox 模板),宿主用户不外泄
-    ```
-  - **测试(`tests/e2e/subos_sandbox_test.sh` S6 加强)**:进入 sandbox 后 `touch /root/.sandbox_marker_S6` + 跳出后断言文件**确实落在 `<sandbox>/root/`**(不是宿主 `/root`)── 这条 assert 是 0.4.22 那个 bind-shadow bug 的 regression guard,如果以后又有人不小心引回 `-R` 或 bind `$HOME`,S6 立刻挂。
-  - 改动量:subos.cppm `build_proot_argv_` ~30 行(注释占大头);test S6 +6 行 assert;版本 0.4.22 → 0.4.23。
+- **`--sandbox` 是 `use` 的修饰符,不再是 subos 的 type** —— 一个 boolean flag。同一个 subos 可以选择带或不带 sandbox 隔离进入,正交两个维度。
+
+  ```
+  xlings subos new mybox            # 普通 subos,不变
+  xlings subos use mybox             # 普通进入,提示符 [xsubos:mybox]
+  xlings subos use mybox --sandbox   # NEW:fs 隔离进入,提示符 <xsubos:mybox>
+  ```
+
+  设计文档:[`.agents/docs/sandbox-v4-design.md`](sandbox-v4-design.md)。
+
+- **核心心智**:sandbox = 普通 subos + dotfile 隔离 + 必要 host 系统目录 RO 复用 + xlings home RW 共享。
+  - **私有(对应 `<subos>/{home/<user>, tmp, etc/...}` 子树)**:`$HOME`、`/tmp`、`/etc/{passwd,group,hosts,nsswitch.conf}`(模板用真实 user,不再是 root 行)
+  - **host RO**:`/proc /sys /dev`、`/etc/resolv.conf`、`/etc/ld.so.cache`、`/usr`(POSIX 工具 + 库)、`/usr/lib:/lib`、`/usr/lib64:/lib64`(usrmerge 兼容)
+  - **host RW**:`~/.xlings`(嵌套 bind 在 `/home/<user>` 之上 ── proot 子路径覆盖父路径) ── 这就是为什么 sandbox 里 `xlings install/list/remove` 跟外面一模一样:同一个 xpkg 池,同一个 xvm DB,workspace 仍然 per-subos
+  - **真实 user 身份**:proot 不带 `-0`,`whoami` 返回 `speak`(uid 1000),`$HOME=/home/speak`,`$USER=speak`。sandbox 内创建的文件 owner 自然连续,出 sandbox 后用户能直接读写
+  - **shell 跟外界一致**:sandbox 用 `$SHELL`(用户当前 shell)。`/bin/<x>` 自动翻译成 `/usr/bin/<x>` 因为 sandbox `/bin` 私有不带 host 二进制
+
+- **删除的旧实现**(V1.1-V1.3,0.4.21-0.4.22):
+  - `xlings subos new --sandbox-shell <xpkg>` flag 删除(parser 直接报 unknown option)
+  - `.xlings.json` 里 `sandbox-shell` / `sandbox-shell-xpkg` 字段不再读写(老 sandbox 的字段被静默忽略)
+  - `create_sandbox()`、`use_sandbox_()`、`ensure_shell_installed_and_linked_()` 函数全删
+  - `<subos>/root`、`<subos>/etc/passwd`(只 root 行)等老布局停止生成
+  - **不做老 sandbox 迁移**:0.4.21-0.4.22 创建的 sandbox `subos use --sandbox` 会 work(init_sandbox_dirs_ idempotent),但老的 `<subos>/root` `<subos>/bin/<shell>` symlink 静静躺着不影响。要彻底清掉 → `subos remove + subos new`
+
+- **提示符切括号**:profile_resources.cppm bump 9 → 10。bash/zsh/fish/pwsh 4 个 profile 各加一个 `XLINGS_SUBOS_MODE=sandbox` 检查分支,选 `<>` 替代 `[]`。idempotency 检查涵盖两种括号形式,re-source 安全。
+
+- **用户体验**:
+  ```
+  $ xlings subos new mybox
+  $ xlings subos use mybox --sandbox
+  <xsubos:mybox> $ whoami                    # speak,真实身份
+  <xsubos:mybox> $ echo $HOME                # /home/speak,但是 sandbox 私有 dir
+  <xsubos:mybox> $ ls ~/                      # 空(只有 .xlings,因为它是宿主 RW bind)
+  <xsubos:mybox> $ xlings install fish        # 跟宿主一样,装到宿主 xpkg 池,workspace 进 mybox
+  <xsubos:mybox> $ fish                       # 启动 fish
+  <xsubos:mybox> $ exit
+  $ ls ~/.config                              # 宿主 ~/.config,sandbox 内的修改不可见 ── 没污染
+  ```
+
+- **修了哪些 0.4.22 实测 bug**(全部由 V4 设计自动解决):
+  - `cd /root: Permission denied` → V4 不去 `/root`,$HOME 是 `/home/<user>`(私有 dir,真实 user owner,可写)
+  - `ls`、`uname` not found → V4 把 `/usr` 整个 RO bind 进来,所有 host coreutils 可用
+  - sandbox 里 `xlings install` 不生效 → V4 把 host `~/.xlings` RW bind 进 sandbox,xlings 看到的是同一个 home,普通 subos workspace activation 流程跑通
+  - elfpatched binary 不能跑 → 没有这个问题了,因为 sandbox 装的包是 sandbox 自己装的(走宿主 xlings install 路径,落到宿主池,跟外面一致)
+
+- **改动量**:`src/core/subos.cppm` 净 -150 LOC(删的比加的多);`profile_resources.cppm` +30 LOC(4 个 shell 都加 mode 分支);`tests/e2e/subos_sandbox_test.sh` 全重写 11 个场景。版本 0.4.22 → 0.4.23。
 
 ### 2026-05 (v0.4.22)
 

--- a/.agents/docs/sandbox-v4-design.md
+++ b/.agents/docs/sandbox-v4-design.md
@@ -1,0 +1,342 @@
+# Sandbox V4 — `--sandbox` 是 use 的修饰符
+
+**Status**: Active design (target 0.4.23)
+**Replaces**: `--sandbox-shell <xpkg>` 那一套(0.4.21 / 0.4.22 V1 ~ V3)
+
+## 一句话
+
+`xlings subos use <name> --sandbox` 进入 subos 的同时罩一层 fs 隔离。`--sandbox` 是 **use 时的模式选择**,不是 subos 创建时的属性。subos 本身没变化。
+
+```
+xlings subos new mybox                # 普通 subos,跟以前完全一样
+xlings subos use mybox                # 普通进入(env-spawn shell),提示符 [xsubos:mybox]
+xlings subos use mybox --sandbox      # NEW:proot fs 隔离进入,提示符 <xsubos:mybox>
+```
+
+## 设计前提与排除项
+
+### 前提
+
+1. **subos 概念不变**:仍然是 workspace 隔离单元。`xlings install`/`use`/`remove` 在 subos 内的语义跟以前一样(payload 进 host 池,workspace 进 `<subos>/.xlings.json`,shim 进 `<subos>/bin/`)。
+2. **xlings home 共享**:sandbox 内 `~/.xlings` 通过 RW bind 指向 host 的 `~/.xlings`,所以 xlings 命令在 sandbox 里跟 host 行为完全一致 ── 装包、查询、xvm 状态都共享。
+3. **真实 user**:proot 不带 `-0`。sandbox 内 `whoami` 返回真实 user(如 speak),`$USER`、`$HOME` 跟 host 同名。
+4. **shell 跟 host 一致**:进 sandbox 用 `$SHELL`(用户当前 shell)。不再有"sandbox 必须先选 shell"概念。
+
+### 排除项
+
+- ❌ 不再支持 `--sandbox-shell <xpkg>` (V1.1 - V1.3 的设计)
+- ❌ `.xlings.json` 里 `sandbox-shell` / `sandbox-shell-xpkg` 字段不再读写,创建时不写,读取时静默忽略
+- ❌ 不再有 `use_sandbox_` 单独函数;sandbox 是 `use_spawn_shell` 的一个 mode 分支
+- ❌ 不再有 sandbox 创建期 eager install / 自愈逻辑
+- ❌ 不需要 fuse-overlayfs / hardlink-pool 等 payload 复用层 ── xlings home 直接 RW 共享
+- ❌ 不主动迁移老 sandbox(0.4.21 - 0.4.22 创建的) ── 老字段直接被忽略,使用上自动走新逻辑
+
+## FS 视图
+
+### sandbox 内 mount table(逻辑)
+
+```
+sandbox view ← source                                    | role
+══════════════════════════════════════════════════════════════════════
+/                    ← <subos>/                          | proot rootfs
+/proc /sys /dev      ← host                               | kernel pseudo-fs(必需)
+
+/usr                 ← /usr                  (host RO)    | POSIX userland
+/lib                 ← /usr/lib              (host RO)    | usrmerge alias
+/lib64               ← /usr/lib64            (host RO)    | loader / libs
+/etc/resolv.conf     ← /etc/resolv.conf      (host RO)    | DNS
+/etc/ld.so.cache     ← /etc/ld.so.cache      (host RO)    | loader cache
+
+/etc/passwd          ← <subos>/etc/passwd                 | sandbox 模板,真实 user 行 + root 行
+/etc/group           ← <subos>/etc/group                  | sandbox 模板
+/etc/hosts           ← <subos>/etc/hosts                  | sandbox 模板
+/etc/nsswitch.conf   ← <subos>/etc/nsswitch.conf          | sandbox 模板(files-only)
+
+/home                ← <subos>/home/                      | dotfile 隔离根
+/home/<user>         ← <subos>/home/<user>/               |   sandbox 私有 user home
+/home/<user>/.xlings ← host ~/.xlings        (RW)         |   xlings home host bind 覆盖
+/tmp                 ← <subos>/tmp/                       | sandbox 私有 temp
+```
+
+### Bind 解析(关键 nesting)
+
+proot 处理 bind 时,**最 specific 的路径胜出**:
+
+```
+--bind=<subos>/home:/home                       # 父 bind:/home 整体指向 sandbox 私有
+--bind=<host>/.xlings:/home/<user>/.xlings      # 子 bind:.xlings 子路径 override 回 host
+```
+
+效果:
+- `/home/<user>/.config/fish/x.txt` → `<subos>/home/<user>/.config/fish/x.txt` (sandbox 私有)
+- `/home/<user>/.xlings/data/xpkgs/foo` → `<host>/.xlings/data/xpkgs/foo` (host 共享)
+
+### user 行为映射
+
+| 进 sandbox 后做的事 | 实际写到哪里 |
+|---|---|
+| `vim ~/.bashrc` | `<subos>/home/<user>/.bashrc` (sandbox 私有) |
+| `mkdir ~/.config/myapp` | `<subos>/home/<user>/.config/myapp/` (sandbox 私有) |
+| `xlings install fish` | xpkgs payload → host `~/.xlings/data/xpkgs/`(共享);workspace 改 `<subos>/.xlings.json`;shim → `<subos>/bin/fish` |
+| `xlings list` | 看 `<subos>/.xlings.json` workspace + host xvm DB |
+| `cat /etc/passwd` | sandbox 模板(只看到自己的 user 行 + root 行,看不到其他 host user) |
+| `mkdir /tmp/work` | `<subos>/tmp/work/` (sandbox 私有) |
+| `mkdir /usr/local/foo` | EROFS (host RO) |
+| `whoami` | 真实 user(如 `speak`) |
+| `id -u` | 真实 uid(如 `1000`) |
+
+## 提示符规范
+
+`src/core/xself/profile_resources.cppm` 已有的 `[xsubos:<name>]` 提示符增强:
+
+| mode | 提示符 | 由 env 决定 |
+|---|---|---|
+| 普通 subos use | `[xsubos:<name>]` (现有) | `XLINGS_ACTIVE_SUBOS=<name>` |
+| sandbox subos use | `<xsubos:<name>>` (新) | `XLINGS_ACTIVE_SUBOS=<name>` + `XLINGS_SUBOS_MODE=sandbox` |
+
+profile 改动(bash / zsh / fish / pwsh 4 种各加一个 `XLINGS_SUBOS_MODE` 检查分支):
+
+```sh
+# bash 例
+if [ "${XLINGS_SUBOS_MODE-}" = "sandbox" ]; then
+    PS1="...<xsubos:${XLINGS_ACTIVE_SUBOS}>... ${PS1}"
+else
+    PS1="...[xsubos:${XLINGS_ACTIVE_SUBOS}]... ${PS1}"
+fi
+```
+
+profile 版本号 bump(`xlings-profile-version: 9 → 10`)以触发自动重写。
+
+## 实施细节
+
+### subos.cppm 改动
+
+#### 删除
+
+- `export create_sandbox()` 整个函数
+- `create_impl_()` 里关于 `sandboxShellXpkg` 的所有分支
+- `use_sandbox_()` 整个函数
+- `ensure_shell_installed_and_linked_()` 整个函数(及其前向声明)
+- `sandbox_detail_::` 内不再使用的 helper(只保留 `init_sandbox_dirs_` 和 `build_proot_argv_`)
+- `use_spawn_shell()` 里检查 `sandbox-shell` 字段并跳到 `use_sandbox_` 的分支
+
+#### 修改
+
+`init_sandbox_layout_(dir)` → `init_sandbox_dirs_(dir, user)`
+
+```cpp
+// 新签名:接 user 名,写真实 user 行的 /etc/passwd
+void init_sandbox_dirs_(const fs::path& subos_dir, const std::string& user, uid_t uid, gid_t gid);
+```
+
+逻辑(idempotent,可以多次调用):
+1. `mkdir -p <subos>/home/<user>` (即 sandbox 内的 `$HOME`)
+2. `mkdir -p <subos>/tmp` (mode 1777 sticky bit, 即使外面没 root)
+3. `mkdir -p <subos>/etc`
+4. 如果 `<subos>/etc/passwd` 不存在,写:
+   ```
+   root:x:0:0:root:/root:/bin/sh
+   <user>:x:<uid>:<gid>:<user>:/home/<user>:/bin/sh
+   ```
+5. 类似写 group, hosts, nsswitch.conf
+
+`build_proot_argv_` 重写为最简版:
+
+```cpp
+std::vector<std::string> build_proot_argv_(
+    const fs::path& proot_bin,
+    const fs::path& subos_dir,
+    const fs::path& host_xlings_home,
+    const std::string& user,
+    const std::string& shell)  // $SHELL,如 /usr/bin/fish
+{
+    auto etc = subos_dir / "etc";
+    return {
+        proot_bin.string(),
+        // NO -0 ── 用真实 user identity
+        "-r", subos_dir.string(),
+        "--bind=/proc:/proc",
+        "--bind=/sys:/sys",
+        "--bind=/dev:/dev",
+        "--bind=/etc/resolv.conf:/etc/resolv.conf",
+        "--bind=/etc/ld.so.cache:/etc/ld.so.cache",
+        std::format("--bind={}:/etc/passwd",       (etc / "passwd").string()),
+        std::format("--bind={}:/etc/group",        (etc / "group").string()),
+        std::format("--bind={}:/etc/hosts",        (etc / "hosts").string()),
+        std::format("--bind={}:/etc/nsswitch.conf",(etc / "nsswitch.conf").string()),
+        "--bind=/usr:/usr",
+        "--bind=/usr/lib:/lib",
+        "--bind=/usr/lib64:/lib64",
+        // sandbox 私有 /home(覆盖 chroot 默认的空 /home)
+        std::format("--bind={}:/home", (subos_dir / "home").string()),
+        // 在 /home 之上叠加 .xlings 的 host bind ── 子路径覆盖父路径
+        std::format("--bind={}:/home/{}/.xlings", host_xlings_home.string(), user),
+        std::format("--cwd=/home/{}", user),
+        shell,
+    };
+}
+```
+
+`use_spawn_shell()` 加 sandbox 模式:
+
+```cpp
+int use_spawn_shell(const std::string& name, EventStream& stream, bool sandbox = false) {
+    // ... validate, nesting check 不变 ...
+
+    if (sandbox) {
+#if !defined(__linux__)
+        stream.emit(ErrorEvent{
+            .message = "sandbox mode is only supported on Linux",
+            // ... 跟以前一样 ...
+        });
+        return 1;
+#else
+        return use_sandbox_mode_(name, stream);
+#endif
+    }
+
+    // ... env-spawn shell 的现有逻辑(完全不变)...
+}
+
+int use_sandbox_mode_(const std::string& name, EventStream& stream) {
+    auto& p = Config::paths();
+    auto subos_dir = p.homeDir / "subos" / name;
+
+    // proot 探测(沿用现有 locate_proot_)
+    auto proot = sandbox_detail_::locate_proot_(p.homeDir);
+    if (!proot) { stream.emit(ErrorEvent{...}); return 1; }
+
+    // lazy init sandbox 私有 dirs
+    auto user = utils::get_env_or_default("USER", "user");
+    auto uid = ::getuid();
+    auto gid = ::getgid();
+    sandbox_detail_::init_sandbox_dirs_(subos_dir, user, uid, gid);
+
+    // env
+    platform::set_env_variable("XLINGS_ACTIVE_SUBOS", name);
+    platform::set_env_variable("XLINGS_SUBOS_MODE", "sandbox");
+    platform::set_env_variable("HOME", "/home/" + user);
+    // 不设 USER ── 用 host 的(已经是真实 user)
+    // PATH 由 profile + xlings shim 解决,不在这里 hardcode
+
+    // shell:用 $SHELL,fallback /bin/sh
+    auto shell = utils::get_env_or_default("SHELL", "/bin/sh");
+
+    // 组装 proot argv 并 exec
+    auto argv = sandbox_detail_::build_proot_argv_(
+        *proot, subos_dir, p.homeDir, user, shell);
+    // ... execvp 不变 ...
+}
+```
+
+### profile_resources.cppm 改动
+
+每个 shell profile 加 `XLINGS_SUBOS_MODE=sandbox` 分支选 `<>` 括号。bump 版本号到 10。
+
+### CLI 解析
+
+`src/core/cmdprocessor.cppm` 或 `src/cli.cppm` 的 `subos use` 子命令解析支持 `--sandbox` flag:
+
+```cpp
+bool sandbox_flag = false;
+for (...) {
+    if (arg == "--sandbox") { sandbox_flag = true; continue; }
+    // ...
+}
+return subos::use_spawn_shell(name, stream, sandbox_flag);
+```
+
+## E2E 测试
+
+`tests/e2e/subos_sandbox_test.sh` 重写为 V4 场景。需要 Linux + proot(可装 xim:proot)。
+
+```
+S1: subos new mybox(纯创建,无 sandbox 字段)
+    断言 .xlings.json 不含 sandbox-shell / sandbox-shell-xpkg
+
+S2: subos use mybox(普通)
+    断言 PS1 出现 [xsubos:mybox]
+    断言 $HOME = host $HOME(没改)
+
+S3: subos use mybox --sandbox
+    断言 PS1 出现 <xsubos:mybox>
+    断言 $HOME = /home/<user>
+    断言 whoami = real user
+    断言 id -u = real uid
+
+S4: dotfile 隔离
+    sandbox 内 mkdir ~/.config/sandboxtest/
+    退出后 host ~/.config/sandboxtest 不存在
+    再次 use --sandbox,~/.config/sandboxtest 还在(persistent)
+
+S5: ~/.xlings 共享
+    sandbox 内 xlings install <fixture>
+    退出后 host ls ~/.xlings/data/xpkgs/<fixture>/<ver>/ 存在
+    sandbox 内 xlings list 显示 <fixture>
+    退出后 host xlings list 也显示 <fixture>(因 workspace 在 mybox subos)
+
+S6: /etc/passwd 隔离
+    sandbox 内 cat /etc/passwd | wc -l → 应 ≤ 2 (root + real user)
+    sandbox 内 grep ^<user> /etc/passwd → 真实 user 行
+
+S7: /tmp 隔离
+    sandbox 内 touch /tmp/sandboxtest
+    退出后 host /tmp/sandboxtest 不存在
+    <subos>/tmp/sandboxtest 存在
+
+S8: subos remove 清干净(包括 home dir、tmp、etc)
+
+S9 (non-Linux): subos use --sandbox 在 macOS / Windows 拒绝
+```
+
+## 老 sandbox 兼容(零代价)
+
+老 0.4.21 - 0.4.22 创建的 sandbox 在 `<subos>/.xlings.json` 里有 `sandbox-shell` / `sandbox-shell-xpkg` 字段,和 `<subos>/root` `<subos>/bin/<shell>` symlink 等遗留。
+
+V4 处理:
+- `subos use mybox`(无 --sandbox) → 走普通路径,完全不读那两个字段,跟现在一致
+- `subos use mybox --sandbox` → 走新 V4 sandbox 路径,init_sandbox_dirs_ 是 idempotent 的(只 mkdir 不存在的目录),老遗留的 `<subos>/root`、shell symlink 静静躺着不影响
+- 用户想清掉老遗留:`subos remove mybox && subos new mybox`
+
+**不主动迁移,不主动删除,不报错提示** ── 沉默兼容。
+
+## 关键不变性 / 失败模式
+
+| 不变性 | 测试位置 | 失败现象 |
+|---|---|---|
+| /home/<user> bind 在前,.xlings host bind 在后 | S5 | sandbox 看不到 host ~/.xlings |
+| 不带 -0,真实 user | S3 | sandbox 内 whoami = root(错) |
+| /etc/passwd 模板含真实 user 行 | S6 | shell 启动时 `getpwuid(uid)` 失败,环境变量异常 |
+| profile 版本 bump → 触发重写 | 手动验证 | 老 profile 不读 XLINGS_SUBOS_MODE,提示符无 `<>` |
+| init_sandbox_dirs_ idempotent | S2/S3 多次 use | 第二次 use --sandbox 报"目录已存在" |
+
+## 不在本设计内(后续)
+
+- payload 复用机制(hardlink / overlay / fuse-overlayfs):V4 不做,xlings home 直接 RW 共享
+- sandbox 内 `xlings self update`:不限制(可能修改 host xlings ── 跟普通 subos 行为一致,本来就该如此)
+- `--sandbox` 跟 `--exec <cmd>` 组合:留作后续 enhancement
+- macOS / Windows sandbox:Linux-only,本设计不变
+
+## 改动量估算
+
+| 文件 | 删除 | 新增 | 修改 |
+|---|---|---|---|
+| `src/core/subos.cppm` | ~300 LOC | ~120 LOC | ~80 LOC |
+| `src/core/xself/profile_resources.cppm` | 0 | ~40 LOC × 4 shells | bump version |
+| `src/core/cmdprocessor.cppm` 或 cli | 0 | ~10 LOC | 1 行加 flag |
+| `tests/e2e/subos_sandbox_test.sh` | 全删 | 全重写 ~200 LOC | — |
+| `.agents/docs/changelog.md` | 0 | ~30 LOC | — |
+| `src/core/config.cppm` | 0 | 0 | VERSION 0.4.22 → 0.4.23 |
+
+**净 ~ -200 LOC**(删的多,设计干净了)。
+
+## 版本号 / Release
+
+包含在 0.4.23 中。0.4.23 内容:
+1. (来自 PR #279)proot `-R` → `-r` 修复 + `/usr` RO bind + `/etc/ld.so.cache` bind ── **被 V4 设计直接吸收**
+2. (新)V4 sandbox 重设计:`--sandbox-shell` 删除,`subos use --sandbox` 上线,提示符 `<>` 标识
+
+changelog 标 BREAKING:
+- `xlings subos new --sandbox-shell <xpkg>` 已删除
+- 老 sandbox(0.4.21 - 0.4.22 创建的)的 `sandbox-shell` 字段被忽略;直接 `subos use <name> --sandbox` 进入新模式
+- 用户原本预期 sandbox 自带 fish/bash 的,需要进入后 `xlings install fish` 自己装

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.22";
+    static constexpr std::string_view VERSION = "0.4.23";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -124,11 +124,19 @@ void update_current_symlink_(EventStream& stream,
 
 namespace sandbox_detail_ {
 
-// /etc/* template builders. We write per-user passwd/group at sandbox
-// init time so getpwuid(real_uid) inside the sandbox returns the real
-// user's home (= /home/<user>) and shell ── most CLI tools depend on
-// this. Root is also included so anything that does getpwuid(0) (some
-// scripts assume "root must exist") doesn't bail.
+// /etc/* template builders + sandbox dir layout init. uid_t / gid_t
+// are POSIX types — Windows MSVC doesn't have them. Sandbox is
+// Linux-only by design (proot uses ptrace + Linux syscall semantics);
+// the only caller (use_sandbox_mode_) is also Linux-guarded, so we
+// guard these helpers too rather than fight the type system with
+// platform-portable substitutes.
+#if defined(__linux__) || defined(__APPLE__)
+
+// We write per-user passwd/group at sandbox init time so getpwuid
+// (real_uid) inside the sandbox returns the real user's home
+// (= /home/<user>) and shell — most CLI tools depend on this. Root
+// is also included so anything that does getpwuid(0) (scripts that
+// assume "root must exist") doesn't bail.
 std::string make_etc_passwd_(const std::string& user, uid_t uid, gid_t gid) {
     return std::format(
         "root:x:0:0:root:/root:/bin/sh\n"
@@ -168,6 +176,8 @@ void init_sandbox_dirs_(const fs::path& subos_dir,
     try_write(etc / "hosts", kEtcHosts);
     try_write(etc / "nsswitch.conf", kEtcNsswitch);
 }
+
+#endif // __linux__ / __APPLE__
 
 } // namespace sandbox_detail_
 

--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -551,24 +551,47 @@ build_proot_argv_(const fs::path& proot_bin,
     std::vector<std::string> argv = {
         proot_bin.string(),
         "-0",                                            // fake root (uid 0 from getuid)
-        "-R", subos_dir.string(),                        // rootfs
+        // -r (bare chroot) instead of -R. -R auto-binds $HOME from host
+        // into the guest at the same path (proot manpage: "host's $HOME
+        // → guest's $HOME"). Combined with our env $HOME=/root, this means
+        // *host's* /root (typically owned by real root, mode 700) shadows
+        // the sandbox's own <subos>/root — fish & co. trying to mkdir
+        // ~/.config/fish hit EACCES because they're writing to host /root,
+        // not the sandbox copy. -r gives us a bare chroot with NO auto-
+        // binds; we add only the binds we want, none of them $HOME.
+        "-r", subos_dir.string(),
+        // Kernel pseudo-fs (must come from host)
         "--bind=/proc:/proc",
         "--bind=/sys:/sys",
         "--bind=/dev:/dev",
-        "--bind=/etc/resolv.conf:/etc/resolv.conf",      // DNS from host
-        // sandbox-owned /etc files (override proot kompat auto-binds)
+        // DNS + dynamic-linker cache (loader needs /etc/ld.so.cache to
+        // find libs in /lib /usr/lib without scanning every dir)
+        "--bind=/etc/resolv.conf:/etc/resolv.conf",
+        "--bind=/etc/ld.so.cache:/etc/ld.so.cache",
+        // sandbox-owned /etc templates (the canonical user/group/hosts
+        // view inside the sandbox — proot -r doesn't auto-bind these,
+        // so the explicit binds below are what surface them)
         std::format("--bind={}:/etc/passwd",       (etc / "passwd").string()),
         std::format("--bind={}:/etc/group",        (etc / "group").string()),
         std::format("--bind={}:/etc/hosts",        (etc / "hosts").string()),
         std::format("--bind={}:/etc/nsswitch.conf",(etc / "nsswitch.conf").string()),
+        // Host /usr provides the POSIX userland (mkdir, uname, ls, cat,
+        // sh, ...) the sandbox's own bin/ doesn't have. Without this even
+        // fish's embedded config.fish fails immediately on `mkdir -p`.
+        // /lib /lib64 overlaid onto host's usr/lib* match the modern
+        // usrmerge layout (Ubuntu 22+, Fedora, Arch, recent Debian) so
+        // ELF interpreters baked as /lib64/ld-linux* resolve. Older
+        // non-merged distros lose access to /bin tools that aren't in
+        // /usr/bin — handle if-when reported.
+        "--bind=/usr:/usr",
+        "--bind=/usr/lib:/lib",
+        "--bind=/usr/lib64:/lib64",
+        // xlings home: /xlings is the user-facing alias, host self-bind
+        // is what makes elfpatched binaries' absolute interpreter / rpath
+        // paths resolve (interpreter is set to absolute host path by
+        // elfpatch). Without this, the loader at the absolute path can't
+        // be found inside proot.
         std::format("--bind={}:/xlings", home_dir.string()),
-        // Self-bind xlings home at its host absolute path. xim-installed
-        // binaries are elfpatched with the absolute host path of their
-        // loader / rpath libs (e.g. ld-linux from xim:d2x). Without this
-        // bind, those paths route to <rootfs>/<host-path> which is empty,
-        // and the shell fails to start with "no such file or directory".
-        // The /xlings bind above is for user-facing convenience; this
-        // self-bind is what makes elfpatched binaries actually run.
         std::format("--bind={}:{}", home_dir.string(), home_dir.string()),
         "--cwd=/root",
         shell_path,

--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -24,8 +24,6 @@ import xlings.platform;
 import xlings.runtime;
 import xlings.core.utils;
 import xlings.core.xself;
-import xlings.core.xvm.db;
-import xlings.core.xim.commands;
 
 namespace xlings::subos {
 
@@ -99,35 +97,65 @@ void update_current_symlink_(EventStream& stream,
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Sandbox subos helpers (0.4.21+)
+// Sandbox subos helpers (0.4.23 V4 — see .agents/docs/sandbox-v4-design.md)
 //
-// A "sandbox" subos is a regular subos plus a `sandbox-shell` field in
-// its .xlings.json. At `subos use` time, presence of that field triggers
-// the proot-based fs-isolated entry path (see use_sandbox_) instead of
-// the env-spawn shell-level path. Sandbox subos design lives in
-// docs/plans/2026-05-09-subos-sandbox-design.md.
+// V4 model: sandbox is NOT a creation property of subos. It's a `use`
+// modifier — `xlings subos use <name> --sandbox` enters the same subos
+// via proot fs-isolation, with sandbox-private $HOME / /tmp / /etc and
+// host-shared ~/.xlings / /usr / /lib*. Real user identity (no fake
+// root). Shell is whatever $SHELL is. Prompt switches from
+// `[xsubos:<name>]` to `<xsubos:<name>>` to signal sandbox mode.
+//
+// Helpers here:
+//   - sandbox_detail_::init_sandbox_dirs_ — lazy-init the per-subos
+//     sandbox dirs (<subos>/{home/<user>, tmp, etc/...}) at first
+//     `subos use --sandbox`. Idempotent.
+//   - sandbox_detail_::locate_proot_ — search for the proot binary
+//     (defined later, alongside build_proot_argv_).
+//   - sandbox_detail_::build_proot_argv_ — assemble the proot CLI for
+//     entering the sandbox (defined later).
+//
+// Note: V1.1-V1.3 (`--sandbox-shell <xpkg>`, `sandbox-shell` /
+// `sandbox-shell-xpkg` config fields, eager shell install at
+// create-time) was removed in V4. Old sandboxes still in user homes
+// retain those fields; V4 silently ignores them, and `subos use
+// --sandbox` works on them because init_sandbox_dirs_ is idempotent.
 // ─────────────────────────────────────────────────────────────────────
 
 namespace sandbox_detail_ {
 
-// Minimum /etc/* templates a sandbox needs so:
-//   - whoami / id work (passwd has root entry)
-//   - /etc/hosts resolves localhost without hitting DNS
-//   - getent users / nsswitch behaves
-// Total ~80 bytes. xlings writes these on `subos new --sandbox-shell`.
-inline constexpr std::string_view kEtcPasswd =
-    "root:x:0:0:root:/root:/bin/sh\n";
-inline constexpr std::string_view kEtcGroup =
-    "root:x:0:\n";
+// /etc/* template builders. We write per-user passwd/group at sandbox
+// init time so getpwuid(real_uid) inside the sandbox returns the real
+// user's home (= /home/<user>) and shell ── most CLI tools depend on
+// this. Root is also included so anything that does getpwuid(0) (some
+// scripts assume "root must exist") doesn't bail.
+std::string make_etc_passwd_(const std::string& user, uid_t uid, gid_t gid) {
+    return std::format(
+        "root:x:0:0:root:/root:/bin/sh\n"
+        "{}:x:{}:{}:{}:/home/{}:/bin/sh\n",
+        user, uid, gid, user, user);
+}
+std::string make_etc_group_(const std::string& user, gid_t gid) {
+    return std::format(
+        "root:x:0:\n"
+        "{}:x:{}:\n",
+        user, gid);
+}
 inline constexpr std::string_view kEtcHosts =
     "127.0.0.1 localhost\n::1 localhost\n";
 inline constexpr std::string_view kEtcNsswitch =
     "hosts: files dns\npasswd: files\ngroup: files\n";
 
-// Lay down /etc/{passwd,group,hosts,nsswitch.conf} templates inside
-// the sandbox subos directory. Files are only written if absent — a
-// returning user's customizations survive subos use re-init.
-void write_etc_templates_(const fs::path& subos_dir) {
+// Initialize the sandbox-specific dirs / templates inside an existing
+// subos. Idempotent: only writes files that don't yet exist, so a
+// returning sandbox session won't clobber user customizations and a
+// repeated `subos use --sandbox` is cheap.
+void init_sandbox_dirs_(const fs::path& subos_dir,
+                        const std::string& user,
+                        uid_t uid, gid_t gid)
+{
+    fs::create_directories(subos_dir / "home" / user);
+    fs::create_directories(subos_dir / "tmp");
     auto etc = subos_dir / "etc";
     fs::create_directories(etc);
 
@@ -135,56 +163,21 @@ void write_etc_templates_(const fs::path& subos_dir) {
         if (fs::exists(path)) return;
         platform::write_string_to_file(path.string(), std::string(body));
     };
-
-    try_write(etc / "passwd", kEtcPasswd);
-    try_write(etc / "group", kEtcGroup);
+    try_write(etc / "passwd", make_etc_passwd_(user, uid, gid));
+    try_write(etc / "group", make_etc_group_(user, gid));
     try_write(etc / "hosts", kEtcHosts);
     try_write(etc / "nsswitch.conf", kEtcNsswitch);
 }
 
-// Initialize sandbox-specific directory layout in addition to the
-// regular subos dirs. /root is $HOME inside; /tmp is per-sandbox tmp.
-// /etc gets the templates above.
-// Forward declaration — definition lives in the second sandbox_detail_
-// block alongside locate_proot_ / build_proot_argv_, which it depends on.
-// create_impl_ (between the two blocks) calls this for the eager-install
-// path on `subos new --sandbox-shell`.
-int ensure_shell_installed_and_linked_(const fs::path& sandbox_dir,
-                                       const std::string& xpkg_id,
-                                       const std::string& shell_inside_path,
-                                       EventStream& stream);
-
-void init_sandbox_layout_(const fs::path& subos_dir) {
-    fs::create_directories(subos_dir / "root");
-    fs::create_directories(subos_dir / "tmp");
-    write_etc_templates_(subos_dir);
-}
-
 } // namespace sandbox_detail_
 
-// Internal worker — exported variants below dispatch into this with
-// or without a sandbox-shell xpkg. Keeping the public `create(name,
-// dir, stream)` signature byte-stable for ABI compatibility with
-// existing capability layer / external imports of the BMI.
-int create_impl_(const std::string& name, const fs::path& customDir,
-                 EventStream& stream,
-                 std::optional<std::string> sandboxShellXpkg) {
+// Create a regular subos. V4: there is only one create path; sandbox
+// is a `use`-time modifier (`--sandbox`), not a create-time property.
+// The sandbox-private dirs (<subos>/{home/<user>, tmp, etc/...}) are
+// laid down lazily on first `subos use --sandbox`, not here.
+export int create(const std::string& name, const fs::path& customDir,
+                  EventStream& stream) {
     auto& p = Config::paths();
-
-    // Sandbox mode is Linux-only. Reject early with a clear hint.
-    if (sandboxShellXpkg.has_value()) {
-#if !defined(__linux__)
-        stream.emit(ErrorEvent{
-            .code = ErrorCode::InvalidInput,
-            .message = "--sandbox-shell is only supported on Linux (current: "
-                       + std::string(platform::OS_NAME) + ")",
-            .recoverable = false,
-            .hint = "create a regular subos by omitting --sandbox-shell, "
-                    "or use the global / shell-level subos modes",
-        });
-        return 1;
-#endif
-    }
 
     if (name == "current") {
         stream.emit(ErrorEvent{
@@ -225,30 +218,10 @@ int create_impl_(const std::string& name, const fs::path& customDir,
     fs::create_directories(dir / "usr");
     fs::create_directories(dir / "generations");
 
-    // Sandbox subos: lay down /etc templates + /root + /tmp on top of
-    // the regular subos directory layout. The regular dirs above are
-    // still created (other code paths assume `bin/`, `lib/` exist).
-    if (sandboxShellXpkg.has_value()) {
-        sandbox_detail_::init_sandbox_layout_(dir);
-    }
-
-    // Create empty .xlings.json with workspace; sandbox-shell field
-    // gets written below if applicable.
     auto subosConfig = dir / ".xlings.json";
     if (!fs::exists(subosConfig)) {
         nlohmann::json j;
         j["workspace"] = nlohmann::json::object();
-        if (sandboxShellXpkg.has_value()) {
-            // sandbox-shell stored as the inside-view path for now.
-            // Convention: xlings install <xpkg> drops the binary into
-            // bin/<basename>, so /bin/<basename> is its inside path.
-            // Bare-name xpkg → /bin/<bare>. ns:name → strip ns prefix.
-            auto bare = *sandboxShellXpkg;
-            if (auto colon = bare.rfind(':'); colon != std::string::npos)
-                bare = bare.substr(colon + 1);
-            j["sandbox-shell"] = "/bin/" + bare;
-            j["sandbox-shell-xpkg"] = *sandboxShellXpkg;  // remember the xpkg id for lazy install
-        }
         write_config_json_(subosConfig, j);
     }
 
@@ -264,45 +237,11 @@ int create_impl_(const std::string& name, const fs::path& customDir,
     json["subos"][name] = {{"dir", customDir.empty() ? "" : customDir.string()}};
     write_config_json_(configPath, json);
 
-    // Sandbox: install the configured shell xpkg and symlink its binary
-    // into <sandbox>/bin/<basename> so `subos use <name>` can exec it.
-    // Done at create time so the user's mental model holds:
-    // "I asked for a sandbox with this shell — it's ready."
-    if (sandboxShellXpkg.has_value()) {
-#if defined(__linux__)
-        auto bare = *sandboxShellXpkg;
-        if (auto colon = bare.rfind(':'); colon != std::string::npos)
-            bare = bare.substr(colon + 1);
-        auto rc = sandbox_detail_::ensure_shell_installed_and_linked_(
-            dir, *sandboxShellXpkg, "/bin/" + bare, stream);
-        if (rc != 0) return rc;
-#endif
-    }
-
     nlohmann::json payload;
     payload["name"] = name;
     payload["dir"]  = dir.string();
     stream.emit(DataEvent{"subos_created", payload.dump()});
     return 0;
-}
-
-// Public exports.
-//
-// `create` keeps its original 3-arg signature byte-stable so existing
-// callers (capabilities.cppm, downstream BMI consumers) link against
-// the same symbol. `create_sandbox` is a separate symbol for the
-// sandbox flow — splitting avoids cross-TU BMI / ABI churn that
-// inflicting an extra default param on `create` would cause under
-// gcc 15.1.0 musl-cross (observed as spurious link errors in CI).
-export int create(const std::string& name, const fs::path& customDir,
-                  EventStream& stream) {
-    return create_impl_(name, customDir, stream, std::nullopt);
-}
-
-export int create_sandbox(const std::string& name, const fs::path& customDir,
-                          const std::string& sandboxShellXpkg,
-                          EventStream& stream) {
-    return create_impl_(name, customDir, stream, sandboxShellXpkg);
 }
 
 // `xlings subos use` modes:
@@ -528,226 +467,111 @@ locate_proot_(const fs::path& home_dir) {
         "or place a proot binary at ~/.xlings/runtimedir/proot");
 }
 
-// Build the proot argv for entering a sandbox subos. Output layout
-// matches the design doc §3.3.
+// Build the proot argv for `subos use --sandbox` entry. V4 layout:
+// real user identity (no `-0`), bare chroot (`-r`, no auto-binds), with
+// explicit binds chosen for "isolate $HOME / /tmp / /etc; share xlings,
+// kernel, POSIX userland from host". See .agents/docs/sandbox-v4-design.md.
 std::vector<std::string>
 build_proot_argv_(const fs::path& proot_bin,
                   const fs::path& subos_dir,
-                  const fs::path& home_dir,
-                  const std::string& subos_name,
+                  const fs::path& host_xlings_home,
+                  const std::string& user,
                   const std::string& shell_path)
 {
-    // proot's CLI uses positional args for the inside-sandbox command;
-    // no `--` separator (passing `--` triggers `unknown option '--'`).
-    //
-    // Note on /etc bindings: proot 5.x has built-in "kompat" auto-binds
-    // for /etc/{passwd,group,hosts,host.conf,localtime,mtab,networks,
-    // nsswitch.conf,resolv.conf} that surface host versions inside the
-    // guest rootfs. For sandbox semantics we want our own templates
-    // (which xlings wrote at subos creation time) to take precedence —
-    // explicit per-file --bind=<sandbox-etc-file>:<inside-path> overrides
-    // the auto-bind. /etc/resolv.conf stays bound to host so DNS works.
+    // proot CLI uses positional args for the inside-sandbox command;
+    // no `--` separator (proot rejects bare `--` with "unknown option").
     auto etc = subos_dir / "etc";
+    auto subos_home = subos_dir / "home";
+    auto user_home = "/home/" + user;
     std::vector<std::string> argv = {
         proot_bin.string(),
-        "-0",                                            // fake root (uid 0 from getuid)
         // -r (bare chroot) instead of -R. -R auto-binds $HOME from host
-        // into the guest at the same path (proot manpage: "host's $HOME
-        // → guest's $HOME"). Combined with our env $HOME=/root, this means
-        // *host's* /root (typically owned by real root, mode 700) shadows
-        // the sandbox's own <subos>/root — fish & co. trying to mkdir
-        // ~/.config/fish hit EACCES because they're writing to host /root,
-        // not the sandbox copy. -r gives us a bare chroot with NO auto-
-        // binds; we add only the binds we want, none of them $HOME.
+        // (proot manpage: "host's $HOME → guest's $HOME"); with $HOME =
+        // /home/<user> set below, that would shadow our sandbox-private
+        // <subos>/home/<user> with the host's real home — full read-write
+        // access to host dotfiles. -r leaves us in full control of binds.
+        // No `-0` either: V4 preserves real user identity (no fake root).
         "-r", subos_dir.string(),
         // Kernel pseudo-fs (must come from host)
         "--bind=/proc:/proc",
         "--bind=/sys:/sys",
         "--bind=/dev:/dev",
         // DNS + dynamic-linker cache (loader needs /etc/ld.so.cache to
-        // find libs in /lib /usr/lib without scanning every dir)
+        // resolve libs without scanning every dir)
         "--bind=/etc/resolv.conf:/etc/resolv.conf",
         "--bind=/etc/ld.so.cache:/etc/ld.so.cache",
-        // sandbox-owned /etc templates (the canonical user/group/hosts
-        // view inside the sandbox — proot -r doesn't auto-bind these,
-        // so the explicit binds below are what surface them)
+        // sandbox-owned /etc templates (passwd has the real user entry +
+        // root; getpwuid(real_uid) inside the sandbox returns the right
+        // home / shell). proot -r doesn't auto-bind these — explicit binds
+        // are what surface them.
         std::format("--bind={}:/etc/passwd",       (etc / "passwd").string()),
         std::format("--bind={}:/etc/group",        (etc / "group").string()),
         std::format("--bind={}:/etc/hosts",        (etc / "hosts").string()),
         std::format("--bind={}:/etc/nsswitch.conf",(etc / "nsswitch.conf").string()),
         // Host /usr provides the POSIX userland (mkdir, uname, ls, cat,
-        // sh, ...) the sandbox's own bin/ doesn't have. Without this even
-        // fish's embedded config.fish fails immediately on `mkdir -p`.
-        // /lib /lib64 overlaid onto host's usr/lib* match the modern
-        // usrmerge layout (Ubuntu 22+, Fedora, Arch, recent Debian) so
-        // ELF interpreters baked as /lib64/ld-linux* resolve. Older
-        // non-merged distros lose access to /bin tools that aren't in
-        // /usr/bin — handle if-when reported.
+        // sh, ...). Without this even basic startup of fish / bash
+        // (which spawn `mkdir`, `uname` from their config.* / .bashrc)
+        // fails immediately. /lib and /lib64 overlaid onto host's
+        // /usr/lib* match the modern usrmerge layout (Ubuntu 22+,
+        // Fedora, Arch, recent Debian) so ELF interpreters baked as
+        // /lib64/ld-linux* resolve correctly.
         "--bind=/usr:/usr",
         "--bind=/usr/lib:/lib",
         "--bind=/usr/lib64:/lib64",
-        // xlings home: /xlings is the user-facing alias, host self-bind
-        // is what makes elfpatched binaries' absolute interpreter / rpath
-        // paths resolve (interpreter is set to absolute host path by
-        // elfpatch). Without this, the loader at the absolute path can't
-        // be found inside proot.
-        std::format("--bind={}:/xlings", home_dir.string()),
-        std::format("--bind={}:{}", home_dir.string(), home_dir.string()),
-        "--cwd=/root",
+        // /home: parent bind to sandbox-private dir. This gives dotfile
+        // isolation — anything the user writes under their home goes
+        // into <subos>/home/<user>/ and doesn't pollute host ~/.
+        std::format("--bind={}:/home", subos_home.string()),
+        // ~/.xlings: nested bind ON TOP of the parent /home bind. proot
+        // resolves the more-specific path first, so /home/<user>/.xlings
+        // hits this host-bound path while everything else under
+        // /home/<user>/ stays in the sandbox-private dir. Effect:
+        //   - sandbox-private:  ~/.config, ~/.cache, ~/.bashrc, ...
+        //   - host-shared:      ~/.xlings/data/xpkgs/, .xlings.json, etc.
+        // The host-shared path makes `xlings install/list/use` inside
+        // the sandbox behave EXACTLY like outside (same xpkg pool, same
+        // xvm DB, workspace per-subos as always — sandbox is just a
+        // different way to enter the same subos).
+        std::format("--bind={}:{}/.xlings",
+                    host_xlings_home.string(), user_home),
+        std::format("--cwd={}", user_home),
         shell_path,
     };
     return argv;
 }
 
-// Ensure the configured sandbox shell binary is installed and present at
-// `<sandbox>/bin/<basename>` as a symlink to the xim-managed payload.
-// Idempotent — safe to re-run from `subos new --sandbox-shell` (eager
-// hydration) and from `subos use <sandbox>` (lazy self-heal when the
-// payload was removed or the symlink dangles).
-//
-// Strategy:
-//   1. If the destination exists and resolves to a real file, no-op.
-//   2. Otherwise, ensure the xpkg is installed (call xim::cmd_install
-//      with yes=true). The install registers a bindir in the xvm DB.
-//   3. Resolve <bindir>/<basename> from the xvm DB and symlink it into
-//      the sandbox's bin/.
-//
-// Returns 0 on success. On failure emits an ErrorEvent and returns 1.
-int ensure_shell_installed_and_linked_(const fs::path& sandbox_dir,
-                                       const std::string& xpkg_id,
-                                       const std::string& shell_inside_path,
-                                       EventStream& stream)
-{
-    namespace fs = std::filesystem;
-
-    // bare name = xpkg id with namespace prefix stripped (xim:fish → fish)
-    std::string bare = xpkg_id;
-    if (auto colon = bare.rfind(':'); colon != std::string::npos)
-        bare = bare.substr(colon + 1);
-
-    // shell_inside_path looks like "/bin/fish"; strip leading '/' to get
-    // the host-side path under <sandbox_dir>.
-    auto rel = shell_inside_path;
-    if (!rel.empty() && rel.front() == '/') rel.erase(0, 1);
-    auto shell_dst = sandbox_dir / rel;
-    auto basename  = fs::path(shell_inside_path).filename().string();
-
-    std::error_code ec;
-
-    // Already there and resolves to a real file → done.
-    if (fs::exists(shell_dst, ec) && !ec) return 0;
-    ec.clear();
-
-    // Dangling symlink (target gone) → remove so create_symlink can run.
-    if (fs::is_symlink(shell_dst, ec)) {
-        fs::remove(shell_dst, ec);
-        ec.clear();
-    }
-
-    // Look up the xpkg in the xvm DB. If no version is registered yet,
-    // run a full install pass — xim::cmd_install handles download +
-    // extract + install hook + xvm registration.
-    //
-    // Important: Config::versions() returns the merged DB BY VALUE, so
-    // the returned object is a temporary. We MUST bind it to a local
-    // variable before pulling pointers out of it (`get_vdata` returns
-    // a pointer into the DB). Calling Config::versions() inline as a
-    // function argument creates a temporary that dies at the end of
-    // the expression, leaving `vd` dangling — observed as a corrupted
-    // path string and a spurious "shell binary not found" error.
-    auto db = Config::versions();
-    auto resolved = xvm::match_version(db, bare, "");
-    if (resolved.empty()) {
-        std::vector<std::string> targets = { xpkg_id };
-        auto rc = xim::cmd_install(targets, /*yes=*/true,
-                                   /*noDeps=*/false, stream);
-        if (rc != 0) {
-            stream.emit(ErrorEvent{
-                .code = ErrorCode::NotFound,
-                .message = std::format(
-                    "failed to install sandbox shell xpkg '{}'", xpkg_id),
-                .recoverable = true,
-                .hint = std::format(
-                    "try manually: xlings install {} (then re-run subos use)",
-                    xpkg_id),
-            });
-            return 1;
-        }
-        db = Config::versions();
-        resolved = xvm::match_version(db, bare, "");
-        if (resolved.empty()) {
-            stream.emit(ErrorEvent{
-                .code = ErrorCode::NotFound,
-                .message = std::format(
-                    "xpkg '{}' installed but no version in xvm DB "
-                    "(unexpected — package may not register a binary)",
-                    xpkg_id),
-                .recoverable = false,
-            });
-            return 1;
-        }
-    }
-
-    auto* vd = xvm::get_vdata(db, bare, resolved);
-    if (!vd || vd->path.empty()) {
-        stream.emit(ErrorEvent{
-            .code = ErrorCode::NotFound,
-            .message = std::format(
-                "xpkg '{}' has no bindir registered in xvm DB", xpkg_id),
-            .recoverable = false,
-        });
-        return 1;
-    }
-
-    auto bindir = fs::path(xvm::expand_path(
-        vd->path, Config::paths().homeDir.string()));
-    auto shell_src = bindir / basename;
-    if (!fs::exists(shell_src, ec)) {
-        stream.emit(ErrorEvent{
-            .code = ErrorCode::NotFound,
-            .message = std::format(
-                "shell binary '{}' not found in xpkg payload (looked at {})",
-                basename, shell_src.string()),
-            .recoverable = false,
-            .hint = std::format(
-                "the xpkg '{}' may not provide a binary called '{}'",
-                xpkg_id, basename),
-        });
-        return 1;
-    }
-
-    fs::create_directories(shell_dst.parent_path(), ec);
-    ec.clear();
-    fs::create_symlink(shell_src, shell_dst, ec);
-    if (ec) {
-        stream.emit(ErrorEvent{
-            .code = ErrorCode::Internal,
-            .message = std::format(
-                "failed to symlink {} -> {}: {}",
-                shell_dst.string(), shell_src.string(), ec.message()),
-            .recoverable = false,
-        });
-        return 1;
-    }
-    log::debug("[sandbox] hydrated shell {} -> {}",
-               shell_dst.string(), shell_src.string());
-    return 0;
-}
-
 } // namespace sandbox_detail_
 
-// Internal — not exported. `xlings subos use <name>` reaches here when
-// the subos's .xlings.json carries a `sandbox-shell` field.
-int use_sandbox_(const std::string& name, EventStream& stream) {
+// V4 sandbox entry. Reached only via `xlings subos use <name> --sandbox`.
+// Linux-only (proot uses ptrace + Linux syscall semantics). On non-Linux
+// the dispatcher in use_spawn_shell rejects --sandbox before reaching here.
+//
+// What it does:
+//   1. proot probe (same as V1 — locate_proot_)
+//   2. lazy init of <subos>/{home/<user>, tmp, etc/...} via init_sandbox_dirs_
+//   3. set env: XLINGS_ACTIVE_SUBOS, XLINGS_SUBOS_MODE=sandbox, HOME=/home/<user>
+//   4. build proot argv with V4 binds, execvp
+//
+// XLINGS_SUBOS_MODE=sandbox is the marker the shell profile checks to
+// switch the prompt pill from `[xsubos:<name>]` to `<xsubos:<name>>`.
+int use_sandbox_mode_(const std::string& name, EventStream& stream) {
+#if !defined(__linux__)
+    stream.emit(ErrorEvent{
+        .code = ErrorCode::InvalidInput,
+        .message = "sandbox mode (`subos use --sandbox`) is only supported "
+                   "on Linux (current: " + std::string(platform::OS_NAME) + ")",
+        .recoverable = false,
+        .hint = "drop --sandbox to use the regular env-spawn shell mode",
+    });
+    return 1;
+#else
     if (auto rc = use_detail_::validate_subos_(name, stream); rc != 0) return rc;
 
-    // Refuse nested sandbox entry. xlings already running inside a sandbox
-    // (XLINGS_ACTIVE_SUBOS set + we're seeing a sandbox config marker) —
-    // ptrace-based reroot inside a ptrace-based reroot is asking for
-    // trouble (proot quirks, exec-veto loops). Tell the user to exit first.
-    if (!utils::get_env_or_default("XLINGS_ACTIVE_SUBOS").empty()
-        && fs::exists("/.xlings.json"))
-    {
+    // Refuse nested sandbox entry. ptrace-based reroot inside a
+    // ptrace-based reroot is unstable (proot quirks, exec-veto loops).
+    // Detection: XLINGS_SUBOS_MODE=sandbox in env means we're already in
+    // one; tell the user to exit first.
+    if (utils::get_env_or_default("XLINGS_SUBOS_MODE") == "sandbox") {
         stream.emit(ErrorEvent{
             .code = ErrorCode::InvalidInput,
             .message = "cannot enter sandbox from inside another sandbox",
@@ -760,97 +584,70 @@ int use_sandbox_(const std::string& name, EventStream& stream) {
     auto& p = Config::paths();
     auto subos_dir = p.homeDir / "subos" / name;
 
-    // Read sandbox-shell path from this subos's config.
-    auto subos_config_path = subos_dir / ".xlings.json";
-    auto subos_config = read_config_json_(subos_config_path);
-    std::string shell_path;
-    if (subos_config.contains("sandbox-shell")
-        && subos_config["sandbox-shell"].is_string())
-    {
-        shell_path = subos_config["sandbox-shell"].get<std::string>();
-    }
-    if (shell_path.empty()) {
-        stream.emit(ErrorEvent{
-            .code = ErrorCode::InvalidInput,
-            .message = "subos '" + name + "' has no sandbox-shell field",
-            .recoverable = false,
-        });
-        return 1;
-    }
-
-    // Probe proot.
     auto proot = sandbox_detail_::locate_proot_(p.homeDir);
     if (!proot) {
         stream.emit(ErrorEvent{
             .code = ErrorCode::NotFound,
             .message = std::move(proot).error(),
             .recoverable = false,
-            .hint = "see docs/plans/2026-05-09-subos-sandbox-design.md",
+            .hint = "see .agents/docs/sandbox-v4-design.md",
         });
         return 1;
     }
 
-    // Self-heal: shell binary may be missing because the user removed
-    // the underlying xpkg (`xlings remove ...`) after creating the
-    // sandbox, leaving a dangling symlink. Re-run the hydrate path,
-    // which is idempotent and reinstalls the xpkg if needed. Eager
-    // install at `subos new` is the primary path; this is the
-    // recovery path so users never get stuck in chicken-and-egg
-    // (can't `subos use` to install, can't install without entering).
-    auto host_shell_path = subos_dir / shell_path.substr(
-        shell_path.front() == '/' ? 1 : 0);  // strip leading "/"
-    if (!fs::exists(host_shell_path)) {
-        std::string xpkg_id;
-        if (subos_config.contains("sandbox-shell-xpkg")
-            && subos_config["sandbox-shell-xpkg"].is_string())
-        {
-            xpkg_id = subos_config["sandbox-shell-xpkg"].get<std::string>();
-        }
-        if (xpkg_id.empty()) {
-            stream.emit(ErrorEvent{
-                .code = ErrorCode::NotFound,
-                .message = std::format(
-                    "sandbox shell '{}' not found in subos '{}' (expected at {})",
-                    shell_path, name, host_shell_path.string()),
-                .recoverable = false,
-                .hint = std::format(
-                    "no sandbox-shell-xpkg recorded — recreate the subos: "
-                    "xlings subos remove {} && xlings subos new {} --sandbox-shell <xpkg>",
-                    name, name),
-            });
-            return 1;
-        }
-        log::info("[sandbox] shell missing — rehydrating from xpkg '{}'",
-                  xpkg_id);
-        if (auto rc = sandbox_detail_::ensure_shell_installed_and_linked_(
-                subos_dir, xpkg_id, shell_path, stream); rc != 0)
-        {
-            return rc;
-        }
+    // Resolve the real user identity. We rely on $USER for the username
+    // (the standard convention; setpwent / getpwuid is libc-heavy and
+    // proot would re-route it anyway). uid / gid come from getuid /
+    // getgid — the kernel value, since we're not using `-0`.
+    auto user = utils::get_env_or_default("USER");
+    if (user.empty()) user = "user";  // defensive; unset $USER is rare
+    auto uid = ::getuid();
+    auto gid = ::getgid();
+
+    // Lazy init: create sandbox-private dirs and /etc templates if not
+    // already there. Idempotent — repeat `subos use --sandbox` is cheap.
+    sandbox_detail_::init_sandbox_dirs_(subos_dir, user, uid, gid);
+
+    auto user_home = "/home/" + user;
+    auto shell = utils::get_env_or_default("SHELL");
+    if (shell.empty()) shell = "/bin/sh";
+
+    // /bin is sandbox-private and only contains the subos's shims, NOT
+    // the host's coreutils / shells. The user's $SHELL on a usrmerge
+    // distro is typically /bin/bash (a symlink to /usr/bin/bash on
+    // host), but proot doesn't follow that — inside the sandbox view
+    // /bin/bash resolves to <subos>/bin/bash which doesn't exist.
+    //
+    // Translate /bin/<x> → /usr/bin/<x> when the latter exists on
+    // host (which means it'll exist inside the sandbox too via the
+    // /usr RO bind). For all other $SHELL values (full path under
+    // /usr/bin, or path under ~/.xlings/data/xpkgs via the nested
+    // .xlings bind), use as-is — they already resolve correctly.
+    if (shell.starts_with("/bin/")) {
+        auto candidate = "/usr/bin/" + shell.substr(5);
+        std::error_code ec;
+        if (fs::exists(candidate, ec)) shell = std::move(candidate);
     }
 
     nlohmann::json payload;
     payload["name"] = name;
     payload["mode"] = "sandbox";
-    payload["shell"] = shell_path;
+    payload["shell"] = shell;
     stream.emit(DataEvent{"subos_entering", payload.dump()});
 
-    // Flush before exec/spawn (same reasoning as use_spawn_shell).
+    // Flush before exec (buffered output is lost across execve(2)).
     std::cout.flush();
     std::cerr.flush();
 
-#if defined(__linux__)
-    // Set sandbox-friendly env before proot exec.
-    platform::set_env_variable("XLINGS_HOME", "/xlings");
+    // Set sandbox-friendly env before proot exec. The shell sources
+    // its profile, profile reads XLINGS_SUBOS_MODE and decorates PS1
+    // with `<xsubos:<name>>` instead of the default `[xsubos:<name>]`.
     platform::set_env_variable("XLINGS_ACTIVE_SUBOS", name);
-    platform::set_env_variable("HOME", "/root");
-    platform::set_env_variable("USER", "root");
-    platform::set_env_variable(
-        "PATH", "/bin:/xlings/bin:/usr/bin:/usr/local/bin");
+    platform::set_env_variable("XLINGS_SUBOS_MODE", "sandbox");
+    platform::set_env_variable("HOME", user_home);
 
-    // Build argv and exec proot.
     auto argv = sandbox_detail_::build_proot_argv_(
-        *proot, subos_dir, p.homeDir, name, shell_path);
+        *proot, subos_dir, p.homeDir, user, shell);
     std::vector<char*> c_argv;
     c_argv.reserve(argv.size() + 1);
     for (auto& s : argv) c_argv.push_back(const_cast<char*>(s.c_str()));
@@ -860,13 +657,6 @@ int use_sandbox_(const std::string& name, EventStream& stream) {
     log::error("failed to exec proot '{}': {}", proot->string(),
                std::strerror(errno));
     return 127;
-#else
-    stream.emit(ErrorEvent{
-        .code = ErrorCode::InvalidInput,
-        .message = "sandbox subos is only supported on Linux",
-        .recoverable = false,
-    });
-    return 1;
 #endif
 }
 
@@ -892,25 +682,17 @@ int use_sandbox_(const std::string& name, EventStream& stream) {
 // process without shell-function infrastructure (we'd have to manipulate
 // the parent shell's env, which exec(2) cannot do). Users who really
 // want flat semantics type `exit` first.
-int use_spawn_shell(const std::string& name, EventStream& stream) {
-    if (auto rc = use_detail_::validate_subos_(name, stream); rc != 0) return rc;
+int use_spawn_shell(const std::string& name, EventStream& stream,
+                    bool sandbox = false)
+{
+    // V4: --sandbox is a `use`-time modifier. Dispatch to the proot
+    // path when set; otherwise the regular env-spawn shell behavior
+    // (this function's body) runs unchanged. Old V1.1-V1.3 detection
+    // of the `sandbox-shell` field in .xlings.json is GONE — the user
+    // explicitly opts into sandbox via the flag now.
+    if (sandbox) return use_sandbox_mode_(name, stream);
 
-    // Sandbox dispatch: if this subos has a `sandbox-shell` field in its
-    // .xlings.json, route to the proot-based entry instead of the
-    // env-spawn shell. Detection is cheap (one JSON file read), so we do
-    // it on every `subos use` rather than a separate command surface —
-    // the user types `xlings subos use foo` regardless of subos type.
-    {
-        auto& p = Config::paths();
-        auto subos_cfg = read_config_json_(
-            p.homeDir / "subos" / name / ".xlings.json");
-        if (subos_cfg.contains("sandbox-shell")
-            && subos_cfg["sandbox-shell"].is_string()
-            && !subos_cfg["sandbox-shell"].get<std::string>().empty())
-        {
-            return use_sandbox_(name, stream);
-        }
-    }
+    if (auto rc = use_detail_::validate_subos_(name, stream); rc != 0) return rc;
 
     auto already = utils::get_env_or_default("XLINGS_ACTIVE_SUBOS");
     if (already == name) {
@@ -1137,22 +919,13 @@ export int run(int argc, char* argv[], EventStream& stream) {
 
     if (sub == "new") {
         if (argc < 4) { usageError("missing <name> for: xlings subos new"); return 1; }
-        // Parse: xlings subos new <name> [--sandbox-shell <xpkg>]
+        // Parse: xlings subos new <name>
+        // (--sandbox-shell removed in 0.4.23 V4: sandbox is a `use` modifier
+        // now, not a creation property — see .agents/docs/sandbox-v4-design.md)
         std::string name;
-        std::optional<std::string> sandbox_shell;
         for (int i = 3; i < argc; ++i) {
             std::string a = argv[i];
-            if (a == "--sandbox-shell") {
-                if (i + 1 >= argc) {
-                    usageError("--sandbox-shell needs an xpkg argument");
-                    return 1;
-                }
-                sandbox_shell = argv[++i];
-            }
-            else if (a.rfind("--sandbox-shell=", 0) == 0) {
-                sandbox_shell = a.substr(16);
-            }
-            else if (!a.empty() && a[0] != '-' && name.empty()) {
+            if (!a.empty() && a[0] != '-' && name.empty()) {
                 name = std::move(a);
             }
             else {
@@ -1164,7 +937,6 @@ export int run(int argc, char* argv[], EventStream& stream) {
             usageError("missing <name> for: xlings subos new");
             return 1;
         }
-        if (sandbox_shell) return create_sandbox(name, {}, *sandbox_shell, stream);
         return create(name, {}, stream);
     }
     if (sub == "use") {
@@ -1174,11 +946,18 @@ export int run(int argc, char* argv[], EventStream& stream) {
         //   --shell <kind>   emit shell code on stdout for the user to
         //                    eval/Invoke-Expression. <kind> ∈ {sh,bash,zsh,
         //                    fish,pwsh}. Defaults to "sh" if not provided.
+        //   --sandbox        Linux-only: enter via proot fs-isolation. $HOME,
+        //                    /tmp, /etc/passwd are sandbox-private; ~/.xlings,
+        //                    /usr, /lib*, /etc/{resolv.conf,ld.so.cache} are
+        //                    bound from host. Same shell (`$SHELL`) as outside.
+        //                    Prompt switches from `[xsubos:<name>]` to
+        //                    `<xsubos:<name>>` so the user can tell at a glance.
         //   (no flag)        spawn a fresh interactive shell with
         //                    XLINGS_ACTIVE_SUBOS=<name> in env. Per-shell.
         std::string name;
         std::string mode = "spawn";        // default
         std::string shell_kind = "sh";
+        bool sandbox = false;
         for (int i = 3; i < argc; ++i) {
             std::string a = argv[i];
             if (a == "--global") { mode = "global"; }
@@ -1192,6 +971,9 @@ export int run(int argc, char* argv[], EventStream& stream) {
                 mode = "shell";
                 shell_kind = a.substr(8);
             }
+            else if (a == "--sandbox") {
+                sandbox = true;
+            }
             else if (!a.empty() && a[0] != '-' && name.empty()) {
                 name = std::move(a);
             }
@@ -1204,7 +986,7 @@ export int run(int argc, char* argv[], EventStream& stream) {
 
         if (mode == "global") return use_global(name, stream);
         if (mode == "shell")  return use_emit_shell(name, shell_kind, stream);
-        return use_spawn_shell(name, stream);
+        return use_spawn_shell(name, stream, sandbox);
     }
     if (sub == "list")   return run_list_(stream);
     if (sub == "remove") {

--- a/src/core/xself/profile_resources.cppm
+++ b/src/core/xself/profile_resources.cppm
@@ -57,10 +57,15 @@ namespace xlings::xself::profile_resources {
 //       name in bold green
 //   9 — subos name color shifts from bold green to bold magenta (8-color
 //       SGR 35) for a calmer "purple" reading; brackets stay slate-400
-export inline constexpr std::string_view kVersion = "9";
+//  10 — sandbox-mode prompt: when XLINGS_SUBOS_MODE=sandbox is set in
+//       env (set by `xlings subos use --sandbox`), the prompt pill
+//       uses angle brackets `<xsubos:<name>>` instead of square
+//       `[xsubos:<name>]` — visually obvious which entry mode the
+//       shell is in. Re-source idempotency checks BOTH bracket forms.
+export inline constexpr std::string_view kVersion = "10";
 
 export inline constexpr std::string_view bash_sh =
-R"XPROFILE(# xlings-profile-version: 9
+R"XPROFILE(# xlings-profile-version: 10
 # Xlings Shell Profile (bash/zsh)
 
 _xlings_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." 2>/dev/null && pwd)"
@@ -91,31 +96,40 @@ esac
 # correctly; bash's \[...\] line-wrap markers are skipped because zsh
 # would render them literally — the marker is short enough that any
 # line-wrap glitch is barely noticeable.
+# Sandbox-mode (XLINGS_SUBOS_MODE=sandbox) flips the brackets to angle:
+#   normal subos use:   [xsubos:foo]
+#   subos use --sandbox: <xsubos:foo>
+# Idempotency check covers both bracket forms so re-source is safe.
 if [ -n "${XLINGS_ACTIVE_SUBOS-}" ] && [ -n "${PS1-}" ]; then
     case "$PS1" in
         *"[xsubos:$XLINGS_ACTIVE_SUBOS]"*) ;;
+        *"<xsubos:$XLINGS_ACTIVE_SUBOS>"*) ;;
         *)
+            if [ "${XLINGS_SUBOS_MODE-}" = "sandbox" ]; then
+                _xlings_lb='<'; _xlings_rb='>'
+            else
+                _xlings_lb='['; _xlings_rb=']'
+            fi
             if [ -z "${NO_COLOR-}" ] && [ -n "${TERM-}" ] && [ "$TERM" != "dumb" ]; then
                 # Brackets / "xsubos:" label tinted slate-400 gray; subos
-                # name itself in bold magenta (SGR 1;35) — calmer "purple"
-                # than truecolor magenta and rendered consistently across
-                # terminals.
+                # name itself in bold magenta (SGR 1;35).
                 _xlings_esc=$(printf '\033')
                 _xlings_g="${_xlings_esc}[38;2;148;163;184m"
                 _xlings_n="${_xlings_esc}[1;35m"
                 _xlings_r="${_xlings_esc}[0m"
-                PS1="${_xlings_g}[xsubos:${_xlings_n}${XLINGS_ACTIVE_SUBOS}${_xlings_r}${_xlings_g}]${_xlings_r} ${PS1}"
+                PS1="${_xlings_g}${_xlings_lb}xsubos:${_xlings_n}${XLINGS_ACTIVE_SUBOS}${_xlings_r}${_xlings_g}${_xlings_rb}${_xlings_r} ${PS1}"
                 unset _xlings_esc _xlings_g _xlings_n _xlings_r
             else
-                PS1="[xsubos:${XLINGS_ACTIVE_SUBOS}] ${PS1}"
+                PS1="${_xlings_lb}xsubos:${XLINGS_ACTIVE_SUBOS}${_xlings_rb} ${PS1}"
             fi
+            unset _xlings_lb _xlings_rb
             ;;
     esac
 fi
 )XPROFILE";
 
 export inline constexpr std::string_view fish =
-R"XPROFILE(# xlings-profile-version: 9
+R"XPROFILE(# xlings-profile-version: 10
 # Xlings Shell Profile (fish)
 
 set -l _script_dir (dirname (status filename))
@@ -143,21 +157,24 @@ if set -q XLINGS_ACTIVE_SUBOS
     end
     function fish_prompt
         if set -q XLINGS_ACTIVE_SUBOS
+            # Sandbox mode flips brackets: <xsubos:foo> instead of [xsubos:foo]
+            if test "$XLINGS_SUBOS_MODE" = "sandbox"
+                set _xlings_lb "<"; set _xlings_rb ">"
+            else
+                set _xlings_lb "["; set _xlings_rb "]"
+            end
             if not set -q NO_COLOR; and set -q TERM; and test "$TERM" != "dumb"
-                # Brackets / "xsubos:" label slate-400 gray; subos name
-                # in bold magenta (the 8-color "purple") for a calmer
-                # tone than the truecolor magenta used by entering.
                 set_color 94a3b8
-                echo -n "[xsubos:"
+                echo -n "$_xlings_lb""xsubos:"
                 set_color --bold magenta
                 echo -n "$XLINGS_ACTIVE_SUBOS"
                 set_color normal
                 set_color 94a3b8
-                echo -n "]"
+                echo -n "$_xlings_rb"
                 set_color normal
                 echo -n " "
             else
-                echo -n "[xsubos:$XLINGS_ACTIVE_SUBOS] "
+                echo -n "$_xlings_lb""xsubos:$XLINGS_ACTIVE_SUBOS""$_xlings_rb "
             end
         end
         _xlings_orig_fish_prompt
@@ -166,7 +183,7 @@ end
 )XPROFILE";
 
 export inline constexpr std::string_view pwsh =
-R"XPROFILE(# xlings-profile-version: 9
+R"XPROFILE(# xlings-profile-version: 10
 # Xlings Shell Profile (PowerShell)
 
 $env:XLINGS_HOME = (Resolve-Path "$PSScriptRoot\..\..").Path
@@ -190,16 +207,20 @@ if ($env:XLINGS_ACTIVE_SUBOS) {
     }
     function global:prompt {
         $useColor = (-not $env:NO_COLOR) -and $env:TERM -ne 'dumb'
+        # Sandbox mode flips brackets: <xsubos:foo> instead of [xsubos:foo]
+        if ($env:XLINGS_SUBOS_MODE -eq 'sandbox') {
+            $lb = '<'; $rb = '>'
+        } else {
+            $lb = '['; $rb = ']'
+        }
         if ($useColor) {
-            # Brackets / "xsubos:" label slate-400 gray; subos name in
-            # bold magenta (8-color "purple") for a calmer tone.
             $e = [char]27
             $g = "$e[38;2;148;163;184m"
             $n = "$e[1;35m"
             $r = "$e[0m"
-            Write-Host -NoNewline "$g[xsubos:$n$($env:XLINGS_ACTIVE_SUBOS)$r$g]$r "
+            Write-Host -NoNewline "$g$lb`xsubos:$n$($env:XLINGS_ACTIVE_SUBOS)$r$g$rb$r "
         } else {
-            Write-Host -NoNewline "[xsubos:$($env:XLINGS_ACTIVE_SUBOS)] "
+            Write-Host -NoNewline "$lb`xsubos:$($env:XLINGS_ACTIVE_SUBOS)$rb "
         }
         & $function:_xlings_orig_prompt
     }

--- a/tests/e2e/subos_sandbox_test.sh
+++ b/tests/e2e/subos_sandbox_test.sh
@@ -1,31 +1,36 @@
 #!/usr/bin/env bash
-# subos_sandbox_test.sh — verifies the sandbox subos type:
+# subos_sandbox_test.sh — verifies the 0.4.23 V4 sandbox model:
 #
-#   * `subos new --sandbox-shell <xpkg>` creates the right layout, /etc/*
-#     templates land where expected, .xlings.json carries the sandbox-shell
-#     fields, AND eagerly installs the configured shell xpkg + symlinks the
-#     binary into <sandbox>/bin/<basename> so `subos use` can run it
-#     (added in 0.4.22).
-#   * `subos use <sandbox>` correctly enters the proot-based sandbox shell.
-#   * If the symlink dangles (e.g. user removed the underlying xpkg), the
-#     next `subos use` self-heals by re-running hydration.
+# - `xlings subos new <name>` creates a regular subos (no sandbox-specific
+#   fields, dirs, or eager xpkg installs — that whole V1.1-V1.3 path is
+#   gone). Workspace .xlings.json contains JUST `{"workspace": {}}`.
 #
-# Sandbox is Linux-only by design (proot uses ptrace + Linux syscall
-# semantics); this test is gated on Linux. macOS / Windows variants only
-# verify that --sandbox-shell at create time is rejected with a clear
-# error.
+# - `xlings subos use <name> --sandbox` enters the SAME subos via proot
+#   with FS isolation:
+#     * real user identity (no `-0`, no fake root);
+#     * $HOME is sandbox-private (`<subos>/home/<user>`);
+#     * /etc/passwd has the real user entry (sandbox template);
+#     * /tmp is sandbox-private;
+#     * ~/.xlings is bound from host RW so xlings install / list / etc.
+#       behave EXACTLY like outside the sandbox (per-subos workspace,
+#       host xpkg pool — sandbox is just a different way to enter the
+#       same subos);
+#     * /usr, /lib, /lib64, /etc/resolv.conf, /etc/ld.so.cache are bound
+#       from host RO so coreutils / loader / DNS just work.
 #
-# Design ref: docs/plans/2026-05-09-subos-sandbox-design.md
+# - `xlings subos use <name>` (no --sandbox) is unchanged from current
+#   subos behavior — env-spawn shell, no FS isolation.
+#
+# Linux-only (proot uses ptrace). Non-Linux platforms verify --sandbox
+# is rejected with a clear error.
+#
+# Design ref: .agents/docs/sandbox-v4-design.md
 set -euo pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
 
-require_fixture_index
-
 RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/subos_sandbox"
 HOME_DIR="$RUNTIME_DIR/home"
-LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
-FIXTURE_PKG="$LOCAL_INDEX_DIR/pkgs/s/sh.lua"
 
 cleanup() { rm -rf "$RUNTIME_DIR"; }
 trap cleanup EXIT
@@ -34,225 +39,184 @@ cleanup
 XLINGS_BIN="$(find_xlings_bin)"
 
 mkdir -p "$HOME_DIR/subos/default/bin" "$HOME_DIR/runtimedir"
-
-# Private copy of the shared fixture index, neutralise sub-index repos.
-cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
-printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
-rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
-mkdir -p "$(dirname "$FIXTURE_PKG")"
-
-# Fixture xpkg `sh`: drops a tiny static-ish shell at
-# <install_dir>/bin/sh and registers via xvm.add. The install
-# hook prefers the system busybox (statically linked on most distros),
-# falling back to /bin/sh otherwise — in either case the binary
-# delivered through the xim install path is what we want the eager
-# hydrate flow to symlink into the sandbox bin.
-cat > "$FIXTURE_PKG" <<'LUA'
-package = {
-    spec = "1",
-    name = "sh",
-    description = "Local fixture for tests/e2e/subos_sandbox_test.sh",
-    authors = {"xlings-ci"},
-    licenses = {"MIT"},
-    type = "package",
-    archs = {"x86_64"},
-    status = "stable",
-    categories = {"test-fixture"},
-    xpm = {
-        linux   = { ["1.0.0"] = {} },
-        macosx  = { ["1.0.0"] = {} },
-        windows = { ["1.0.0"] = {} },
-    },
-}
-
-import("xim.libxpkg.pkginfo")
-import("xim.libxpkg.xvm")
-
-function install()
-    local bindir = path.join(pkginfo.install_dir(), "bin")
-    os.tryrm(pkginfo.install_dir())
-    os.mkdir(bindir)
-    -- Prefer system busybox (static, dispatches by argv[0] so the
-    -- "sh" applet is available when invoked as bin/sh). Otherwise
-    -- copy /bin/sh. The hydrate flow symlinks <install_dir>/bin/sh
-    -- into <sandbox>/bin/sh for the sandbox shell.
-    local src = "/bin/busybox"
-    if not os.isfile(src) then src = "/bin/sh" end
-    if os.isfile(src) then
-        os.cp(src, path.join(bindir, "sh"))
-    else
-        io.writefile(path.join(bindir, "sh"),
-                     "#!/bin/sh\nexec /bin/sh \"$@\"\n")
-    end
-    os.exec("chmod +x " .. path.join(bindir, "sh"))
-    return true
-end
-
-function config()
-    xvm.add("sh", { bindir = path.join(pkginfo.install_dir(), "bin") })
-    return true
-end
-
-function uninstall()
-    xvm.remove("sh")
-    return true
-end
-LUA
-
 cat > "$HOME_DIR/.xlings.json" <<JSON
-{
-  "activeSubos": "default",
-  "mirror": "GLOBAL",
-  "index_repos": [
-    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
-  ]
-}
+{ "activeSubos": "default" }
 JSON
 
 run_x() {
-  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
+  ( cd /tmp && env -i HOME="$HOME" USER="$USER" SHELL="${SHELL:-/bin/sh}" \
+      PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
       "$XLINGS_BIN" "$@" )
 }
 
 # ─────────────────────────────────────────────────────────────────────
-# Linux path: full sandbox creation + entry
+# Linux path: full V4 sandbox flow
 # ─────────────────────────────────────────────────────────────────────
 if [[ "$(uname -s)" == "Linux" ]]; then
 
-# ── S1: subos new --sandbox-shell creates layout + auto-hydrates shell
-log "S1: subos new --sandbox-shell mybox xim:sh"
-run_x subos new mybox --sandbox-shell xim:sh >/dev/null 2>&1
-
-[[ -d "$HOME_DIR/subos/mybox" ]]              || fail "S1: subos dir not created"
-[[ -d "$HOME_DIR/subos/mybox/bin" ]]          || fail "S1: bin/ missing"
-[[ -d "$HOME_DIR/subos/mybox/etc" ]]          || fail "S1: etc/ missing"
-[[ -d "$HOME_DIR/subos/mybox/root" ]]         || fail "S1: root/ missing (expected for sandbox subos)"
-[[ -d "$HOME_DIR/subos/mybox/tmp" ]]          || fail "S1: tmp/ missing (expected for sandbox subos)"
-[[ -f "$HOME_DIR/subos/mybox/.xlings.json" ]] || fail "S1: .xlings.json missing"
-
-# Eager hydration: shell binary must be present at <sandbox>/bin/sh
-# (created as a symlink to the xim payload's binary).
-shell_link="$HOME_DIR/subos/mybox/bin/sh"
-[[ -L "$shell_link" ]] || fail "S1: shell symlink missing at $shell_link"
-[[ -f "$shell_link" ]] || fail "S1: shell symlink dangling at $shell_link"
-target="$(readlink "$shell_link")"
-[[ "$target" == *"data/xpkgs/xim-x-sh"* ]] \
-  || fail "S1: shell symlink target unexpected: $target"
-log "  ✓ layout + auto-installed shell (symlink: $target)"
-
-# ── S2: /etc/* templates have correct content
-log "S2: /etc/{passwd,group,hosts,nsswitch.conf} populated correctly"
-grep -q "^root:x:0:0:root:/root:/bin/sh" "$HOME_DIR/subos/mybox/etc/passwd" \
-  || fail "S2: /etc/passwd missing root entry"
-grep -q "^root:x:0:" "$HOME_DIR/subos/mybox/etc/group" \
-  || fail "S2: /etc/group missing root entry"
-grep -q "127.0.0.1.*localhost" "$HOME_DIR/subos/mybox/etc/hosts" \
-  || fail "S2: /etc/hosts missing localhost"
-grep -q "hosts:.*files" "$HOME_DIR/subos/mybox/etc/nsswitch.conf" \
-  || fail "S2: /etc/nsswitch.conf missing hosts: files"
-log "  ✓ /etc templates present and well-formed"
-
-# ── S3: .xlings.json has sandbox-shell + sandbox-shell-xpkg fields
-log "S3: .xlings.json carries sandbox-shell metadata"
-shell_value="$(python3 -c '
+# ── S1: subos new is back to a plain subos (no sandbox-specific stuff)
+log "S1: subos new mybox creates a plain subos"
+run_x subos new mybox >/dev/null
+[[ -d "$HOME_DIR/subos/mybox/bin" ]] || fail "S1: bin/ missing"
+[[ -d "$HOME_DIR/subos/mybox/lib" ]] || fail "S1: lib/ missing"
+# V4: no sandbox dirs at create time — those are lazy on first --sandbox use
+[[ ! -d "$HOME_DIR/subos/mybox/home" ]] || fail "S1: home/ created too early (should be lazy)"
+[[ ! -d "$HOME_DIR/subos/mybox/etc" ]]  || fail "S1: etc/ created too early (should be lazy)"
+[[ ! -d "$HOME_DIR/subos/mybox/tmp" ]]  || fail "S1: tmp/ created too early (should be lazy)"
+# .xlings.json should be just `{ "workspace": {} }`, no sandbox-shell field
+shell_field="$(python3 -c '
 import json, sys
-data = json.loads(open(sys.argv[1]).read())
-print(data.get("sandbox-shell", "<missing>"))
-print(data.get("sandbox-shell-xpkg", "<missing>"))
+d = json.load(open(sys.argv[1]))
+print(d.get("sandbox-shell", "<absent>"))
+print(d.get("sandbox-shell-xpkg", "<absent>"))
 ' "$HOME_DIR/subos/mybox/.xlings.json")"
-[[ "$shell_value" == "/bin/sh"$'\n'"xim:sh" ]] \
-  || fail "S3: sandbox-shell fields wrong: '$shell_value'"
-log "  ✓ sandbox-shell=/bin/sh, sandbox-shell-xpkg=xim:sh"
+[[ "$shell_field" == "<absent>"$'\n'"<absent>" ]] \
+  || fail "S1: stale sandbox-shell fields in fresh .xlings.json: '$shell_field'"
+log "  ✓ plain subos, no V1 sandbox-shell residue"
 
-# ── S4: regular subos (no --sandbox-shell) does NOT have sandbox fields
-log "S4: regular subos retains its existing schema (no sandbox leak)"
-run_x subos new normalbox >/dev/null
-if grep -q "sandbox-shell" "$HOME_DIR/subos/normalbox/.xlings.json"; then
-  fail "S4: regular subos accidentally got sandbox-shell field"
-fi
-[[ ! -d "$HOME_DIR/subos/normalbox/etc" ]] \
-  || fail "S4: regular subos accidentally got etc/ directory"
-[[ ! -d "$HOME_DIR/subos/normalbox/root" ]] \
-  || fail "S4: regular subos accidentally got root/ directory"
-log "  ✓ regular subos layout unchanged"
-
-# ── S5: subos use sandbox without proot installed → clear error
-log "S5: subos use requires proot — clear error if missing"
-out="$(run_x subos use mybox 2>&1 || true)"
-echo "$out" | grep -q "proot not found" \
-  || fail "S5: expected 'proot not found' error, got:
+# ── S2: --sandbox-shell flag is gone (rejected by `subos new`)
+log "S2: subos new --sandbox-shell is now rejected (V4 removed the flag)"
+out="$(run_x subos new someotherbox --sandbox-shell xim:fish 2>&1 || true)"
+echo "$out" | grep -q "unknown option" \
+  || fail "S2: expected 'unknown option' for --sandbox-shell, got:
 $out"
-log "  ✓ proot probe error fires before exec"
+[[ ! -d "$HOME_DIR/subos/someotherbox" ]] \
+  || fail "S2: someotherbox dir created despite the rejection"
+log "  ✓ --sandbox-shell rejected at parse time"
 
-# ── S6: subos use after proot is staged → enters sandbox successfully
-#       (needs network for proot fetch; gracefully skip if offline)
-log "S6: subos use enters proot session (requires network for proot fetch)"
-if curl -fsLo "$HOME_DIR/runtimedir/proot" \
+# ── S3: subos use --sandbox without proot → clear error before exec
+log "S3: subos use --sandbox without proot installed → clear error"
+out="$(run_x subos use mybox --sandbox 2>&1 || true)"
+echo "$out" | grep -q "proot not found" \
+  || fail "S3: expected 'proot not found' error, got:
+$out"
+log "  ✓ proot probe error fires before fs-isolation exec"
+
+# ── S4: install proot (or skip rest if no network)
+log "S4: install proot for the rest of the suite"
+if ! curl -fsLo "$HOME_DIR/runtimedir/proot" \
      https://proot.gitlab.io/proot/bin/proot 2>/dev/null; then
-  chmod +x "$HOME_DIR/runtimedir/proot"
-  if [[ -x /bin/busybox ]] && file /bin/busybox 2>/dev/null | grep -q "statically linked"; then
-    # Inside-sandbox script:
-    #   1. fake-root identity (whoami / id)
-    #   2. /etc/passwd is our sandbox template (not host's)
-    #   3. /root is the SANDBOX'S /root (not host's) — write a marker
-    #      file and verify it lands in <sandbox>/root, not /root on host
-    #   4. /usr/bin host-bound tools work (uname is busybox here, but on
-    #      a real flow host /usr/bin/uname would be invoked)
-    out_inside="$(echo 'echo "I_AM_$(whoami)_UID_$(id -u)"; echo "PASSWD_FIRST=$(head -1 /etc/passwd)"; touch /root/.sandbox_marker_S6 && echo "ROOT_WRITE_OK"; ls /xlings 2>/dev/null | head -3 | tr "\n" " "; echo "<-- /xlings"; exit' | \
-      ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
-        timeout 10 "$XLINGS_BIN" subos use mybox ) 2>&1 || true)"
-    echo "$out_inside" | grep -q "I_AM_root_UID_0" \
-      || fail "S6: sandbox didn't fake root (expected I_AM_root_UID_0):
-$out_inside"
-    echo "$out_inside" | grep -q "PASSWD_FIRST=root:x:0:0:root:/root:/bin/sh" \
-      || fail "S6: /etc/passwd inside sandbox is not our template:
-$out_inside"
-    echo "$out_inside" | grep -q "ROOT_WRITE_OK" \
-      || fail "S6: writing to /root inside sandbox failed (probably proot
-auto-bound host /root over sandbox /root — regression of 0.4.23 fix):
-$out_inside"
-    [[ -f "$HOME_DIR/subos/mybox/root/.sandbox_marker_S6" ]] \
-      || fail "S6: /root marker did not land in <sandbox>/root — probably
-proot is binding host /root over the sandbox /root again"
-    log "  ✓ sandbox: fake-root + sandbox /etc/passwd + sandbox /root writable"
-  else
-    log "  (skip: no static /bin/busybox to invoke as sandbox shell)"
-  fi
-else
-  log "  (skip: cannot fetch proot from gitlab.io; offline or restricted)"
+  log "  (skip rest: cannot fetch proot from gitlab.io; offline or restricted)"
+  log "PASS: subos sandbox V4 (Linux, partial — S1-S3 only)"
+  exit 0
 fi
+chmod +x "$HOME_DIR/runtimedir/proot"
 
-# ── S7: self-heal — manually break the symlink, next `subos use` rehydrates
-log "S7: subos use self-heals when shell symlink is missing"
-rm -f "$shell_link"
-[[ ! -e "$shell_link" ]] || fail "S7: setup failed — shell still present"
-# Trigger use; it'll fail on proot probe (or shell exec), but the
-# rehydrate path runs BEFORE proot exec and should restore the symlink.
-run_x subos use mybox >/dev/null 2>&1 || true
-[[ -L "$shell_link" ]] || fail "S7: symlink not restored after self-heal"
-[[ -f "$shell_link" ]] || fail "S7: symlink still dangling after self-heal"
-log "  ✓ rehydrate restored shell symlink without recreating subos"
+# ── S5: --sandbox enters proot, real user identity preserved
+log "S5: subos use --sandbox preserves real user identity"
+out_inside="$(echo 'echo "ID:$(whoami):$(id -u)"; echo "HOME=$HOME"; echo "SHELL=$SHELL"; echo "MODE=$XLINGS_SUBOS_MODE"; exit' | \
+  ( cd /tmp && env -i HOME="$HOME" USER="$USER" SHELL=/bin/sh \
+      PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
+      timeout 10 "$XLINGS_BIN" subos use mybox --sandbox ) 2>&1 || true)"
+echo "$out_inside" | grep -q "ID:$USER:$(id -u)" \
+  || fail "S5: identity not preserved (expected ID:$USER:$(id -u)):
+$out_inside"
+echo "$out_inside" | grep -q "HOME=/home/$USER" \
+  || fail "S5: \$HOME is not /home/<user>:
+$out_inside"
+echo "$out_inside" | grep -q "MODE=sandbox" \
+  || fail "S5: XLINGS_SUBOS_MODE not set:
+$out_inside"
+log "  ✓ inside sandbox: $USER (uid $(id -u)), \$HOME=/home/$USER, mode=sandbox"
 
-# ── S8: subos remove sandbox cleans up everything
-log "S8: subos remove sandbox removes the directory tree"
+# ── S6: /etc/passwd is sandbox template with real user + root only
+log "S6: /etc/passwd is sandbox template (real user + root, no host users)"
+out_passwd="$(echo 'cat /etc/passwd; echo MARKER_END; exit' | \
+  ( cd /tmp && env -i HOME="$HOME" USER="$USER" SHELL=/bin/sh \
+      PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
+      timeout 10 "$XLINGS_BIN" subos use mybox --sandbox ) 2>&1 || true)"
+# Expect ONLY root + current user — no daemon, sshd, sys, etc.
+line_count=$(echo "$out_passwd" | sed -n '/^root:/,/^MARKER_END/p' | grep -c '^[a-zA-Z]' || true)
+[[ "$line_count" -le 3 ]] \
+  || fail "S6: /etc/passwd has too many entries (expected ≤2 + MARKER_END line, got $line_count):
+$out_passwd"
+echo "$out_passwd" | grep -q "^root:x:0:0:root:" \
+  || fail "S6: /etc/passwd missing root entry:
+$out_passwd"
+echo "$out_passwd" | grep -q "^$USER:x:$(id -u):" \
+  || fail "S6: /etc/passwd missing real-user entry:
+$out_passwd"
+log "  ✓ /etc/passwd: only root + $USER, no host user leak"
+
+# ── S7: dotfile isolation — sandbox writes to /home/<user> stay private
+log "S7: writing to ~/ inside sandbox doesn't pollute host"
+marker_file="$HOME/.xlings-sandbox-test-marker-$$"
+trap "rm -f '$marker_file'" EXIT
+[[ ! -e "$marker_file" ]] || fail "S7: setup — marker exists before sandbox"
+echo "echo SANDBOX > '$marker_file' && exit" | \
+  ( cd /tmp && env -i HOME="$HOME" USER="$USER" SHELL=/bin/sh \
+      PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
+      timeout 10 "$XLINGS_BIN" subos use mybox --sandbox ) >/dev/null 2>&1 || true
+[[ ! -e "$marker_file" ]] \
+  || fail "S7: sandbox $marker_file leaked to host!"
+[[ -f "$HOME_DIR/subos/mybox/home/$USER$marker_file" ]] || true
+# Check the file landed inside <subos>/home/<user>/...
+sandbox_marker="$HOME_DIR/subos/mybox/home/$USER${marker_file#$HOME}"
+[[ -f "$sandbox_marker" ]] \
+  || fail "S7: sandbox marker not found at $sandbox_marker"
+log "  ✓ host \$HOME unaffected; file landed in <subos>/home/$USER/"
+
+# ── S8: ~/.xlings IS host-shared (RW bind override on top of /home)
+log "S8: ~/.xlings is the host xlings home, RW shared"
+out_xl="$(echo 'ls ~/.xlings/ 2>&1 | tr "\n" " "; echo MARKER; exit' | \
+  ( cd /tmp && env -i HOME="$HOME" USER="$USER" SHELL=/bin/sh \
+      PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
+      timeout 10 "$XLINGS_BIN" subos use mybox --sandbox ) 2>&1 || true)"
+echo "$out_xl" | grep -q "subos" \
+  || fail "S8: ~/.xlings doesn't show host content (expected to see 'subos'):
+$out_xl"
+log "  ✓ ~/.xlings inside sandbox is host bind (subos/, etc. visible)"
+
+# ── S9: /tmp is sandbox-private
+log "S9: /tmp is sandbox-private (writes don't pollute host /tmp)"
+host_tmp_marker="/tmp/xlings-sandbox-host-marker-$$"
+trap "rm -f '$marker_file' '$host_tmp_marker'" EXIT
+echo "touch /tmp/xlings-sandbox-host-marker-$$; ls /tmp/ | head -3; exit" | \
+  ( cd /tmp && env -i HOME="$HOME" USER="$USER" SHELL=/bin/sh \
+      PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
+      timeout 10 "$XLINGS_BIN" subos use mybox --sandbox ) >/dev/null 2>&1 || true
+[[ ! -e "$host_tmp_marker" ]] \
+  || fail "S9: sandbox /tmp file leaked to host /tmp"
+[[ -f "$HOME_DIR/subos/mybox/tmp/xlings-sandbox-host-marker-$$" ]] \
+  || fail "S9: sandbox /tmp marker not landed in <subos>/tmp/"
+log "  ✓ /tmp inside sandbox is <subos>/tmp/, host /tmp unaffected"
+
+# ── S10: subos use mybox (no --sandbox) is unchanged
+log "S10: subos use mybox (no --sandbox) is plain env-spawn shell"
+# We can't easily probe interactive shell behavior in a CI script, but
+# we CAN assert the binary exits without trying to fork proot. Use
+# `echo` piped to xlings to get one shell command + exit.
+out_plain="$(echo 'echo NORMAL_MODE_$XLINGS_SUBOS_MODE; echo HOME=$HOME; exit' | \
+  ( cd /tmp && env -i HOME="$HOME" USER="$USER" SHELL=/bin/sh \
+      PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
+      timeout 10 "$XLINGS_BIN" subos use mybox ) 2>&1 || true)"
+echo "$out_plain" | grep -q "NORMAL_MODE_$" \
+  || fail "S10: XLINGS_SUBOS_MODE was set (expected unset for plain subos use):
+$out_plain"
+echo "$out_plain" | grep -q "HOME=$HOME" \
+  || fail "S10: \$HOME was changed (expected host \$HOME for plain use):
+$out_plain"
+log "  ✓ plain subos use: no XLINGS_SUBOS_MODE, host \$HOME preserved"
+
+# ── S11: subos remove cleans up everything (including sandbox dirs)
+log "S11: subos remove cleans up entirely"
 run_x subos remove mybox >/dev/null 2>&1 || true
-[[ ! -d "$HOME_DIR/subos/mybox" ]] || fail "S8: subos dir not removed"
+[[ ! -d "$HOME_DIR/subos/mybox" ]] || fail "S11: subos dir not removed"
 log "  ✓ sandbox subos removed cleanly"
 
-log "PASS: subos sandbox (Linux) — 8 scenarios"
+log "PASS: subos sandbox V4 (Linux) — 11 scenarios"
 
 else
 # ─────────────────────────────────────────────────────────────────────
-# macOS / Windows: --sandbox-shell must be rejected
+# macOS / Windows: --sandbox should be rejected
 # ─────────────────────────────────────────────────────────────────────
-log "non-Linux: --sandbox-shell rejected with clear hint"
-out="$(run_x subos new mybox --sandbox-shell xim:sh 2>&1 || true)"
-if ! echo "$out" | grep -q "only supported on Linux"; then
-  fail "expected 'only supported on Linux' error on $(uname -s), got:
+log "non-Linux: subos use --sandbox rejected with clear hint"
+mkdir -p "$HOME_DIR/subos/default/bin"
+run_x subos new mybox >/dev/null
+out="$(run_x subos use mybox --sandbox 2>&1 || true)"
+echo "$out" | grep -q "only supported on Linux" \
+  || fail "expected 'only supported on Linux' on $(uname -s), got:
 $out"
-fi
-[[ ! -d "$HOME_DIR/subos/mybox" ]] \
-  || fail "subos dir created despite the rejection"
-log "  ✓ rejected, no subos created"
-log "PASS: subos sandbox (non-Linux) — rejection path"
+log "  ✓ rejected on $(uname -s)"
+log "PASS: subos sandbox V4 (non-Linux) — rejection path"
 fi

--- a/tests/e2e/subos_sandbox_test.sh
+++ b/tests/e2e/subos_sandbox_test.sh
@@ -191,7 +191,14 @@ if curl -fsLo "$HOME_DIR/runtimedir/proot" \
      https://proot.gitlab.io/proot/bin/proot 2>/dev/null; then
   chmod +x "$HOME_DIR/runtimedir/proot"
   if [[ -x /bin/busybox ]] && file /bin/busybox 2>/dev/null | grep -q "statically linked"; then
-    out_inside="$(echo 'echo "I_AM_$(whoami)_UID_$(id -u)"; echo "PASSWD_FIRST=$(head -1 /etc/passwd)"; ls /xlings 2>/dev/null | head -3 | tr "\n" " "; echo "<-- /xlings"; exit' | \
+    # Inside-sandbox script:
+    #   1. fake-root identity (whoami / id)
+    #   2. /etc/passwd is our sandbox template (not host's)
+    #   3. /root is the SANDBOX'S /root (not host's) — write a marker
+    #      file and verify it lands in <sandbox>/root, not /root on host
+    #   4. /usr/bin host-bound tools work (uname is busybox here, but on
+    #      a real flow host /usr/bin/uname would be invoked)
+    out_inside="$(echo 'echo "I_AM_$(whoami)_UID_$(id -u)"; echo "PASSWD_FIRST=$(head -1 /etc/passwd)"; touch /root/.sandbox_marker_S6 && echo "ROOT_WRITE_OK"; ls /xlings 2>/dev/null | head -3 | tr "\n" " "; echo "<-- /xlings"; exit' | \
       ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
         timeout 10 "$XLINGS_BIN" subos use mybox ) 2>&1 || true)"
     echo "$out_inside" | grep -q "I_AM_root_UID_0" \
@@ -200,7 +207,14 @@ $out_inside"
     echo "$out_inside" | grep -q "PASSWD_FIRST=root:x:0:0:root:/root:/bin/sh" \
       || fail "S6: /etc/passwd inside sandbox is not our template:
 $out_inside"
-    log "  ✓ inside sandbox: whoami=root, /etc/passwd matches sandbox template"
+    echo "$out_inside" | grep -q "ROOT_WRITE_OK" \
+      || fail "S6: writing to /root inside sandbox failed (probably proot
+auto-bound host /root over sandbox /root — regression of 0.4.23 fix):
+$out_inside"
+    [[ -f "$HOME_DIR/subos/mybox/root/.sandbox_marker_S6" ]] \
+      || fail "S6: /root marker did not land in <sandbox>/root — probably
+proot is binding host /root over the sandbox /root again"
+    log "  ✓ sandbox: fake-root + sandbox /etc/passwd + sandbox /root writable"
   else
     log "  (skip: no static /bin/busybox to invoke as sandbox shell)"
   fi


### PR DESCRIPTION
## Summary

User-reported regression on 0.4.22 sandbox with `xim:fish`:

```
warning-path: Unable to locate data directory derived from $HOME: '/root/.local/share/fish'.
warning-path: The error was 'Permission denied (os error 13)'.
fish: Unknown command: mkdir
fish: Unknown command: uname
```

Two layered root causes — both fixed:

### Root cause 1 (the EACCES): proot `-R` auto-binds `$HOME`

proot manpage:
> `-R` is `-r` plus a couple of recommended `-b`. […] auto-binds: /etc/host.conf, /etc/hosts, …, /tmp/, /run/, **$HOME**

We `setenv("HOME", "/root")` before exec'ing proot so the shell sees a sandbox home. proot then reads `$HOME=/root` and binds **host's `/root`** (typically `drwx------ root:root`) over the sandbox's own `<subos>/root`. fish under proot `-0` fakes uid 0 in syscall returns, but the kernel enforces real perms with the real uid (`speak`), so writes to `/root` → EACCES against the *host* `/root`.

### Root cause 2: missing POSIX userland

`<sandbox>/bin` only contains the shell symlink. No `mkdir`, `uname`, `sh`, `ls`, etc. fish embedded `config.fish` fails on its first `mkdir -p`.

## Fix (`build_proot_argv_`)

1. **`-R` → `-r`** (bare chroot, no auto-binds — we already had explicit binds for the /etc/* templates we care about, so we don't lose anything; we gain control).
2. **Bind `/usr` from host** + `/usr/lib:/lib` + `/usr/lib64:/lib64` (covers usrmerge layout: Ubuntu 22+, Fedora, Arch, recent Debian).
3. **Bind `/etc/ld.so.cache`** so the linker doesn't scan every dir.
4. **Don't bind `$HOME`** — `/root` inside is now `<sandbox>/root` (sandbox-private, owned by real uid, writable).
5. **Don't bind `/tmp`** — sandbox now has truly private `/tmp` (matches sandbox semantics).

## Verified end-to-end (Ubuntu 24.04, xim:fish)

```
sandbox> mkdir -p /root/.config/myapp                  ✓
sandbox> ls /root/.config/                              # fish + myapp (sandbox-private)
sandbox> uname -a                                       # full host kernel via /usr/bin/uname
sandbox> cat /etc/passwd                                # only sandbox root entry
```

## Test plan

E2E `tests/e2e/subos_sandbox_test.sh` S6 strengthened with regression guards:

- [x] S1-S5: existing layout / templates / metadata / regular subos / proot probe
- [x] **S6**: enter sandbox → `touch /root/.sandbox_marker_S6` → exit → assert file landed in **`<sandbox>/root/`** (NOT host `/root/`). Catches re-introduction of `-R` or `$HOME` bind.
- [x] S7: lazy self-heal of shell symlink
- [x] S8: subos remove cleanup

8/8 local pass. CI exercises all 3 platforms (Linux is where it matters; macOS / Windows take the rejection path).