### PR TITLE
fix(0.4.24): sandbox install lands in correct subos + PATH finds it

### DIFF
--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -2,6 +2,32 @@
 
 ## 2026
 
+### 2026-05 (v0.4.24) — Sandbox V4 修关键 P0 bug:`xlings install` 进 sandbox 后实际"装到正确 subos"
+
+V4 (0.4.23) 出来后用户实测发现 install 看着成功但装的包根本不在 PATH 里。把现场拼起来,**根因不是 install 自己的 bug**,而是两个环境层面的设计漏洞:
+
+1. **`<subos>/.xlings.json` 被 xlings 项目发现误识别为 anonymous project root**
+   - 用户:`subos use tmp --sandbox` 后 `xlings install bwrap`,bwrap 落在 `<subos>/.xlings/subos/_/bin/`,不在 `<subos>/tmp/bin/`(PATH 找不到)。
+   - xlings 项目发现(`config.cppm load_project_config_`)从 cwd 向上 walk,找 `.xlings.json`。在 V4 sandbox 内,cwd = `/home/<user>`,walk 到 `/` 时找到 `/.xlings.json`(= `<subos>/.xlings.json`,subos workspace 文件)。
+   - 0.4.20 加的 xlings-home boundary check:目录同时含 `.xlings.json` AND `subos/` 子目录则视为 xlings home,不是 user project,**终止 walk**。
+   - V4 sandbox 的 `<subos>/` 含 `.xlings.json` 但**没有 `subos/` 子目录** → boundary check 失败 → 把 `/.xlings.json` 当成 anonymous project → `paths_.activeSubos = "_"` → 覆盖了 per-shell `XLINGS_ACTIVE_SUBOS=tmp` → 所有路径都歪了。
+   - **修复**:`init_sandbox_dirs_` 多加一行 `mkdir <subos>/subos/`(空目录,纯 marker)。inside sandbox 看到 `/.xlings.json` + `/subos/` → boundary 触发 → 不进入 project mode → activeSubos 用 env = "tmp" → install 路径正确。
+
+2. **PATH 不会自动包含 sandbox subos bin**
+   - V4 进 sandbox 时只设 `HOME / XLINGS_ACTIVE_SUBOS / XLINGS_SUBOS_MODE`,**没设 PATH**。bash 继承父进程(host xlings)PATH ── 包含 `/home/speak/.xlings/data/xpkgs/...`、`/home/speak/.xlings/subos/default/bin` 这种 host 路径,但**不**包含 `~/.xlings/subos/tmp/bin`(sandbox 当前 subos 的 bin)。
+   - 即使 install 落到正确位置,PATH 也找不到。
+   - **修复**:`use_sandbox_mode_` exec proot 前显式设 `PATH=$HOME/.xlings/subos/<name>/bin:$HOME/.xlings/bin:/usr/local/bin:/usr/bin:/bin`(per-subos bin 第一,xlings 全局 bin 第二,host POSIX 兜底)。
+   - 同时 `init_sandbox_dirs_` 在 `<subos>/home/<user>/` 写**最小 `.bashrc` / `.profile` / `.config/fish/config.fish`**,各自 source `~/.xlings/config/shell/xlings-profile.{sh,fish}`。交互式 shell 起来时 profile 被 source,XLINGS_SUBOS_MODE 被读到 → 提示符切成 `<xsubos:tmp>`(就是 0.4.23 标的 V4 区分符)。非交互 shell(`bash -c`、脚本)走显式 PATH 兜底。两条路都不漏。
+
+**用户报告里的"3 个 bug"实际是 2 个根因**(那条"`xlings install` 跟 per-shell 解耦"的判断**误诊**了 ── install 其实读 `XLINGS_ACTIVE_SUBOS` env 没问题,问题在 env 被项目发现给覆盖了,以及 PATH 不包含正确 subos bin)。
+
+E2E 加 3 个 regression 场景(11 → 14 scenarios):
+- **S11**:`<subos>/subos/` marker dir 必须存在(boundary check 锚)
+- **S12**:非交互 shell 进 sandbox PATH 第一段必须是 `<home>/.xlings/subos/<name>/bin`
+- **S13**:seeded `.bashrc` / `.profile` / `config.fish` 必须 chain 到 xlings profile
+
+改动量:`subos.cppm` ~50 行(init_sandbox_dirs_ 加 marker + rc seeding,use_sandbox_mode_ 加 PATH 设置),`subos_sandbox_test.sh` +30 行 regression。版本 0.4.23 → 0.4.24。
+
 ### 2026-05 (v0.4.23) — Sandbox V4 重设计 (BREAKING)
 
 - **`--sandbox` 是 `use` 的修饰符,不再是 subos 的 type** —— 一个 boolean flag。同一个 subos 可以选择带或不带 sandbox 隔离进入,正交两个维度。

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.23";
+    static constexpr std::string_view VERSION = "0.4.24";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -154,6 +154,32 @@ inline constexpr std::string_view kEtcHosts =
 inline constexpr std::string_view kEtcNsswitch =
     "hosts: files dns\npasswd: files\ngroup: files\n";
 
