### PR TITLE
feat: add semver module for unified version handling

### DIFF
--- a/.agents/docs/semver-module-design.md
+++ b/.agents/docs/semver-module-design.md
@@ -1,0 +1,200 @@
+# xlings 语义化版本模块设计方案
+
+> 日期: 2026-05-12
+> 状态: 实施中
+
+## 一、问题
+
+版本处理散落在 6+ 个文件中，存在三套不同的比较逻辑：
+
+| 位置 | 比较方式 | 问题 |
+|------|---------|------|
+| `catalog.cppm:select_version_()` | 字典序 `ver > best` | `"9.0" > "15.0"` 结果错误 |
+| `db.cppm:pick_highest_version()` | 按 `.` 拆分数值比较 | 正确但重复实现 |
+| `commands.cppm:cmd_use()` | 按 `.` 拆分数值比较 | 与 db.cppm 重复 |
+| `resolver.cppm` | 字典序 | 同 catalog 问题 |
+
+且不支持任何版本范围表达式（`>=`、`^`、`~`）。
+
+## 二、目标
+
+1. 新增 `xlings::semver` 模块，统一版本解析、比较、匹配
+2. 支持核心 semver range 语法（对齐 npm/Cargo 规范）
+3. 替换用户面对的版本处理代码，使用统一接口
+
+## 三、作用域
+
+### semver 模块处理的（用户面对的版本号）
+
+- xpm 中定义的包版本: `"15.1.0"`, `"2.39"`, `"2026.5.7"`
+- 用户 CLI 输入: `pkg@15`, `pkg@^15.1.0`, `pkg@>=22.0`
+- .xlings.json workspace 中的版本约束: `"^15.1.0"`, `">=2.0"`
+- 依赖解析时的版本选择
+
+### semver 模块不处理的（xvm 内部版本键）
+
+- xvm 注册版本键: `"gcc-15.1.0"`, `"glibc-2.39"`, `"node-24.15.0"`
+- 这些是不透明的绑定标签，格式由包脚本作者决定，无规范
+- 保持现有的精确匹配 + 前缀匹配逻辑，不走 semver
+- `db.cppm` 中的 `match_version()` 和 `pick_highest_version()` 不改造
+
+## 四、支持的语法
+
+```
+精确:     1.2.3          → == 1.2.3
+前缀:     15             → >= 15.0.0 && < 16.0.0（现有行为保留）
+          15.1           → >= 15.1.0 && < 15.2.0
+范围:     >=1.2.0        → >= 1.2.0
+          >1.0.0         → > 1.0.0
+          <=2.0.0        → <= 2.0.0
+          <3.0.0         → < 3.0.0
+兼容:     ^1.2.3         → >= 1.2.3 && < 2.0.0（同主版本）
+          ^0.2.3         → >= 0.2.3 && < 0.3.0（主版本为0时锁次版本）
+近似:     ~1.2.3         → >= 1.2.3 && < 1.3.0（同主+次版本）
+通配:     1.2.*          → >= 1.2.0 && < 1.3.0
+          1.*            → >= 1.0.0 && < 2.0.0
+区间:     >=1.0.0 <2.0.0 → 空格分隔表示 AND
+```
+
+不支持（避免过度复杂）：`||`（OR）、build metadata（`+build`）。
+
+prerelease 标签（`-beta.1`）：支持解析和比较，`1.0.0-beta.1 < 1.0.0`。
+
+## 五、模块接口
+
+### 文件：`src/core/semver.cppm`
+
+```cpp
+export module xlings.core.semver;
+import std;
+
+export namespace xlings::semver {
+
+// ── 版本号 ──
+struct Version {
+    int major = 0;
+    int minor = 0;
+    int patch = 0;
+    int components = 0;       // 用户写了几段: "15"→1, "15.1"→2, "15.1.0"→3
+    std::string prerelease;   // "beta.1", "" 表示正式版
+
+    // 比较: 1.3.3-beta.1 < 1.3.3 < 1.3.4
+    std::strong_ordering operator<=>(const Version& o) const;
+    bool operator==(const Version& o) const;
+};
+
+// 解析版本字符串
+// "15.1.0"        → Version{15, 1, 0, 3, ""}
+// "15"            → Version{15, 0, 0, 1, ""}
+// "1.3.3-beta.1"  → Version{1, 3, 3, 3, "beta.1"}
+std::optional<Version> parse(std::string_view s);
+
+// 格式化输出
+std::string to_string(const Version& v);
+
+// ── 版本范围 ──
+enum class Op { Eq, Gt, Gte, Lt, Lte };
+
+struct Constraint {
+    Op op;
+    Version ver;
+};
+
+struct Range {
+    std::vector<Constraint> constraints;  // 所有约束取交集 (AND)
+};
+
+// 解析范围表达式
+// "^1.2.3"          → [Gte{1,2,3}, Lt{2,0,0}]
+// ">=1.0.0 <2.0.0"  → [Gte{1,0,0}, Lt{2,0,0}]
+// "~1.2.3"          → [Gte{1,2,3}, Lt{1,3,0}]
+// "15"              → [Gte{15,0,0}, Lt{16,0,0}]
+// "15.1.0"          → [Eq{15,1,0}]
+// "1.2.*"           → [Gte{1,2,0}, Lt{1,3,0}]
+std::optional<Range> parse_range(std::string_view expr);
+
+// 版本是否满足范围
+bool satisfies(const Version& ver, const Range& range);
+
+// ── 实用函数 ──
+
+// 从版本字符串列表中选择满足范围的最高版本
+// 跳过 "latest" 标签，返回空字符串表示无匹配
+std::string select_best(std::span<const std::string> available,
+                        std::string_view range_expr);
+
+// 比较两个版本字符串 (-1, 0, 1)
+// 无法解析的版本回退到字典序比较
+int compare(std::string_view a, std::string_view b);
+
+// 排序：降序（最高版本在前）
+void sort_desc(std::vector<std::string>& versions);
+
+} // namespace xlings::semver
+```
+
+## 六、改造点清单
+
+### Phase 1: semver 核心模块
+
+新增 `src/core/semver.cppm`，实现上述接口。
+
+### Phase 2: 替换用户面对的版本处理
+
+| 文件 | 函数 | 当前逻辑 | 改为 |
+|------|------|---------|------|
+| `catalog.cppm:105-141` | `select_version_()` | 字典序前缀匹配 | `semver::select_best(available, hint)` |
+| `catalog.cppm:120` | 版本比较 | `ver > best` | `semver::compare(ver, best) > 0` |
+| `resolver.cppm:81-95` | 版本选择 | 字典序 | `semver::select_best()` |
+| `resolver.cppm:131-150` | 版本选择 | `ver > best` | `semver::compare(ver, best) > 0` |
+| `commands.cppm:160-188` | `cmd_use()` latest | 手写 numeric sort | `semver::sort_desc()` |
+
+### Phase 3: 扩展支持
+
+- `.xlings.json` workspace 版本值支持 range 表达式
+- CLI `pkg@^15` / `pkg@>=1.0` 语法
+
+### 不改动的部分
+
+| 文件 | 函数 | 原因 |
+|------|------|------|
+| `db.cppm:99-129` | `pick_highest_version()` | xvm 内部键，非用户版本 |
+| `db.cppm:136-219` | `match_version()` | xvm 内部键，非用户版本 |
+
+## 七、.xlings.json 新增支持写法
+
+```json
+{
+  "workspace": {
+    "gcc": "^15.1.0",
+    "node": ">=22.0.0",
+    "npm": "~11.2.0",
+    "glibc": "2.39",
+    "cmake": ">=3.28 <4.0"
+  }
+}
+```
+
+## 八、向后兼容
+
+- `"15.1.0"` → 解析为精确匹配 `Eq{15,1,0}`，行为不变
+- `"15"` → 解析为前缀范围 `[Gte{15,0,0}, Lt{16,0,0}]`，行为不变
+- `"latest"` → 特殊处理保留，不经过 semver 解析
+- 现有 `.xlings.json` 零改动即兼容
+
+## 九、职责边界
+
+```
+┌──────────────────────────────────────────┐
+│  semver 模块                              │
+│  只处理规范版本号: "15.1.0", "^2.39"      │
+│  用于: install, workspace, 依赖解析       │
+└──────────────────────────────────────────┘
+
+┌──────────────────────────────────────────┐
+│  xvm 版本键 (不改动)                      │
+│  不透明字符串: "gcc-15.1.0", "glibc-2.39" │
+│  保持现有的精确匹配 + 前缀匹配            │
+│  不走 semver                              │
+└──────────────────────────────────────────┘
+```

