### PR TITLE
feat: wire libxpkg fs module + pkgindex custom module loading

### DIFF
--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -1071,6 +1071,11 @@ public:
             ctx.xpkg_dir = node.pkgFile.parent_path();
             ctx.project_data_dir = Config::project_data_dir();
             ctx.subos_sysrootdir = Config::paths().subosDir.string();
+            // pkgindex_dir: package index repo root (for custom module loading).
+            // pkgFile layout: <pkgindex>/pkgs/<letter>/<name>.lua → 3 levels up.
+            ctx.pkgindex_dir = node.pkgFile.parent_path()
+                                           .parent_path()
+                                           .parent_path().string();
             ctx.deps_list = node.deps;                  // legacy union (compat)
             ctx.runtime_deps_list = node.runtime_deps;  // split form
             ctx.build_deps_list   = node.build_deps;
@@ -1514,6 +1519,9 @@ public:
         ctx.install_dir = installDir;
         ctx.xpkg_dir = pkgFile.parent_path();
         ctx.subos_sysrootdir = Config::paths().subosDir.string();
+        ctx.pkgindex_dir = pkgFile.parent_path()
+                                  .parent_path()
+                                  .parent_path().string();
 
         if (executor.has_hook(mcpplibs::xpkg::HookType::Uninstall)) {
             log::debug("uninstalling {}...", name);

--- a/xmake.lua
+++ b/xmake.lua
@@ -42,7 +42,7 @@ add_requires("mcpplibs-capi-lua")
 if has_config("local_libxpkg") and get_config("local_libxpkg") ~= "" then
     includes(path.join(get_config("local_libxpkg"), "xmake.lua"))
 else
-    add_requires("mcpplibs-xpkg 0.0.38")
+    add_requires("mcpplibs-xpkg 0.0.40")
 end
 add_requires("gtest 1.15.2")
 add_requires("mcpplibs-tinyhttps 0.2.0")


### PR DESCRIPTION
## Summary
- Bump `mcpplibs-xpkg` from 0.0.38 to 0.0.40
- Wire `pkgindex_dir` in installer for both install and uninstall paths

## What's in libxpkg 0.0.40
- **fs module** (`import("xim.libxpkg.fs")`): `fs.symlink`, `fs.readlink`, `fs.is_symlink`, `fs.entries`, `fs.files`, `fs.dirs`, `fs.copy_file`, `fs.mkdir_p`, `fs.remove`, `fs.remove_all` — all backed by `std::filesystem`, no shell commands
- **pkgindex custom module loading** (`import("xim.pkgindex.xxx")`): loads `.lua` modules from `<pkgindex>/libs/` directory with caching, works at both top-level and inside hook functions

## Motivation
Fixes proot sandbox `Permission denied` when packages use `cp -r` for header installation. Package scripts can now use `fs.symlink` or define shared sysroot helpers in pkgindex `libs/`.

## Test plan
- [x] libxpkg: 35/35 tests pass (8 new for fs + pkgindex modules)
- [x] xlings: builds with `--local_libxpkg` against updated libxpkg