### PR TITLE
fix: chown mountpoint after image mount to avoid permission denied

### DIFF
--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -303,14 +303,27 @@ bool is_mounted_(const fs::path& path) {
 }
 
 // Mount an image file at mountpoint. Supports multi-terminal reuse.
-int mount_image_(const fs::path& img, const fs::path& mountpoint) {
+// After mount, chown the mountpoint root to the calling user so
+// subsequent directory/file creation doesn't need sudo.
+int mount_image_(const fs::path& img, const fs::path& mountpoint,
+                 const std::string& user = {}) {
     fs::create_directories(mountpoint);
     if (is_mounted_(mountpoint)) return 0;  // already mounted
 
     // sudo mount (universally available)
     auto cmd = "sudo mount -o loop " + img.string() + " "
                + mountpoint.string();
-    return std::system(cmd.c_str());
+    auto rc = std::system(cmd.c_str());
+    if (rc != 0) return rc;
+
+    // ext4 root dir is owned by root after mkfs; chown to real user
+    // so sandbox init can create dirs without sudo.
+    if (!user.empty()) {
+        auto chown_cmd = "sudo chown " + user + ":" + user + " "
+                         + mountpoint.string();
+        std::system(chown_cmd.c_str());
+    }
+    return 0;
 }
 
 // Unmount an image file.
@@ -1012,7 +1025,7 @@ int use_sandbox_mode_(const std::string& name, EventStream& stream,
             });
             return 1;
         }
-        auto rc = sandbox_detail_::mount_image_(img, image_mountpoint);
+        auto rc = sandbox_detail_::mount_image_(img, image_mountpoint, user);
         if (rc != 0) {
             stream.emit(ErrorEvent{
                 .code = ErrorCode::Internal,


### PR DESCRIPTION
## Problem

`xlings subos use <name>` with `--storage image` crashes after mount:

```
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what(): filesystem error: cannot create directories: Permission denied
    [~/.xlings/subos/test-img/.mountpoint/speak]
```

## Root cause

`mkfs.ext4` creates the filesystem root dir owned by `root:root`. After `sudo mount -o loop`, the mountpoint inherits this ownership. The xlings process (running as unprivileged user) cannot create directories inside it.

## Fix

Add `sudo chown <user>:<user>` on the mountpoint root immediately after mount, so subsequent `fs::create_directories` works without elevated privileges.

## Test plan

- [x] Build compiles successfully
- [ ] CI passes
- [ ] `xlings subos use test-img` with image storage no longer crashes