--- a/src/core/semver.cppm
+++ b/src/core/semver.cppm
@@ -1,0 +1,344 @@
+module;
+
+export module xlings.core.semver;
+import std;
+
+export namespace xlings::semver {
+
+// ── Version ──────────────────────────────────────────────────────────
+
+struct Version {
+    int major = 0;
+    int minor = 0;
+    int patch = 0;
+    int components = 0;       // how many segments the user wrote
+    std::string prerelease;   // "" = release, "beta.1" = prerelease
+};
+
+// Three-way compare: major → minor → patch → prerelease.
+// Prerelease sorts lower than the same triple without prerelease
+// (semver §11: 1.0.0-alpha < 1.0.0).
+inline std::strong_ordering compare_versions(const Version& a, const Version& b) {
+    if (auto c = a.major <=> b.major; c != 0) return c;
+    if (auto c = a.minor <=> b.minor; c != 0) return c;
+    if (auto c = a.patch <=> b.patch; c != 0) return c;
+    // Both have prerelease → lexicographic (alpha < beta < rc)
+    if (!a.prerelease.empty() && !b.prerelease.empty())
+        return a.prerelease <=> b.prerelease;
+    // One has, other doesn't → prerelease is lower
+    if (a.prerelease.empty() && !b.prerelease.empty())
+        return std::strong_ordering::greater;
+    if (!a.prerelease.empty() && b.prerelease.empty())
+        return std::strong_ordering::less;
+    return std::strong_ordering::equal;
+}
+
+// ── Parse ────────────────────────────────────────────────────────────
+
+// Parse "15.1.0", "15.1", "15", "1.3.3-beta.1"
+inline std::optional<Version> parse(std::string_view s) {
+    if (s.empty()) return std::nullopt;
+
+    Version v;
+    // Strip leading whitespace
+    while (!s.empty() && s.front() == ' ') s.remove_prefix(1);
+    while (!s.empty() && s.back() == ' ') s.remove_suffix(1);
+    if (s.empty()) return std::nullopt;
+
+    // Split off prerelease: everything after first '-' that follows digits
+    std::string_view numpart = s;
+    std::string_view prepart;
+    if (auto dash = s.find('-'); dash != std::string_view::npos) {
+        // Make sure there's at least one digit before the dash
+        bool has_digit = false;
+        for (std::size_t i = 0; i < dash; ++i) {
+            if (s[i] >= '0' && s[i] <= '9') { has_digit = true; break; }
+        }
+        if (has_digit) {
+            numpart = s.substr(0, dash);
+            prepart = s.substr(dash + 1);
+        }
+    }
+
+    // Parse numeric components (up to 3)
+    int parts[3] = {0, 0, 0};
+    int count = 0;
+    std::size_t pos = 0;
+    while (pos < numpart.size() && count < 3) {
+        // Must start with digit
+        if (numpart[pos] < '0' || numpart[pos] > '9') return std::nullopt;
+
+        int val = 0;
+        while (pos < numpart.size() && numpart[pos] >= '0' && numpart[pos] <= '9') {
+            val = val * 10 + (numpart[pos] - '0');
+            ++pos;
+        }
+        parts[count++] = val;
+
+        if (pos < numpart.size()) {
+            if (numpart[pos] == '.') {
+                ++pos; // skip dot
+            } else {
+                return std::nullopt; // unexpected char
+            }
+        }
+    }
+    // Trailing content after 3 components is invalid
+    if (pos < numpart.size()) return std::nullopt;
+    if (count == 0) return std::nullopt;
+
+    v.major = parts[0];
+    v.minor = parts[1];
+    v.patch = parts[2];
+    v.components = count;
+    if (!prepart.empty()) v.prerelease = std::string(prepart);
+
+    return v;
+}
+
+// Format version back to string
+inline std::string to_string(const Version& v) {
+    std::string s;
+    s += std::to_string(v.major);
+    if (v.components >= 2) { s += '.'; s += std::to_string(v.minor); }
+    if (v.components >= 3) { s += '.'; s += std::to_string(v.patch); }
+    if (!v.prerelease.empty()) { s += '-'; s += v.prerelease; }
+    return s;
+}
+
+// ── Range ────────────────────────────────────────────────────────────
+
+enum class Op { Eq, Gt, Gte, Lt, Lte };
+
+struct Constraint {
+    Op op;
+    Version ver;
+};
+
+struct Range {
+    std::vector<Constraint> constraints;
+};
+
+// Check if a single constraint is satisfied
+inline bool check_constraint(const Version& ver, const Constraint& c) {
+    auto cmp = compare_versions(ver, c.ver);
+    switch (c.op) {
+        case Op::Eq:  return cmp == 0;
+        case Op::Gt:  return cmp > 0;
+        case Op::Gte: return cmp >= 0;
+        case Op::Lt:  return cmp < 0;
+        case Op::Lte: return cmp <= 0;
+    }
+    return false;
+}
+
+inline bool satisfies(const Version& ver, const Range& range) {
+    for (auto& c : range.constraints) {
+        if (!check_constraint(ver, c)) return false;
+    }
+    return true;
+}
+
+// Parse a single constraint token: ">=1.2.3", ">1.0", "<=2.0.0", "<3", "1.2.3"
+inline std::optional<std::pair<Op, Version>> parse_constraint_token(std::string_view tok) {
+    while (!tok.empty() && tok.front() == ' ') tok.remove_prefix(1);
+    while (!tok.empty() && tok.back() == ' ') tok.remove_suffix(1);
+    if (tok.empty()) return std::nullopt;
+
+    Op op = Op::Eq;
+    if (tok.starts_with(">=")) { op = Op::Gte; tok.remove_prefix(2); }
+    else if (tok.starts_with(">"))  { op = Op::Gt;  tok.remove_prefix(1); }
+    else if (tok.starts_with("<=")) { op = Op::Lte; tok.remove_prefix(2); }
+    else if (tok.starts_with("<"))  { op = Op::Lt;  tok.remove_prefix(1); }
+
+    while (!tok.empty() && tok.front() == ' ') tok.remove_prefix(1);
+    auto v = parse(tok);
+    if (!v) return std::nullopt;
+    return std::pair{op, *v};
+}
+
+// Parse range expression. Returns nullopt only for truly malformed input.
+//
+// Supported forms:
+//   "1.2.3"           → Eq{1.2.3}
+//   "15"              → Gte{15.0.0} Lt{16.0.0}   (bare prefix → range)
+//   "15.1"            → Gte{15.1.0} Lt{15.2.0}
+//   ">=1.0.0"         → Gte{1.0.0}
+//   ">=1.0.0 <2.0.0"  → Gte{1.0.0} Lt{2.0.0}
+//   "^1.2.3"          → Gte{1.2.3} Lt{2.0.0}
+//   "^0.2.3"          → Gte{0.2.3} Lt{0.3.0}
+//   "~1.2.3"          → Gte{1.2.3} Lt{1.3.0}
+//   "1.2.*"           → Gte{1.2.0} Lt{1.3.0}
+//   "1.*"             → Gte{1.0.0} Lt{2.0.0}
+inline std::optional<Range> parse_range(std::string_view expr) {
+    while (!expr.empty() && expr.front() == ' ') expr.remove_prefix(1);
+    while (!expr.empty() && expr.back() == ' ') expr.remove_suffix(1);
+    if (expr.empty()) return std::nullopt;
+
+    Range range;
+
+    // ── Caret: ^1.2.3 ──
+    if (expr.starts_with("^")) {
+        auto v = parse(expr.substr(1));
+        if (!v) return std::nullopt;
+        Version lo = *v;
+        lo.components = 3;
+        Version hi{};
+        hi.components = 3;
+        if (v->major != 0) {
+            hi.major = v->major + 1; // ^1.2.3 → < 2.0.0
+        } else if (v->minor != 0) {
+            hi.minor = v->minor + 1; // ^0.2.3 → < 0.3.0
+        } else {
+            hi.patch = v->patch + 1; // ^0.0.3 → < 0.0.4
+        }
+        range.constraints.push_back({Op::Gte, lo});
+        range.constraints.push_back({Op::Lt, hi});
+        return range;
+    }
+
+    // ── Tilde: ~1.2.3 ──
+    if (expr.starts_with("~")) {
+        auto v = parse(expr.substr(1));
+        if (!v) return std::nullopt;
+        Version lo = *v;
+        lo.components = 3;
+        Version hi{};
+        hi.components = 3;
+        hi.major = v->major;
+        hi.minor = v->minor + 1; // ~1.2.3 → < 1.3.0
+        range.constraints.push_back({Op::Gte, lo});
+        range.constraints.push_back({Op::Lt, hi});
+        return range;
+    }
+
+    // ── Wildcard: 1.2.*, 1.* ──
+    if (expr.find('*') != std::string_view::npos) {
+        // Replace * with 0, parse, then build range
+        std::string clean;
+        // "1.2.*" → parse "1.2" then make range
+        auto star = expr.find('*');
+        auto prefix = expr.substr(0, star);
+        while (!prefix.empty() && prefix.back() == '.') prefix.remove_suffix(1);
+        if (prefix.empty()) return std::nullopt;
+        auto v = parse(prefix);
+        if (!v) return std::nullopt;
+        // Build range from prefix components
+        Version lo = *v;
+        lo.components = 3;
+        Version hi{};
+        hi.components = 3;
+        if (v->components == 1) {
+            hi.major = v->major + 1; // 1.* → < 2.0.0
+        } else {
+            hi.major = v->major;
+            hi.minor = v->minor + 1; // 1.2.* → < 1.3.0
+        }
+        range.constraints.push_back({Op::Gte, lo});
+        range.constraints.push_back({Op::Lt, hi});
+        return range;
+    }
+
+    // ── Comparison operators: >=, >, <=, <, or space-separated multiple ──
+    if (expr.starts_with(">") || expr.starts_with("<")) {
+        // Split by spaces for multiple constraints: ">=1.0.0 <2.0.0"
+        std::size_t pos = 0;
+        while (pos < expr.size()) {
+            while (pos < expr.size() && expr[pos] == ' ') ++pos;
+            if (pos >= expr.size()) break;
+
+            // Find end of this constraint token
+            std::size_t start = pos;
+            // Skip operator
+            while (pos < expr.size() && (expr[pos] == '>' || expr[pos] == '<' || expr[pos] == '='))
+                ++pos;
+            // Skip spaces between operator and version
+            while (pos < expr.size() && expr[pos] == ' ') ++pos;
+            // Skip version chars
+            while (pos < expr.size() && expr[pos] != ' ') ++pos;
+
+            auto tok = expr.substr(start, pos - start);
+            auto parsed = parse_constraint_token(tok);
+            if (!parsed) return std::nullopt;
+            range.constraints.push_back({parsed->first, parsed->second});
+        }
+        return range.constraints.empty() ? std::nullopt : std::optional{range};
+    }
+
+    // ── Bare version: "15.1.0" (exact) or "15" / "15.1" (prefix range) ──
+    auto v = parse(expr);
+    if (!v) return std::nullopt;
+
+    if (v->components == 3 && v->prerelease.empty()) {
+        // Full 3-component version → exact match
+        range.constraints.push_back({Op::Eq, *v});
+    } else if (!v->prerelease.empty()) {
+        // Version with prerelease → exact match
+        v->components = 3;
+        range.constraints.push_back({Op::Eq, *v});
+    } else {
+        // Partial version (1 or 2 components) → prefix range
+        Version lo = *v;
+        lo.components = 3;
+        Version hi{};
+        hi.components = 3;
+        if (v->components == 1) {
+            hi.major = v->major + 1; // "15" → [15.0.0, 16.0.0)
+        } else {
+            hi.major = v->major;
+            hi.minor = v->minor + 1; // "15.1" → [15.1.0, 15.2.0)
+        }
+        range.constraints.push_back({Op::Gte, lo});
+        range.constraints.push_back({Op::Lt, hi});
+    }
+    return range;
+}
+
+// ── Utility functions ────────────────────────────────────────────────
+
+// Compare two version strings. Returns -1, 0, or 1.
+// Falls back to lexicographic comparison for unparseable strings.
+inline int compare(std::string_view a, std::string_view b) {
+    auto va = parse(a);
+    auto vb = parse(b);
+    if (va && vb) {
+        auto c = compare_versions(*va, *vb);
+        if (c < 0) return -1;
+        if (c > 0) return 1;
+        return 0;
+    }
+    // Fallback: lexicographic
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+}
+
+// Sort version strings in descending order (highest first).
+inline void sort_desc(std::vector<std::string>& versions) {
+    std::sort(versions.begin(), versions.end(),
+        [](const std::string& a, const std::string& b) {
+            return compare(a, b) > 0;
+        });
+}
+
+// Select the highest version from `available` that satisfies `range_expr`.
+// Skips "latest" tags. Returns "" if no match.
+inline std::string select_best(std::span<const std::string> available,
+                               std::string_view range_expr) {
+    auto range = parse_range(range_expr);
+    if (!range) return {};
+
+    std::string best;
+    for (auto& vs : available) {
+        if (vs == "latest") continue;
+        auto v = parse(vs);
+        if (!v) continue;
+        if (!satisfies(*v, *range)) continue;
+        if (best.empty() || compare(vs, best) > 0) {
+            best = vs;
+        }
+    }
+    return best;
+}
+
+} // namespace xlings::semver