+// Minimal user shell rc files written into <subos>/home/<user>/ at
+// init. Without these, bash starts with no .bashrc / .profile (sandbox
+// $HOME is fresh empty dir, dotfile isolation by design) and never
+// sources the xlings profile — so the prompt pill is missing AND
+// PATH doesn't pick up the per-subos bin dir. We seed minimal rc
+// files that just chain into the host xlings profile; user can edit
+// these to add their own customizations later (they're sandbox-private
+// so they won't pollute host).
+inline constexpr std::string_view kSandboxBashrc =
+    "# xlings sandbox bashrc — chains to host xlings profile so PATH /\n"
+    "# prompt pill / XLINGS_BIN are set up. Edit this file to add your\n"
+    "# own customizations (it's sandbox-private at <subos>/home/<user>).\n"
+    "if [ -r \"$HOME/.xlings/config/shell/xlings-profile.sh\" ]; then\n"
+    "    . \"$HOME/.xlings/config/shell/xlings-profile.sh\"\n"
+    "fi\n";
+inline constexpr std::string_view kSandboxProfile =
+    "# xlings sandbox profile (sourced by sh / bash login shells)\n"
+    "if [ -r \"$HOME/.bashrc\" ]; then\n"
+    "    . \"$HOME/.bashrc\"\n"
+    "fi\n";
+inline constexpr std::string_view kSandboxFishConfig =
+    "# xlings sandbox fish config — chains to host xlings profile\n"
+    "if test -r \"$HOME/.xlings/config/shell/xlings-profile.fish\"\n"
+    "    source \"$HOME/.xlings/config/shell/xlings-profile.fish\"\n"
+    "end\n";
+
 // Initialize the sandbox-specific dirs / templates inside an existing
 // subos. Idempotent: only writes files that don't yet exist, so a
 // returning sandbox session won't clobber user customizations and a
