### PR TITLE
feat(0.4.28): sandbox cross-platform — macOS/Windows L2 HOME redirect

### DIFF
--- a/.agents/docs/sandbox-cross-platform-design.md
+++ b/.agents/docs/sandbox-cross-platform-design.md
@@ -1,0 +1,295 @@
+# Sandbox 跨平台设计:隔离级别 + Linux/macOS/Windows 统一方案
+
+**Status**: 实现中
+**Target**: 0.4.28
+**Depends on**: 0.4.27 (统一 bind 列表 + 双后端)
+
+## 一、隔离级别定义
+
+| 级别 | 名称 | 隔离范围 | 共享范围 | 典型应用 |
+|---|---|---|---|---|
+| L0 | 无隔离 | 无 | 全部 | 直接运行程序 |
+| L1 | Workspace | 工具版本 + PATH | $HOME、fs、网络 | `xlings subos use`(普通 use) |
+| L2 | Dotfile | $HOME + $TMPDIR + XDG dirs | fs 视图、网络、/etc | macOS/Windows `--sandbox` |
+| L3 | FS 视图 | $HOME + /tmp + /etc(部分) + 可见路径白名单 | 网络、kernel、PID | Linux `--sandbox`(proot/bwrap) |
+| L4 | Namespace | FS + PID + 网络(可选) | kernel | Flatpak / bwrap --unshare-* |
+| L5 | 容器 | FS + PID + 网络 + cgroup | kernel | Docker / Podman |
+| L6 | VM | 全部(独立 kernel) | 无 | VirtualBox / QEMU / WSL2 |
+
+### xlings 定位
+
+```
+xlings subos use <name>              → L1 (所有平台)
+xlings subos use <name> --sandbox    → L3 (Linux) / L2 (macOS/Windows)
+```
+
+L2 和 L3 的**用户体验一致**(同一命令、同一提示符 `<xsubos:name>`、同一 xlings 行为)。底层隔离程度不同,但对 dev 工作流(隔离 shell 配置、npm/cargo 缓存、IDE settings 等)效果等价。
+
+## 二、三平台 sandbox 实现对比
+
+### 2.1 机制对比
+
+| 维度 | Linux L3 (bwrap/proot) | macOS L2 (HOME 重定向) | Windows L2 (USERPROFILE 重定向) |
+|---|---|---|---|
+| 底层机制 | mount namespace / ptrace | 纯 env 变量 | 纯 env 变量 |
+| 工具依赖 | bwrap 或 proot | 无 | 无 |
+| $HOME 隔离 | ✅ bind mount | ✅ env 重定向 | ✅ env 重定向 |
+| /tmp 隔离 | ✅ bind mount | ✅ $TMPDIR 重定向 | ✅ %TEMP% 重定向 |
+| /etc 隔离 | ✅ 部分(passwd/group/hosts/nsswitch) | ❌ (macOS 用 Directory Services,无影响) | ❌ (Windows 不读 /etc) |
+| /bin /usr 可见 | ✅ 精准 bind | ✅ 天然(env 不改 PATH 结构) | ✅ 天然 |
+| 额外 sudo | bwrap 可能需要(Ubuntu 24+) | 不需要 | 不需要 |
+| 性能开销 | proot 30-50% / bwrap ~0% | ~0% | ~0% |
+
+### 2.2 隔离效果对比
+
+| 场景 | Linux L3 | macOS L2 | Windows L2 |
+|---|---|---|---|
+| `vim ~/.bashrc` 写到 sandbox | ✅ | ✅ | ✅ |
+| `npm install -g` 缓存隔离 | ✅ (~/.npm) | ✅ (~/.npm) | ✅ (%APPDATA%/npm) |
+| `cargo build` 缓存隔离 | ✅ (~/.cargo) | ✅ (~/.cargo) | ✅ (%USERPROFILE%/.cargo) |
+| fish/zsh/bash 配置隔离 | ✅ | ✅ | ✅ |
+| git config 隔离 | ✅ (~/.gitconfig) | ✅ | ✅ |
+| VSCode settings 隔离 | ✅ (~/.config/Code) | ✅ (~/Library/...) | ✅ (%APPDATA%/Code) |
+| `/etc/passwd` 隔离 | ✅ sandbox 模板 | ❌ (无影响) | ❌ (无影响) |
+| `/tmp` 隔离 | ✅ | ✅ | ✅ |
+| `ls /etc/hostname` 隐藏 | ✅ | ❌ (可见) | ❌ (无此文件) |
+| `ps aux` 看到 host 进程 | ✅ (可见) | ✅ (可见) | ✅ (可见) |
+
+**核心 dev 场景(dotfile + 缓存隔离)三平台效果一致。**
+
+## 三、macOS 实现方案
+
+### 3.1 env 重定向列表
+
+```cpp
+// macOS sandbox env overrides
+platform::set_env_variable("HOME", sandbox_home);
+platform::set_env_variable("TMPDIR", sandbox_tmp);
+// XDG (respected by many CLI tools even on macOS)
+platform::set_env_variable("XDG_CONFIG_HOME", sandbox_home + "/.config");
+platform::set_env_variable("XDG_DATA_HOME", sandbox_home + "/.local/share");
+platform::set_env_variable("XDG_CACHE_HOME", sandbox_home + "/.cache");
+platform::set_env_variable("XDG_STATE_HOME", sandbox_home + "/.local/state");
+```
+
+### 3.2 macOS 特有路径
+
+macOS 应用常用 `~/Library/` 而非 XDG:
+
+```
+~/Library/Application Support/  → 应用数据
+~/Library/Preferences/          → plist 配置
+~/Library/Caches/               → 缓存
+```
+
+`HOME` 重定向会自动覆盖这些(因为 `~/Library` = `$HOME/Library`)。✅
+
+### 3.3 exec 方式
+
+跟普通 `subos use` 一样:exec `$SHELL -i`。不需要 proot/bwrap。
+
+```cpp
+// macOS/Windows sandbox: 跟 use_spawn_shell 几乎一样,
+// 只是多设了 HOME/TMPDIR/XDG env
+::execl(shell.c_str(), shell.c_str(), "-i", nullptr);
+```
+
+## 四、Windows 实现方案
+
+### 4.1 env 重定向列表
+
+```cpp
+// Windows sandbox env overrides
+platform::set_env_variable("USERPROFILE", sandbox_home);
+platform::set_env_variable("APPDATA", sandbox_home + "\\AppData\\Roaming");
+platform::set_env_variable("LOCALAPPDATA", sandbox_home + "\\AppData\\Local");
+platform::set_env_variable("TEMP", sandbox_tmp);
+platform::set_env_variable("TMP", sandbox_tmp);
+// XDG (Git for Windows, cargo, npm respect these)
+platform::set_env_variable("XDG_CONFIG_HOME", sandbox_home + "\\.config");
+platform::set_env_variable("XDG_DATA_HOME", sandbox_home + "\\.local\\share");
+platform::set_env_variable("XDG_CACHE_HOME", sandbox_home + "\\.cache");
+```
+
+### 4.2 Windows 特有目录
+
+sandbox_home 下需预建:
+
+```
+<subos>/home/<user>/
+  AppData/
+    Roaming/    → %APPDATA%
+    Local/      → %LOCALAPPDATA%
+```
+
+### 4.3 exec 方式
+
+Windows 已有 CreateProcess 路径(现有 `use_spawn_shell` 的 Windows 分支):
+
+```cpp
+// 现有代码: CreateProcess + WaitForSingleObject
+// 只需在 CreateProcess 前多设几个 env
+```
+
+## 五、代码结构(统一 use_sandbox_mode_)
+
+```cpp
+int use_sandbox_mode_(const std::string& name, EventStream& stream,
+                      const std::string& preferred_backend = "") {
+    // ... validate, nesting check ...
+    
+    auto user_home = sandbox_user_home_(user);  // /home/<user> (POSIX) or C:\...\<user> (Win)
+    auto sandbox_home = (subos_dir / "home" / user).string();
+    auto sandbox_tmp = (subos_dir / "tmp").string();
+    
+    // ── Lazy init ──
+    init_sandbox_dirs_(subos_dir, user, ...);
+    
+    // ── Env (unified, all platforms) ──
+    platform::set_env_variable("XLINGS_ACTIVE_SUBOS", name);
+    platform::set_env_variable("XLINGS_SUBOS_MODE", "sandbox");
+    
+#if defined(__linux__)
+    // L3: FS 视图隔离 (bwrap/proot)
+    auto backend = detect/select backend...
+    set_linux_sandbox_env_(name, user_home, sandbox_home, sandbox_tmp);
+    auto argv = build_xxx_argv_(...);
+    execvp(...);
+    
+#elif defined(__APPLE__)
+    // L2: HOME 重定向
+    set_macos_sandbox_env_(sandbox_home, sandbox_tmp);
+    exec_shell_(shell);
+    
+#elif defined(_WIN32)
+    // L2: USERPROFILE 重定向
+    set_windows_sandbox_env_(sandbox_home, sandbox_tmp);
+    create_process_shell_();
+    
+#endif
+}
+```
+
+### 各平台 env helper
+
+```cpp
+void set_linux_sandbox_env_(const std::string& name,
+                            const std::string& user_home,
+                            const std::string& sandbox_home,
+                            const std::string& sandbox_tmp) {
+    platform::set_env_variable("HOME", user_home);
+    platform::set_env_variable("PATH", std::format(
+        "{}/.xlings/subos/{}/bin:{}/.xlings/bin:/usr/local/bin:/usr/bin:/bin",
+        user_home, name, user_home));
+}
+
+void set_macos_sandbox_env_(const std::string& sandbox_home,
+                            const std::string& sandbox_tmp) {
+    platform::set_env_variable("HOME", sandbox_home);
+    platform::set_env_variable("TMPDIR", sandbox_tmp);
+    platform::set_env_variable("XDG_CONFIG_HOME", sandbox_home + "/.config");
+    platform::set_env_variable("XDG_DATA_HOME", sandbox_home + "/.local/share");
+    platform::set_env_variable("XDG_CACHE_HOME", sandbox_home + "/.cache");
+    platform::set_env_variable("XDG_STATE_HOME", sandbox_home + "/.local/state");
+}
+
+void set_windows_sandbox_env_(const std::string& sandbox_home,
+                              const std::string& sandbox_tmp) {
+    platform::set_env_variable("USERPROFILE", sandbox_home);
+    platform::set_env_variable("APPDATA", sandbox_home + "\\AppData\\Roaming");
+    platform::set_env_variable("LOCALAPPDATA", sandbox_home + "\\AppData\\Local");
+    platform::set_env_variable("TEMP", sandbox_tmp);
+    platform::set_env_variable("TMP", sandbox_tmp);
+    platform::set_env_variable("XDG_CONFIG_HOME", sandbox_home + "\\.config");
+    platform::set_env_variable("XDG_DATA_HOME", sandbox_home + "\\.local\\share");
+    platform::set_env_variable("XDG_CACHE_HOME", sandbox_home + "\\.cache");
+}
+```
+
+## 六、init_sandbox_dirs_ 跨平台
+
+```cpp
+void init_sandbox_dirs_(const fs::path& subos_dir,
+                        const std::string& user, ...) {
+    auto user_home = subos_dir / "home" / user;
+    fs::create_directories(user_home);
+    fs::create_directories(subos_dir / "tmp");
+    
+#if defined(__linux__)
+    // /etc templates (L3 需要)
+    auto etc = subos_dir / "etc";
+    fs::create_directories(etc);
+    // passwd, group, hosts, nsswitch.conf ...
+    // subos/ marker dir ...
+    
+    // seed .bashrc / .profile / config.fish
+    seed_shell_rc_files_(user_home);
+    
+#elif defined(__APPLE__)
+    // macOS: seed shell rc
+    seed_shell_rc_files_(user_home);
+    // 不需要 /etc templates
+    
+#elif defined(_WIN32)
+    // Windows: AppData 目录结构
+    fs::create_directories(user_home / "AppData" / "Roaming");
+    fs::create_directories(user_home / "AppData" / "Local");
+    // 不需要 /etc, 不需要 .bashrc (pwsh 有 $PROFILE)
+#endif
+}
+```
+
+## 七、提示符(跨平台统一)
+
+所有平台 `--sandbox` 都显示 `<xsubos:name>`:
+
+- bash/zsh/fish: profile_resources.cppm 已有(读 `XLINGS_SUBOS_MODE=sandbox` → `<>` 括号)
+- pwsh: profile_resources.cppm 已有
+
+**零额外改动。** macOS/Windows 的 `use_sandbox_mode_` 只要设了 `XLINGS_SUBOS_MODE=sandbox`,profile 自动切括号。
+
+## 八、E2E 测试
+
+### Linux (已有, 15 scenarios)
+
+S1-S15 全保留,涵盖 bwrap/proot 自动检测 + FS 隔离验证。
+
+### macOS (新增)
+
+```
+SM1: subos use --sandbox 不报错(不再 reject)
+SM2: $HOME 指向 <subos>/home/<user> (sandbox 私有)
+SM3: dotfile 写隔离(sandbox 内 touch ~/.test,host 看不到)
+SM4: $TMPDIR 隔离
+SM5: XLINGS_SUBOS_MODE=sandbox 设置正确
+SM6: xlings install/list 正常(xlings home 共享)
+SM7: exit 后 host $HOME 不变
+```
+
+### Windows (新增)
+
+```
+SW1: subos use --sandbox 不报错
+SW2: %USERPROFILE% 指向 sandbox home
+SW3: %APPDATA% / %LOCALAPPDATA% 指向 sandbox
+SW4: %TEMP% 隔离
+SW5: XLINGS_SUBOS_MODE=sandbox
+SW6: xlings install/list 正常
+SW7: exit 后 host %USERPROFILE% 不变
+```
+
+## 九、改动量估算
+
+| 文件 | Linux | macOS | Windows |
+|---|---|---|---|
+| `src/core/subos.cppm` | 不变 | +30 LOC(env helper + exec) | +30 LOC(env helper + CreateProcess) |
+| `init_sandbox_dirs_` | 不变 | +5 LOC(seed rc) | +10 LOC(AppData dirs) |
+| `tests/e2e/subos_sandbox_test.sh` | 不变 | +30 LOC(SM1-SM7) | +30 LOC(SW1-SW7,PowerShell) |
+| **总计** | **0** | **~65 LOC** | **~70 LOC** |
+
+## 十、不在本设计内
+
+- L4+ 隔离(namespace/容器/VM)
+- WSL2 集成(从 Windows host 透明进 WSL2 sandbox)
+- Lima/Colima 集成(macOS 上 Linux VM sandbox)
+- `--sandbox --no-net`(网络隔离,Linux-only,bwrap `--unshare-net`)

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.27";
+    static constexpr std::string_view VERSION = "0.4.28";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -770,16 +770,6 @@ int auto_install_backend_(const fs::path& home_dir, EventStream& stream) {
 // See .agents/docs/sandbox-v5-dual-backend-design.md for full design.
 int use_sandbox_mode_(const std::string& name, EventStream& stream,
                       const std::string& preferred_backend = "") {
-#if !defined(__linux__)
-    stream.emit(ErrorEvent{
-        .code = ErrorCode::InvalidInput,
-        .message = "sandbox mode (`subos use --sandbox`) is only supported "
-                   "on Linux (current: " + std::string(platform::OS_NAME) + ")",
-        .recoverable = false,
-        .hint = "drop --sandbox to use the regular env-spawn shell mode",
-    });
-    return 1;
-#else
     if (auto rc = use_detail_::validate_subos_(name, stream); rc != 0) return rc;
 
     // Refuse nested sandbox entry.
@@ -796,7 +786,77 @@ int use_sandbox_mode_(const std::string& name, EventStream& stream,
     auto& p = Config::paths();
     auto subos_dir = p.homeDir / "subos" / name;
 
-    // ── Backend selection ──
+    // ── Resolve user ──
+#if defined(_WIN32)
+    auto user = utils::get_env_or_default("USERNAME");
+    if (user.empty()) user = "user";
+#else
+    auto user = utils::get_env_or_default("USER");
+    if (user.empty()) user = "user";
+#endif
+
+    auto sandbox_home = (subos_dir / "home" / user).string();
+    auto sandbox_tmp = (subos_dir / "tmp").string();
+
+    // ── Lazy init sandbox dirs ──
+    fs::create_directories(subos_dir / "home" / user);
+    fs::create_directories(subos_dir / "tmp");
+
+#if defined(__linux__) || defined(__APPLE__)
+    // Seed shell rc files so profile is sourced (prompt pill + PATH)
+    {
+        auto user_home_dir = subos_dir / "home" / user;
+        auto try_write = [](const fs::path& path, std::string_view body) {
+            if (fs::exists(path)) return;
+            platform::write_string_to_file(path.string(), std::string(body));
+        };
+        try_write(user_home_dir / ".bashrc",
+            "# xlings sandbox bashrc\n"
+            "if [ -r \"$HOME/.xlings/config/shell/xlings-profile.sh\" ]; then\n"
+            "    . \"$HOME/.xlings/config/shell/xlings-profile.sh\"\n"
+            "fi\n");
+        try_write(user_home_dir / ".profile",
+            "# xlings sandbox profile\n"
+            "if [ -r \"$HOME/.bashrc\" ]; then . \"$HOME/.bashrc\"; fi\n");
+        auto fish_dir = user_home_dir / ".config" / "fish";
+        fs::create_directories(fish_dir);
+        try_write(fish_dir / "config.fish",
+            "# xlings sandbox fish config\n"
+            "if test -r \"$HOME/.xlings/config/shell/xlings-profile.fish\"\n"
+            "    source \"$HOME/.xlings/config/shell/xlings-profile.fish\"\n"
+            "end\n");
+        try_write(user_home_dir / ".zshrc",
+            "# xlings sandbox zshrc\n"
+            "if [ -r \"$HOME/.xlings/config/shell/xlings-profile.sh\" ]; then\n"
+            "    . \"$HOME/.xlings/config/shell/xlings-profile.sh\"\n"
+            "fi\n");
+    }
+#endif
+
+    // ── Common env (all platforms) ──
+    platform::set_env_variable("XLINGS_ACTIVE_SUBOS", name);
+    platform::set_env_variable("XLINGS_SUBOS_MODE", "sandbox");
+
+    nlohmann::json payload;
+    payload["name"] = name;
+    payload["mode"] = "sandbox";
+
+    std::cout.flush();
+    std::cerr.flush();
+
+#if defined(__linux__)
+    // ═══════════════════════════════════════════════════════════════
+    // Linux L3: FS view isolation via bwrap/proot
+    // ═══════════════════════════════════════════════════════════════
+
+    // /etc templates for Linux sandbox (NSS)
+    {
+        auto uid = ::getuid();
+        auto gid = ::getgid();
+        sandbox_detail_::init_sandbox_dirs_(subos_dir, user, uid, gid);
+    }
+
+    // Backend selection
     using sandbox_detail_::SandboxBackend;
     using sandbox_detail_::BackendInfo;
     std::optional<BackendInfo> backend;
@@ -826,7 +886,6 @@ int use_sandbox_mode_(const std::string& name, EventStream& stream,
         }
         backend = BackendInfo{ SandboxBackend::Proot, *bin };
     } else {
-        // Auto-detect: bwrap preferred, proot fallback
         backend = sandbox_detail_::detect_backend_(p.homeDir, subos_dir);
         if (!backend) {
             auto rc = sandbox_detail_::auto_install_backend_(p.homeDir, stream);
@@ -854,43 +913,19 @@ int use_sandbox_mode_(const std::string& name, EventStream& stream,
     auto backend_name = (backend->type == SandboxBackend::Bwrap) ? "bwrap" : "proot";
     log::debug("sandbox backend: {}", backend_name);
 
-    // ── Resolve user identity ──
-    auto user = utils::get_env_or_default("USER");
-    if (user.empty()) user = "user";
-    auto uid = ::getuid();
-    auto gid = ::getgid();
-
-    // ── Lazy init sandbox dirs ──
-    sandbox_detail_::init_sandbox_dirs_(subos_dir, user, uid, gid);
-
     auto user_home = "/home/" + user;
     auto shell = utils::get_env_or_default("SHELL");
     if (shell.empty()) shell = "/bin/sh";
 
-    // Both backends bind /bin from host (proot: --bind=/bin:/bin;
-    // bwrap: --ro-bind /bin /bin), so /bin/bash etc. resolve natively.
-    // No shell path translation needed.
-
-    // ── Event ──
-    nlohmann::json payload;
-    payload["name"] = name;
-    payload["mode"] = "sandbox";
     payload["backend"] = backend_name;
     payload["shell"] = shell;
     stream.emit(DataEvent{"subos_entering", payload.dump()});
 
-    std::cout.flush();
-    std::cerr.flush();
-
-    // ── Env (unified, backend-independent) ──
-    platform::set_env_variable("XLINGS_ACTIVE_SUBOS", name);
-    platform::set_env_variable("XLINGS_SUBOS_MODE", "sandbox");
     platform::set_env_variable("HOME", user_home);
     platform::set_env_variable("PATH", std::format(
         "{}/.xlings/subos/{}/bin:{}/.xlings/bin:/usr/local/bin:/usr/bin:/bin",
         user_home, name, user_home));
 
-    // ── Build argv ──
     std::vector<std::string> argv;
     if (backend->type == SandboxBackend::Bwrap) {
         argv = sandbox_detail_::build_bwrap_argv_(
@@ -900,7 +935,6 @@ int use_sandbox_mode_(const std::string& name, EventStream& stream,
             backend->binary, subos_dir, p.homeDir, user, shell);
     }
 
-    // ── Exec ──
     std::vector<char*> c_argv;
     c_argv.reserve(argv.size() + 1);
     for (auto& s : argv) c_argv.push_back(const_cast<char*>(s.c_str()));
@@ -909,6 +943,70 @@ int use_sandbox_mode_(const std::string& name, EventStream& stream,
     ::execvp(c_argv[0], c_argv.data());
     log::error("failed to exec {} '{}': {}", backend_name,
                backend->binary.string(), std::strerror(errno));
+    return 127;
+
+#elif defined(__APPLE__)
+    // ═══════════════════════════════════════════════════════════════
+    // macOS L2: HOME redirect (dotfile isolation)
+    // ═══════════════════════════════════════════════════════════════
+
+    auto shell = utils::get_env_or_default("SHELL");
+    if (shell.empty()) shell = "/bin/zsh";  // macOS default
+
+    payload["backend"] = "home-redirect";
+    payload["shell"] = shell;
+    stream.emit(DataEvent{"subos_entering", payload.dump()});
+
+    platform::set_env_variable("HOME", sandbox_home);
+    platform::set_env_variable("TMPDIR", sandbox_tmp);
+    platform::set_env_variable("XDG_CONFIG_HOME", sandbox_home + "/.config");
+    platform::set_env_variable("XDG_DATA_HOME", sandbox_home + "/.local/share");
+    platform::set_env_variable("XDG_CACHE_HOME", sandbox_home + "/.cache");
+    platform::set_env_variable("XDG_STATE_HOME", sandbox_home + "/.local/state");
+
+    ::execl(shell.c_str(), shell.c_str(), "-i", static_cast<char*>(nullptr));
+    log::error("failed to exec shell '{}': {}", shell, std::strerror(errno));
+    return 127;
+
+#elif defined(_WIN32)
+    // ═══════════════════════════════════════════════════════════════
+    // Windows L2: USERPROFILE redirect (dotfile isolation)
+    // ═══════════════════════════════════════════════════════════════
+
+    // Pre-create AppData structure
+    fs::create_directories(fs::path(sandbox_home) / "AppData" / "Roaming");
+    fs::create_directories(fs::path(sandbox_home) / "AppData" / "Local");
+
+    payload["backend"] = "home-redirect";
+    stream.emit(DataEvent{"subos_entering", payload.dump()});
+
+    platform::set_env_variable("USERPROFILE", sandbox_home);
+    platform::set_env_variable("APPDATA", sandbox_home + "\\AppData\\Roaming");
+    platform::set_env_variable("LOCALAPPDATA", sandbox_home + "\\AppData\\Local");
+    platform::set_env_variable("TEMP", sandbox_tmp);
+    platform::set_env_variable("TMP", sandbox_tmp);
+    platform::set_env_variable("XDG_CONFIG_HOME", sandbox_home + "\\.config");
+    platform::set_env_variable("XDG_DATA_HOME", sandbox_home + "\\.local\\share");
+    platform::set_env_variable("XDG_CACHE_HOME", sandbox_home + "\\.cache");
+
+    // Windows: CreateProcess + WaitForSingleObject (same as use_spawn_shell)
+    constexpr const char* shells[] = { "pwsh.exe", "powershell.exe", "cmd.exe" };
+    for (auto* exe : shells) {
+        STARTUPINFOA si{};
+        si.cb = sizeof(si);
+        PROCESS_INFORMATION pi{};
+        std::string cmdline = exe;
+        if (::CreateProcessA(nullptr, cmdline.data(), nullptr, nullptr,
+                             TRUE, 0, nullptr, nullptr, &si, &pi)) {
+            ::WaitForSingleObject(pi.hProcess, INFINITE);
+            DWORD exitCode = 0;
+            ::GetExitCodeProcess(pi.hProcess, &exitCode);
+            ::CloseHandle(pi.hThread);
+            ::CloseHandle(pi.hProcess);
+            return static_cast<int>(exitCode);
+        }
+    }
+    log::error("could not launch any shell on Windows");
     return 127;
 #endif
 }

--- a/tests/e2e/subos_sandbox_test.sh
+++ b/tests/e2e/subos_sandbox_test.sh
@@ -282,15 +282,49 @@ log "PASS: subos sandbox V5 (Linux) — 15 scenarios"
 
 else
 # ─────────────────────────────────────────────────────────────────────
-# macOS / Windows: --sandbox should be rejected
+# macOS / Windows: L2 sandbox (HOME redirect, no FS isolation)
 # ─────────────────────────────────────────────────────────────────────
-log "non-Linux: subos use --sandbox rejected with clear hint"
+log "non-Linux ($(uname -s)): L2 sandbox via HOME redirect"
 mkdir -p "$HOME_DIR/subos/default/bin"
 run_x subos new mybox >/dev/null
-out="$(run_x subos use mybox --sandbox 2>&1 || true)"
-echo "$out" | grep -q "only supported on Linux" \
-  || fail "expected 'only supported on Linux' on $(uname -s), got:
+
+# SM1: --sandbox should NOT be rejected anymore (cross-platform L2)
+log "SM1: subos use --sandbox enters (not rejected)"
+out="$(echo 'echo SANDBOX_L2_OK; echo HOME=$HOME; echo XLINGS_SUBOS_MODE=$XLINGS_SUBOS_MODE; exit' | \
+  ( cd /tmp && env -i HOME="$HOME" USER="${USER:-$(whoami)}" SHELL=/bin/sh \
+      PATH=/usr/bin:/bin:/usr/local/bin XLINGS_HOME="$HOME_DIR" \
+      timeout 10 "$XLINGS_BIN" subos use mybox --sandbox ) 2>&1 || true)"
+echo "$out" | grep -q "SANDBOX_L2_OK" \
+  || fail "SM1: sandbox didn't enter on $(uname -s):
 $out"
-log "  ✓ rejected on $(uname -s)"
-log "PASS: subos sandbox V5 (non-Linux) — rejection path"
+log "  ✓ sandbox entered on $(uname -s)"
+
+# SM2: HOME points to sandbox-private dir
+echo "$out" | grep -q "HOME=.*subos/mybox/home" \
+  || fail "SM2: HOME not redirected to sandbox dir:
+$out"
+log "  ✓ HOME redirected to sandbox home"
+
+# SM3: XLINGS_SUBOS_MODE=sandbox set
+echo "$out" | grep -q "XLINGS_SUBOS_MODE=sandbox" \
+  || fail "SM3: XLINGS_SUBOS_MODE not set:
+$out"
+log "  ✓ XLINGS_SUBOS_MODE=sandbox"
+
+# SM4: dotfile isolation — write inside, host unaffected
+marker_file="$HOME/.xlings-sandbox-sm4-marker-$$"
+echo "echo test > '$marker_file'; exit" | \
+  ( cd /tmp && env -i HOME="$HOME" USER="${USER:-$(whoami)}" SHELL=/bin/sh \
+      PATH=/usr/bin:/bin:/usr/local/bin XLINGS_HOME="$HOME_DIR" \
+      timeout 10 "$XLINGS_BIN" subos use mybox --sandbox ) >/dev/null 2>&1 || true
+[[ ! -e "$marker_file" ]] \
+  || fail "SM4: sandbox write leaked to host!"
+log "  ✓ dotfile isolation (host \$HOME clean)"
+
+# SM5: subos remove works
+run_x subos remove mybox >/dev/null 2>&1 || true
+[[ ! -d "$HOME_DIR/subos/mybox" ]] || fail "SM5: subos dir not removed"
+log "  ✓ subos removed cleanly"
+
+log "PASS: subos sandbox ($(uname -s)) — 5 scenarios (L2 HOME redirect)"
 fi


### PR DESCRIPTION
## Summary

`--sandbox` now works on all 3 platforms:

| Platform | Isolation | Mechanism |
|---|---|---|
| Linux | L3 (FS view) | bwrap/proot (unchanged) |
| **macOS** | **L2 (dotfile)** | **HOME + TMPDIR + XDG redirect (NEW)** |
| **Windows** | **L2 (dotfile)** | **USERPROFILE + APPDATA + TEMP redirect (NEW)** |

Previously macOS/Windows rejected `--sandbox`. Now they use pure env redirect — zero tool dependencies.

Same command, same prompt `<xsubos:name>`, same dotfile isolation across all platforms.

## Test plan

- Linux: existing 15 scenarios (S1-S15)
- macOS/Windows (NEW): 5 L2 scenarios (SM1-SM5):
  - SM1: sandbox enters (not rejected)
  - SM2: HOME redirected to sandbox dir
  - SM3: XLINGS_SUBOS_MODE=sandbox set
  - SM4: dotfile isolation (host $HOME clean)
  - SM5: subos remove