--- a/src/core/xim/catalog.cppm
+++ b/src/core/xim/catalog.cppm
@@ -8,6 +8,7 @@ import xlings.core.log;
 import xlings.core.xim.index;
 import xlings.core.xim.repo;
 import xlings.core.xim.libxpkg.types.type;
+import xlings.core.semver;
 
 namespace xpkg = mcpplibs::xpkg;
 
@@ -110,34 +111,38 @@ std::string select_version_(const xpkg::Package& pkg,
 
     auto& versions = platformIt->second;
     if (!versionHint.empty()) {
+        // Direct exact match (handles "latest" ref resolution too)
         auto directIt = versions.find(versionHint);
         if (directIt != versions.end()) {
             return directIt->second.ref.empty() ? versionHint : directIt->second.ref;
         }
-        std::string best;
+        // Semver range/prefix matching against available versions
+        std::vector<std::string> available;
         for (auto& [ver, _] : versions) {
-            if (ver == "latest") continue;
-            if (ver.rfind(versionHint, 0) == 0 && ver > best) {
-                best = ver;
-            }
+            if (ver != "latest") available.push_back(ver);
         }
-        return best;
+        return semver::select_best(available, versionHint);
     }
 
+    // No hint: resolve "latest" ref or pick highest
     auto latestIt = versions.find("latest");
     if (latestIt != versions.end() && !latestIt->second.ref.empty()) {
         return latestIt->second.ref;
     }
 
-    std::string best;
+    std::vector<std::string> available;
     for (auto& [ver, _] : versions) {
-        if (ver != "latest" && ver > best) best = ver;
+        if (ver != "latest") available.push_back(ver);
+    }
+    if (!available.empty()) {
+        semver::sort_desc(available);
+        return available[0];
     }
     // If no numbered version found but "latest" exists (no ref), use it directly
-    if (best.empty() && latestIt != versions.end()) {
+    if (latestIt != versions.end()) {
         return "latest";
     }
-    return best;
+    return {};
 }
 
 std::string make_canonical_name_(const std::string& namespaceName,

--- a/src/core/xim/resolver.cppm
+++ b/src/core/xim/resolver.cppm
@@ -6,6 +6,7 @@ import xlings.core.xim.libxpkg.types.type;
 import xlings.core.xim.index;
 import xlings.core.xim.catalog;
 import xlings.core.log;
+import xlings.core.semver;
 import xlings.platform;
 
 export namespace xlings::xim {
@@ -87,11 +88,13 @@ resolve(IndexManager& index,
             if (latestIt != versions.end() && !latestIt->second.ref.empty()) {
                 return latestIt->second.ref;
             }
-            std::string best;
+            std::vector<std::string> available;
             for (auto& [ver, _] : versions) {
-                if (ver != "latest" && ver > best) best = ver;
+                if (ver != "latest") available.push_back(ver);
             }
-            return best;
+            if (available.empty()) return std::string{};
+            semver::sort_desc(available);
+            return available[0];
         };
 
         // Load full package data to get deps and version info
@@ -139,12 +142,14 @@ resolve(IndexManager& index,
                     if (latestIt != versions.end() && !latestIt->second.ref.empty()) {
                         node.version = latestIt->second.ref;
                     } else {
-                        // Pick lexicographically greatest non-"latest" version
-                        std::string best;
+                        std::vector<std::string> available;
                         for (auto& [ver, _] : versions) {
-                            if (ver != "latest" && ver > best) best = ver;
+                            if (ver != "latest") available.push_back(ver);
                         }
-                        node.version = best;
+                        if (!available.empty()) {
+                            semver::sort_desc(available);
+                            node.version = available[0];
+                        }
                     }
                 }
             }

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -8,6 +8,7 @@ import xlings.core.log;
 import xlings.platform;
 import xlings.runtime;
 import xlings.libs.json;
+import xlings.core.semver;
 import xlings.core.xself;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
@@ -165,26 +166,7 @@ int cmd_use(const std::string& target, const std::string& version, EventStream& 
             log::error("no versions installed for '{}'", target);
             return 1;
         }
-        // sort_desc: highest version first
-        std::ranges::sort(all, [](const std::string& a, const std::string& b) {
-            auto split = [](const std::string& s) {
-                std::vector<int> parts;
-                std::istringstream iss(s);
-                std::string part;
-                while (std::getline(iss, part, '.')) {
-                    int n = 0;
-                    std::from_chars(part.data(), part.data() + part.size(), n);
-                    parts.push_back(n);
-                }
-                return parts;
-            };
-            auto pa = split(strip_namespace(a));
-            auto pb = split(strip_namespace(b));
-            for (std::size_t i = 0; i < std::min(pa.size(), pb.size()); ++i) {
-                if (pa[i] != pb[i]) return pa[i] > pb[i];
-            }
-            return pa.size() > pb.size();
-        });
+        semver::sort_desc(all);
         resolved = all[0];
     } else {
         // Fuzzy match version

--- a/tests/unit/test_semver.cpp
+++ b/tests/unit/test_semver.cpp
@@ -1,0 +1,236 @@
+#include <gtest/gtest.h>
+import std;
+import xlings.core.semver;
+
+using namespace xlings::semver;
+
+// ── Parse ──
+
+TEST(SemverParse, ThreeComponents) {
+    auto v = parse("15.1.0");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->major, 15);
+    EXPECT_EQ(v->minor, 1);
+    EXPECT_EQ(v->patch, 0);
+    EXPECT_EQ(v->components, 3);
+    EXPECT_TRUE(v->prerelease.empty());
+}
+
+TEST(SemverParse, TwoComponents) {
+    auto v = parse("15.1");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->major, 15);
+    EXPECT_EQ(v->minor, 1);
+    EXPECT_EQ(v->patch, 0);
+    EXPECT_EQ(v->components, 2);
+}
+
+TEST(SemverParse, OneComponent) {
+    auto v = parse("15");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->major, 15);
+    EXPECT_EQ(v->components, 1);
+}
+
+TEST(SemverParse, Prerelease) {
+    auto v = parse("1.3.3-beta.1");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->major, 1);
+    EXPECT_EQ(v->minor, 3);
+    EXPECT_EQ(v->patch, 3);
+    EXPECT_EQ(v->prerelease, "beta.1");
+}
+
+TEST(SemverParse, LargeNumbers) {
+    auto v = parse("2026.5.7");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->major, 2026);
+    EXPECT_EQ(v->minor, 5);
+    EXPECT_EQ(v->patch, 7);
+}
+
+TEST(SemverParse, Empty) {
+    EXPECT_FALSE(parse("").has_value());
+}
+
+TEST(SemverParse, Letters) {
+    EXPECT_FALSE(parse("abc").has_value());
+    EXPECT_FALSE(parse("gcc-15").has_value());
+}
+
+// ── Compare ──
+
+TEST(SemverCompare, NumericCorrect) {
+    // The bug: lexicographic "9.0" > "15.0", but numeric 9 < 15
+    EXPECT_LT(compare("9.0.0", "15.0.0"), 0);
+    EXPECT_GT(compare("15.0.0", "9.0.0"), 0);
+}
+
+TEST(SemverCompare, BasicOrdering) {
+    EXPECT_LT(compare("1.0.0", "2.0.0"), 0);
+    EXPECT_LT(compare("1.0.0", "1.1.0"), 0);
+    EXPECT_LT(compare("1.0.0", "1.0.1"), 0);
+    EXPECT_EQ(compare("1.0.0", "1.0.0"), 0);
+}
+
+TEST(SemverCompare, PrereleaseIsLower) {
+    // semver: 1.0.0-beta < 1.0.0
+    EXPECT_LT(compare("1.0.0-beta", "1.0.0"), 0);
+    EXPECT_GT(compare("1.0.0", "1.0.0-beta"), 0);
+}
+
+TEST(SemverCompare, PrereleaseOrdering) {
+    EXPECT_LT(compare("1.0.0-alpha", "1.0.0-beta"), 0);
+    EXPECT_LT(compare("1.0.0-beta.1", "1.0.0-beta.2"), 0);
+}
+
+// ── SortDesc ──
+
+TEST(SemverSort, DescendingOrder) {
+    std::vector<std::string> versions = {"1.0.0", "15.1.0", "9.4.0", "2.39", "15.0.0"};
+    sort_desc(versions);
+    ASSERT_EQ(versions.size(), 5);
+    EXPECT_EQ(versions[0], "15.1.0");
+    EXPECT_EQ(versions[1], "15.0.0");
+    EXPECT_EQ(versions[2], "9.4.0");
+    EXPECT_EQ(versions[3], "2.39");
+    EXPECT_EQ(versions[4], "1.0.0");
+}
+
+// ── Range parsing ──
+
+TEST(SemverRange, ExactThreeComponent) {
+    auto r = parse_range("15.1.0");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(satisfies(*parse("15.1.0"), *r));
+    EXPECT_FALSE(satisfies(*parse("15.1.1"), *r));
+    EXPECT_FALSE(satisfies(*parse("15.0.0"), *r));
+}
+
+TEST(SemverRange, PrefixOneComponent) {
+    // "15" → [15.0.0, 16.0.0)
+    auto r = parse_range("15");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(satisfies(*parse("15.0.0"), *r));
+    EXPECT_TRUE(satisfies(*parse("15.1.0"), *r));
+    EXPECT_TRUE(satisfies(*parse("15.99.99"), *r));
+    EXPECT_FALSE(satisfies(*parse("14.9.9"), *r));
+    EXPECT_FALSE(satisfies(*parse("16.0.0"), *r));
+}
+
+TEST(SemverRange, PrefixTwoComponent) {
+    // "15.1" → [15.1.0, 15.2.0)
+    auto r = parse_range("15.1");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(satisfies(*parse("15.1.0"), *r));
+    EXPECT_TRUE(satisfies(*parse("15.1.5"), *r));
+    EXPECT_FALSE(satisfies(*parse("15.0.0"), *r));
+    EXPECT_FALSE(satisfies(*parse("15.2.0"), *r));
+}
+
+TEST(SemverRange, Caret) {
+    // ^1.2.3 → [1.2.3, 2.0.0)
+    auto r = parse_range("^1.2.3");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(satisfies(*parse("1.2.3"), *r));
+    EXPECT_TRUE(satisfies(*parse("1.9.0"), *r));
+    EXPECT_FALSE(satisfies(*parse("1.2.2"), *r));
+    EXPECT_FALSE(satisfies(*parse("2.0.0"), *r));
+}
+
+TEST(SemverRange, CaretZeroMajor) {
+    // ^0.2.3 → [0.2.3, 0.3.0)
+    auto r = parse_range("^0.2.3");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(satisfies(*parse("0.2.3"), *r));
+    EXPECT_TRUE(satisfies(*parse("0.2.9"), *r));
+    EXPECT_FALSE(satisfies(*parse("0.3.0"), *r));
+}
+
+TEST(SemverRange, Tilde) {
+    // ~1.2.3 → [1.2.3, 1.3.0)
+    auto r = parse_range("~1.2.3");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(satisfies(*parse("1.2.3"), *r));
+    EXPECT_TRUE(satisfies(*parse("1.2.9"), *r));
+    EXPECT_FALSE(satisfies(*parse("1.3.0"), *r));
+    EXPECT_FALSE(satisfies(*parse("1.2.2"), *r));
+}
+
+TEST(SemverRange, Gte) {
+    auto r = parse_range(">=1.0.0");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(satisfies(*parse("1.0.0"), *r));
+    EXPECT_TRUE(satisfies(*parse("2.0.0"), *r));
+    EXPECT_FALSE(satisfies(*parse("0.9.9"), *r));
+}
+
+TEST(SemverRange, Lt) {
+    auto r = parse_range("<2.0.0");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(satisfies(*parse("1.9.9"), *r));
+    EXPECT_FALSE(satisfies(*parse("2.0.0"), *r));
+}
+
+TEST(SemverRange, CombinedGteLt) {
+    // ">=1.0.0 <2.0.0"
+    auto r = parse_range(">=1.0.0 <2.0.0");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(satisfies(*parse("1.0.0"), *r));
+    EXPECT_TRUE(satisfies(*parse("1.5.0"), *r));
+    EXPECT_FALSE(satisfies(*parse("0.9.0"), *r));
+    EXPECT_FALSE(satisfies(*parse("2.0.0"), *r));
+}
+
+TEST(SemverRange, Wildcard) {
+    // "1.2.*" → [1.2.0, 1.3.0)
+    auto r = parse_range("1.2.*");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(satisfies(*parse("1.2.0"), *r));
+    EXPECT_TRUE(satisfies(*parse("1.2.5"), *r));
+    EXPECT_FALSE(satisfies(*parse("1.3.0"), *r));
+}
+
+TEST(SemverRange, WildcardMajor) {
+    // "1.*" → [1.0.0, 2.0.0)
+    auto r = parse_range("1.*");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(satisfies(*parse("1.0.0"), *r));
+    EXPECT_TRUE(satisfies(*parse("1.99.0"), *r));
+    EXPECT_FALSE(satisfies(*parse("2.0.0"), *r));
+}
+
+// ── SelectBest ──
+
+TEST(SemverSelectBest, BasicSelection) {
+    std::vector<std::string> available = {"13.1.0", "14.2.0", "15.1.0", "16.1.0", "latest"};
+    EXPECT_EQ(select_best(available, "15"), "15.1.0");
+    EXPECT_EQ(select_best(available, "^14.0.0"), "14.2.0");
+    EXPECT_EQ(select_best(available, ">=15.0.0"), "16.1.0");
+    EXPECT_EQ(select_best(available, ">=15.0.0 <16.0.0"), "15.1.0");
+}
+
+TEST(SemverSelectBest, NoMatch) {
+    std::vector<std::string> available = {"1.0.0", "2.0.0"};
+    EXPECT_EQ(select_best(available, ">=3.0.0"), "");
+}
+
+TEST(SemverSelectBest, SkipsLatest) {
+    std::vector<std::string> available = {"latest", "1.0.0"};
+    EXPECT_EQ(select_best(available, ">=1.0.0"), "1.0.0");
+}
+
+TEST(SemverSelectBest, NumericNotLexicographic) {
+    // Regression: lexicographic "9.4.0" > "15.1.0"
+    std::vector<std::string> available = {"9.4.0", "15.1.0", "11.5.0"};
+    EXPECT_EQ(select_best(available, ">=1.0.0"), "15.1.0");
+}
+
+// ── ToString ──
+
+TEST(SemverToString, RoundTrip) {
+    EXPECT_EQ(to_string(*parse("15.1.0")), "15.1.0");
+    EXPECT_EQ(to_string(*parse("15.1")), "15.1");
+    EXPECT_EQ(to_string(*parse("15")), "15");
+    EXPECT_EQ(to_string(*parse("1.3.3-beta.1")), "1.3.3-beta.1");
+}


### PR DESCRIPTION
## Summary
- Add `xlings::semver` module with version parsing, comparison, and range matching
- Replace ad-hoc version handling in catalog, resolver, and xvm commands
- Fix lexicographic comparison bug (e.g. `"9.0" > "15.0"` was wrong)
- Support version range expressions: `^`, `~`, `>=`, `>`, `<`, `<=`, `*`

## Supported syntax
```
1.2.3          exact match
15             prefix range [15.0.0, 16.0.0)
^1.2.3         compatible [1.2.3, 2.0.0)
~1.2.3         patch-level [1.2.3, 1.3.0)
>=1.0.0        greater or equal
>=1.0.0 <2.0.0 combined range
1.2.*          wildcard
1.0.0-beta.1   prerelease (sorts lower than 1.0.0)
```

## Scope
- **Replaces**: catalog.cppm `select_version_`, resolver.cppm version selection, commands.cppm `cmd_use` latest sorting
- **Unchanged**: xvm internal version keys (`gcc-15.1.0`, `glibc-2.39`) — these are opaque binding labels, not user-facing versions

## Test plan
- [x] 28 unit tests (parse, compare, sort, range, select_best)
- [x] xlings builds successfully
- [x] Backward compatible: bare versions and prefix matching work as before