@@ -162,10 +188,25 @@ void init_sandbox_dirs_(const fs::path& subos_dir,
                         const std::string& user,
                         uid_t uid, gid_t gid)
 {
-    fs::create_directories(subos_dir / "home" / user);
+    auto user_home = subos_dir / "home" / user;
+    fs::create_directories(user_home);
     fs::create_directories(subos_dir / "tmp");
     auto etc = subos_dir / "etc";
     fs::create_directories(etc);
+
+    // Empty `subos/` marker dir at sandbox root. xlings's project
+    // discovery walks cwd → / looking for `.xlings.json`; it stops at
+    // any dir that ALSO contains a `subos/` sibling (xlings-home
+    // boundary check, see config.cppm load_project_config_). Without
+    // this marker, the sandbox's own `<subos>/.xlings.json` (the
+    // workspace file, which appears at `/.xlings.json` inside the
+    // chroot) gets misinterpreted as an anonymous-project root, which
+    // OVERRIDES the per-shell XLINGS_ACTIVE_SUBOS=<name> and routes
+    // all install / shim / workspace paths into a phantom
+    // `<subos>/.xlings/subos/_/` tree disjoint from where PATH points.
+    // Empty `<subos>/subos/` ≈ "this is an xlings-managed dir, not a
+    // user project root" — boundary check terminates the walk.
+    fs::create_directories(subos_dir / "subos");
 
     auto try_write = [&](const fs::path& path, std::string_view body) {
         if (fs::exists(path)) return;
@@ -175,6 +216,14 @@ void init_sandbox_dirs_(const fs::path& subos_dir,
     try_write(etc / "group", make_etc_group_(user, gid));
     try_write(etc / "hosts", kEtcHosts);
     try_write(etc / "nsswitch.conf", kEtcNsswitch);
+
+    // Seed shell rc files so the xlings profile gets sourced (PATH +
+    // prompt pill). Sandbox-private; user can edit freely.
+    try_write(user_home / ".bashrc", kSandboxBashrc);
+    try_write(user_home / ".profile", kSandboxProfile);
+    auto fish_config_dir = user_home / ".config" / "fish";
+    fs::create_directories(fish_config_dir);
+    try_write(fish_config_dir / "config.fish", kSandboxFishConfig);
 }
 
 #endif // __linux__ / __APPLE__
@@ -649,12 +698,29 @@ int use_sandbox_mode_(const std::string& name, EventStream& stream) {
     std::cout.flush();
     std::cerr.flush();
 
-    // Set sandbox-friendly env before proot exec. The shell sources
-    // its profile, profile reads XLINGS_SUBOS_MODE and decorates PS1
-    // with `<xsubos:<name>>` instead of the default `[xsubos:<name>]`.
+    // Set sandbox-friendly env before proot exec.
+    //
+    // The shell sources its profile (via the seeded .bashrc / config.fish
+    // in <subos>/home/<user>/), profile reads XLINGS_SUBOS_MODE and
+    // decorates PS1 with `<xsubos:<name>>` instead of the default
+    // `[xsubos:<name>]`.
+    //
+    // PATH is set explicitly here as a defensive baseline: interactive
+    // shells will re-set it via the profile (which knows about
+    // XLINGS_ACTIVE_SUBOS), but non-interactive shells (`echo ... |
+    // bash`, scripts run with `bash -c`) skip rc files. Without this
+    // explicit set, those see whatever PATH the host xlings inherited
+    // — typically full of /home/speak/.xlings/data/xpkgs/... and host
+    // subos bin paths — none of which point inside the sandbox. The
+    // baseline below front-loads the per-subos bin and the xlings home
+    // bin so installed shims are reachable, then falls through to host
+    // /usr/bin etc. (visible via the /usr RO bind).
     platform::set_env_variable("XLINGS_ACTIVE_SUBOS", name);
     platform::set_env_variable("XLINGS_SUBOS_MODE", "sandbox");
     platform::set_env_variable("HOME", user_home);
+    platform::set_env_variable("PATH", std::format(
+        "{}/.xlings/subos/{}/bin:{}/.xlings/bin:/usr/local/bin:/usr/bin:/bin",
+        user_home, name, user_home));
 
     auto argv = sandbox_detail_::build_proot_argv_(
         *proot, subos_dir, p.homeDir, user, shell);

--- a/tests/e2e/subos_sandbox_test.sh
+++ b/tests/e2e/subos_sandbox_test.sh
@@ -198,13 +198,64 @@ echo "$out_plain" | grep -q "HOME=$HOME" \
 $out_plain"
 log "  ✓ plain subos use: no XLINGS_SUBOS_MODE, host \$HOME preserved"
 
-# ── S11: subos remove cleans up everything (including sandbox dirs)
-log "S11: subos remove cleans up entirely"
+# ── S11: empty <subos>/subos/ marker dir is created at sandbox init
+# Without this marker, `<subos>/.xlings.json` at the chroot root gets
+# treated as an anonymous-project root, which OVERRIDES per-shell
+# XLINGS_ACTIVE_SUBOS=mybox and routes install / shim / workspace
+# into <subos>/.xlings/subos/_/ instead of <subos>/. Symptom from
+# user side: `xlings install foo` reports success but the binary
+# isn't on PATH because shim went to the wrong dir.
+#
+# The fix is the empty marker: xlings's project discovery (config.cppm
+# load_project_config_) treats any dir containing both `.xlings.json`
+# AND a `subos/` sibling as an xlings home (boundary, NOT a project).
+# We seed an empty `<subos>/subos/` so the chroot root looks like an
+# xlings home from the project-discovery walk's POV.
+log "S11: <subos>/subos/ marker dir created (project-discovery boundary fix)"
+[[ -d "$HOME_DIR/subos/mybox/subos" ]] \
+  || fail "S11: <subos>/subos/ marker dir missing — boundary check
+won't fire, project discovery will misfire and override XLINGS_ACTIVE_SUBOS"
+log "  ✓ <subos>/subos/ marker exists"
+
+# ── S12: explicit PATH front-loads <subos>/bin (non-interactive defensive)
+# Interactive shells source the seeded .bashrc which sets PATH via the
+# xlings profile; non-interactive shells (`bash -c`, scripts) skip the
+# rc files. Both paths should still see the per-subos bin first because
+# we set PATH explicitly in env before exec proot.
+log "S12: PATH front-loads <subos>/bin even in non-interactive shell"
+out_path="$(echo 'echo "PATH:$PATH"; exit' | \
+  ( cd /tmp && env -i HOME="$HOME" USER="$USER" SHELL=/bin/sh \
+      PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
+      timeout 10 "$XLINGS_BIN" subos use mybox --sandbox ) 2>&1 || true)"
+echo "$out_path" | grep -q "PATH:/home/$USER/.xlings/subos/mybox/bin:" \
+  || fail "S12: PATH first segment is NOT <home>/.xlings/subos/mybox/bin:
+$out_path"
+log "  ✓ PATH starts with /home/$USER/.xlings/subos/mybox/bin"
+
+# ── S13: seeded shell rc files exist (interactive prompt-pill plumbing)
+# init_sandbox_dirs_ writes minimal .bashrc / .profile / config.fish
+# into <subos>/home/<user>/ that source the host xlings profile. Without
+# these, interactive sandbox sessions don't get PATH adjusted, prompt
+# pill never appears (XLINGS_SUBOS_MODE is set in env but the shell
+# never sources the profile that consumes it).
+log "S13: seeded shell rc files chain to host xlings profile"
+[[ -f "$HOME_DIR/subos/mybox/home/$USER/.bashrc" ]] \
+  || fail "S13: .bashrc not seeded"
+grep -q "xlings-profile.sh" "$HOME_DIR/subos/mybox/home/$USER/.bashrc" \
+  || fail "S13: .bashrc doesn't chain to xlings-profile.sh"
+[[ -f "$HOME_DIR/subos/mybox/home/$USER/.config/fish/config.fish" ]] \
+  || fail "S13: fish config.fish not seeded"
+grep -q "xlings-profile.fish" "$HOME_DIR/subos/mybox/home/$USER/.config/fish/config.fish" \
+  || fail "S13: config.fish doesn't chain to xlings-profile.fish"
+log "  ✓ .bashrc, .profile, .config/fish/config.fish all seeded"
+
+# ── S14: subos remove cleans up everything (including sandbox dirs)
+log "S14: subos remove cleans up entirely"
 run_x subos remove mybox >/dev/null 2>&1 || true
-[[ ! -d "$HOME_DIR/subos/mybox" ]] || fail "S11: subos dir not removed"
+[[ ! -d "$HOME_DIR/subos/mybox" ]] || fail "S14: subos dir not removed"
 log "  ✓ sandbox subos removed cleanly"
 
-log "PASS: subos sandbox V4 (Linux) — 11 scenarios"
+log "PASS: subos sandbox V4 (Linux) — 14 scenarios"
 
 else
 # ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

V4 sandbox (0.4.23) shipped with two layered environment-layer holes that combined into "install reports success but binary not on PATH":

### Bug 1: project discovery overrides `XLINGS_ACTIVE_SUBOS`

The 0.4.20 xlings-home boundary check requires both `.xlings.json` AND `subos/` sibling. V4 sandbox's chroot root has only `.xlings.json` (the workspace file at `<subos>/.xlings.json`), no `subos/` dir — so it gets misinterpreted as an anonymous-project root, which OVERRIDES `XLINGS_ACTIVE_SUBOS=mybox` and routes install/shim/workspace into `<subos>/.xlings/subos/_/` instead of `<subos>/bin/`.

**Fix**: `init_sandbox_dirs_` adds an empty `<subos>/subos/` marker dir. Inside sandbox `/` now has both `.xlings.json` and `subos/`, boundary check fires, project mode is skipped, `activeSubos` honors env again.

### Bug 2: PATH doesn't include `<subos>/bin`

V4 `use_sandbox_mode_` set `HOME` / `XLINGS_ACTIVE_SUBOS` / `XLINGS_SUBOS_MODE` but left PATH alone. bash inherits host xlings's PATH (host xpkgs paths, `subos/default/bin`) but NOT the sandbox subos's bin — so even when install lands correctly, PATH lookup misses.

**Fix**:
- Set PATH explicitly in `use_sandbox_mode_` before exec proot: `<home>/.xlings/subos/<name>/bin:<home>/.xlings/bin:/usr/local/bin:/usr/bin:/bin`. Defensive baseline that works even when shell skips rc files.
- `init_sandbox_dirs_` seeds minimal `.bashrc`, `.profile`, `.config/fish/config.fish` into `<subos>/home/<user>/` that chain to host xlings profile. Interactive shells re-derive PATH via the profile AND pick up `XLINGS_SUBOS_MODE=sandbox` → prompt pill switches to `<xsubos:<name>>` as designed.

## Note on the user's quoted analysis

User's analysis claimed `xlings install` is decoupled from per-shell `XLINGS_ACTIVE_SUBOS` — that was **misdiagnosed**. Install IS coupled (via `Config::paths().binDir`), but the env was being overridden by project mode (Bug 1), and PATH didn't reach the right bin (Bug 2). Shim creation was always going to the *path xlings believed was active* — which due to Bug 1 was `_`, not `mybox`.

## Verified end-to-end (Ubuntu 24.04)

```
sandbox$ xlings install bwrap -y --use
  ✓ bwrap -> 0.11.2
sandbox$ ls ~/.xlings/subos/tmp/bin/                     # bwrap is here ✓
bubblewrap  bwrap  xlings
sandbox$ cat ~/.xlings/subos/tmp/.xlings.json
{ "workspace": { "bwrap": {"active":"0.11.2","installed":["0.11.2"]}, ... }}
sandbox$ echo $PATH | head -c80
/home/speak/.xlings/subos/tmp/bin:/home/speak/.xlings/bin:/usr/local/bin:/usr/bin:
sandbox$ type bwrap
bwrap is /home/speak/.xlings/subos/tmp/bin/bwrap
sandbox$ bwrap --version
bubblewrap 0.11.2
```

## Test plan

E2E `tests/e2e/subos_sandbox_test.sh` extended 11 → 14:

- [x] S1-S10 (existing V4 scenarios, all still passing)
- [x] **S11**: `<subos>/subos/` marker dir created at sandbox init (boundary-check anchor)
- [x] **S12**: PATH first segment is `<home>/.xlings/subos/<name>/bin` even in non-interactive shell
- [x] **S13**: seeded `.bashrc` / `.profile` / `config.fish` all chain to xlings profile
- [x] S14 (was S11): subos remove cleans up

Local: 14/14 pass.