### PR TITLE
fix(subos): decouple storage from sandbox + transparent bwrap probe errors

### DIFF
--- a/.agents/docs/changelog.md
+++ b/.agents/docs/changelog.md
@@ -2,13 +2,22 @@
 
 ## 2026
 
+### 2026-05 — Subos sandbox UX hotfix (V6 followup)
+
+- **storage 与 sandbox 解耦**:`xlings subos use <name>` 不再因 `storage=image|tmpfs` 自动强制 `--sandbox`。V4 的"两个维度正交"原则恢复 —— shell-level 永远只换 env/PATH，image/tmpfs 仅在显式 `--sandbox` 时被消费。shell-level 进入非 shared subos 时打一行 info 提示 storage 未激活。
+- **`probe_bwrap_` 改用 `platform::run_command_capture` 并透出真实 stderr**:之前用 `system() + 2>/dev/null` 把"binary build 不支持 setuid"、"AppArmor 拦截 userns"、"内核禁 unprivileged_userns_clone"三种完全不同的失败压扁成 bool,用户只能看到无信息量的 `run: xlings install bwrap`。现在 probe 返回 `(ok, output)`,新增 `classify_bwrap_probe_error_` 按已知关键字分流到 actionable hint,未匹配的原始 stderr 透传。
+- **`subos remove` 先 umount image storage**:V6 image storage 异常退出会留下 `.mountpoint` 活挂载。之前 `rm -rf` 要么 EBUSY 卡死要么递归进活挂载误删 image 内容(home.img 被标 `(deleted)`)。remove 现在检测到活挂载先 `unmount_image_`,失败时拒绝继续以保护数据。Linux 专用路径(`#if defined(__linux__)`),其它平台不变。
+- **image/tmpfs 在 proot fallback 时输出真实 bwrap probe 错误**:之前 image storage 撞上 proot fallback 会无脑提示 `run: xlings install bwrap`(即便 bwrap 已装)。现在重跑一次 probe,把分流后的真错误抛给用户。
+
+设计文档:[`.agents/docs/sandbox-v6-followup-fixes-2026-05-15.md`](sandbox-v6-followup-fixes-2026-05-15.md)
+
 ### 2026-05 (v0.4.25) — Sandbox V5:双后端 bwrap + proot 自动切换 + `/bin` 从宿主挂载
 
 - **双后端自动检测**:`xlings subos use <name> --sandbox` 自动选最优 backend:
   - bwrap 优先(mount namespace,native 全兼容,无 ptrace 开销)
   - proot 兜底(零权限要求,ptrace 模式有 native 限制)
   - 自动安装:首次 `--sandbox` 如果没有任何 backend,静默 `xlings install xim:bwrap`,probe 失败则装 `xim:proot`
-  - Ubuntu 24+ bwrap namespace 受限时提示 `sudo apt install bubblewrap`,自动用 proot
+  - Ubuntu 24+ bwrap namespace 受限时回落 proot(后续 followup hotfix 改为透出真实 probe stderr,见 2026-05 V6 followup 条目)
 - **可选指定后端**:`--sandbox bwrap` / `--sandbox proot`(缺省 = 自动)
 - **`--bind=/bin:/bin`**:宿主 `/bin` 整体挂进 sandbox,`/bin/sh` `/bin/bash` `/bin/ls` 全齐,解决 `system()` / shebang / POSIX 工具缺失
 - **同一 subos 任意后端切换**:bwrap 进、proot 进、普通进 —— dotfile 持久,workspace 持久,backend 无痕

--- a/.agents/docs/sandbox-v6-followup-fixes-2026-05-15.md
+++ b/.agents/docs/sandbox-v6-followup-fixes-2026-05-15.md
@@ -1,0 +1,366 @@
+# Subos Sandbox V6 — Followup Fixes & Design Revisions
+
+**Status**: 部分完成 — bwrap rebuild ✅ done (xim-pkgindex `99a1f9b`)；xlings 主仓侧 6 项待办
+**Trigger**: 2026-05-15 用户实测 V6 image storage + bwrap 链路发现连锁问题
+**Depends on**: V5 双后端、V6 storage isolation、PR #193 (xim:bwrap setuid)
+
+## 进度
+- ✅ **P0-2** xlings-res/bwrap rebuild with `-Dsupport_setuid=true` (2026-05-15 07:21, binary 137K→145K, probe exit=0)
+- ⬜ **P0-1, P0-3, P0-4, P1-5, P1-6, P2-8** — xlings 主仓内待办，见下
+
+## 一、问题来源
+
+用户实测序列：
+
+```fish
+$ xlings subos use mode-image-test
+[xlings] storage=image requires sandbox, entering sandbox mode...
+[sudo] password for speak:
+[error] image storage requires bwrap (proot does not support mount namespace)
+[error]   run: xlings install bwrap
+
+$ xlings install bwrap     # 已装，再装一遍
+✓ 1 package(s) installed
+
+$ xlings subos use mode-image-test
+[error] image storage requires bwrap (proot does not support mount namespace)   # 死循环
+
+$ sudo rm .xlings/subos/test-img -rf
+rm: cannot remove '.xlings/subos/test-img/.mountpoint': Device or resource busy
+```
+
+链条上有 6 个独立问题在叠加，逐项剖析见下。
+
+## 二、问题清单与修复方案
+
+> **图例**:
+> 🐧 = Linux 专有 | 🍎 = macOS 专有 | 🪟 = Windows 专有 | 🌐 = 跨平台
+> P0 = 阻塞性 / P1 = 应做 / P2 = 锦上添花
+
+---
+
+### P0-1 🌐 解耦 storage mode 与 sandbox mode
+
+**症状**: 用户 `xlings subos use <image-subos>` 不带 `--sandbox` 时被自动强制升级为 sandbox 模式，引发后续所有 bwrap 探测、sudo prompt、错误连锁。
+
+**根因**: V6 设计第 16/33/57-65 行强制 "非 shared 模式自动 sandbox"。这违反 V4 设计原则 (`docs/plans/2026-05-09-subos-sandbox-design.md:20`)：
+> "`--sandbox` 是 `use` 的修饰符,不再是 subos 的 type —— 一个 boolean flag。同一个 subos 可以选择带或不带 sandbox 隔离进入，正交两个维度。"
+
+storage（数据放哪）和 use mode（怎么用）本来就该正交：
+
+| `xlings subos use foo` | storage=shared | storage=image | storage=tmpfs |
+|---|---|---|---|
+| 不带 `--sandbox` (shell-level) | env/PATH 切换 | **同左**：image 文件存在但不挂载、不用 | **同左**：tmpfs 不创建、不用 |
+| 带 `--sandbox` (sandbox-level) | bwrap/proot 进 home bind 视图 | bwrap 挂 image 到 `/home/$user` | bwrap 给 `/home/$user` 一块 tmpfs |
+
+**修复**: 移除 `src/core/subos.cppm:1307-1318` 强制提升逻辑。改为：
+- shell-level 永远只做 env/tools 切换（跨平台一致：L1）
+- storage 模式仅在 `--sandbox` 路径中被消费
+- shell-level 进入非 shared subos 时打一行 info 提示，说明 storage 当前未激活
+
+**跨平台影响**:
+- 🐧 Linux: bwrap 才挂 image / tmpfs；shell-level 不碰挂载
+- 🍎 macOS / 🪟 Windows: image / tmpfs 当前就**不支持**（V6 表格已标"不支持"）。shell-level 行为变成 "image storage configured but not activated (sandbox-only on this platform; full FS isolation requires Linux)"
+- `subos new --storage image` 在 macOS/Windows 上应当 **直接拒绝创建**（创建时检测，不是 use 时才暴露），错误信息明确"image/tmpfs storage is Linux-only"
+
+**附带价值**: 解耦后，今天的"`rm -rf .mountpoint` busy" 和 "use 死循环" 在 shell-level 路径自动消失 —— shell 不挂载就没残留。挂载相关的全部 corner case 收敛到 sandbox 路径。
+
+**文件**:
+- `src/core/subos.cppm:1307-1318` — 删除强制提升
+- `src/core/subos.cppm` — `subos new` 加跨平台 storage 校验
+- `.agents/docs/sandbox-v6-storage-isolation-design.md:16,33,57-65` — 设计文档同步更新
+
+---
+
+### P0-2 🐧 `xlings-res/bwrap` 构建时启用 setuid 模式 ✅ DONE (2026-05-15)
+
+**症状**: `chmod 4755` 后 binary 启动报 `setuid use of bubblewrap is not supported in this build` 自杀退出。
+
+**根因**: bubblewrap 0.10+ meson 默认 `-Dpriv_mode=none`，编译期砍掉 setuid 路径并加运行时自检（带 setuid 位即拒绝）。`xlings-res/bwrap` 镜像构建没传 `-Dpriv_mode=setuid`，与 PR #193 install hook 的 `chmod 4755` 直接冲突。
+
+**修复**: 在 `xlings-res/bwrap` 的构建脚本中加 meson 选项：
+
+```sh
+meson setup _build \
+    -Dpriv_mode=setuid \
+    -Drequire_userns=false \
+    --buildtype=release --strip
+meson compile -C _build
+```
+
+重 build 重发资产（建议 bump 0.11.2 → 0.11.3 避开镜像缓存）。`xim-pkgindex/pkgs/b/bwrap.lua` 和 xlings 主仓代码一行不动，install hook 的 `chmod 4755` 立刻生效。
+
+**跨平台影响**:
+- 🐧 仅 Linux —— bwrap 本身就是 Linux-only
+- 🍎 🪟 macOS/Windows 用 env redirect 实现 sandbox (L2)，与 bwrap 无关
+
+**验证矩阵**（Linux 内必跨发行版）:
+- Ubuntu 24.04（apparmor_restrict_unprivileged_userns=1）
+- Ubuntu 22.04（无该 sysctl 文件）
+- Fedora 40+（默认禁 unprivileged_userns_clone）
+- Alpine 3.20+（musl，无 AppArmor）
+- WSL2（特殊内核子集）
+- minimal Docker (`alpine:latest`、`debian:slim`)
+
+---
+
+### P0-3 🌐 `probe_bwrap_` 透出 stderr，错误消息分流
+
+**症状**: probe 失败时用户只看到 `run: xlings install bwrap`，重装无效，陷入死循环。
+
+**根因**: `src/core/subos.cppm:795-799` 的 probe：
+```cpp
+auto cmd = bwrap_bin.string() + " --ro-bind / / -- /bin/true 2>/dev/null";
+return std::system(cmd.c_str()) == 0;
+```
+返回 bool，stderr 直接丢弃，三种完全不同的失败被压扁成"bwrap 不可用"。
+
+**修复**: probe 改返回 `(ok, stderr)`：
+
+```cpp
+struct ProbeResult { bool ok; std::string err; };
+ProbeResult probe_bwrap_(const fs::path& bwrap_bin) {
+    auto cmd = bwrap_bin.string() + " --ro-bind / / -- /bin/true 2>&1";
+    FILE* p = popen(cmd.c_str(), "r");
+    std::string out; char buf[256];
+    while (fgets(buf, sizeof(buf), p)) out += buf;
+    return { pclose(p) == 0, std::move(out) };
+}
+```
+
+下游错误分流（在 `use_sandbox_mode_` line 1081-1101、1142 几处）：
+
+| stderr 关键字 | 归类 | hint |
+|---|---|---|
+| `setuid use of bubblewrap is not supported` | build-config 错误 | "xim:bwrap binary lacks setuid support; rebuild required" + issue link |
+| `setting up uid map: Permission denied` | AppArmor / LSM 拦截 | "kernel restricts unprivileged userns; check apparmor_restrict_unprivileged_userns" |
+| `clone() failed: Operation not permitted` | 内核 userns 关闭 | "enable kernel.unprivileged_userns_clone=1" |
+| (其他) | 未分类 | 原文透传 |
+
+同时**区分 "not installed" vs "installed but probe failed"**（`subos.cppm:1142`），避免无脑提示 `xlings install bwrap`：
+
+```cpp
+auto bin = locate_bwrap_(p.homeDir);
+if (!bin) {
+    // 没装
+    hint = "run: xlings install bwrap";
+} else {
+    auto pr = probe_bwrap_(*bin);
+    if (!pr.ok) {
+        // 装了但 probe 失败 → 分流抛真实错误
+        hint = classify_probe_error_(pr.err, *bin);
+    }
+}
+```
+
+**跨平台影响**:
+- 🐧 主要修在 Linux 路径（bwrap/proot 探测）
+- 🍎 🪟 同样的"诊断信息透明化"原则适用于 macOS/Windows L2 的失败路径 —— 比如 env 不可设置、目录权限不足等，错误信息也要给真实原因而不是占位符
+
+---
+
+### P0-4 🐧 `subos remove` 先 umount image，避免 EBUSY + rm 误入挂载
+
+**症状**:
+```
+sudo rm .xlings/subos/test-img -rf
+rm: cannot remove '.xlings/subos/test-img/.mountpoint': Device or resource busy
+```
+而且 `rm -rf` 在 EBUSY 之前已经递归进了挂载内部，**把 image 里的内容删了一遍**（home.img 标 `(deleted)`，但内核还持有 inode）。
+
+**根因**: `remove` 实现没考虑 image storage 的活挂载 + 异常退出残留挂载。
+
+**修复**: 在 `subos remove` 流程开头：
+1. 读取 storage mode；如果是 image，检测 `<subos>/.mountpoint` 是否为活挂载（`mountpoint -q` 或 `findmnt`）
+2. 活挂载 → `sudo umount <path>`（失败给清晰错误，不静默）
+3. 再执行 `rm -rf`
+
+**跨平台影响**:
+- 🐧 image / tmpfs 只在 Linux 存在挂载，仅 Linux 路径需要这条
+- 🍎 🪟 image / tmpfs 在 macOS/Windows 应在创建时被拒绝（见 P0-1），所以 remove 路径无需特殊处理
+
+---
+
+### P1-5 🐧 sandbox 入口扫 stale mount
+
+**症状**: subos 进程异常退出（kill -9、终端 force close、xlings crash）会留下 `.mountpoint` 挂载。下次 `subos use <name> --sandbox` 会撞 "already mounted" 或其它二次挂载错误。
+
+**根因**: `mount_image_` (subos.cppm:308) 现在用 `is_mounted_` 短路返回，但没区分"上次正常使用复用"和"上次 crash 残留"。
+
+**修复（sandbox 路径开头）**:
+1. 检测 `.mountpoint` 是否 mounted
+2. 若 mounted，检查是否有活进程持有（`fuser -m` 或 `lsof`）
+3. 无活进程 → 视为 stale，主动 umount + 重新 mount
+4. 有活进程 → 复用（当前 multi-terminal 设计意图）
+
+**跨平台影响**:
+- 🐧 仅 Linux
+
+---
+
+### P1-6 🌐 `subos new --storage image|tmpfs` 在非 Linux 平台直接拒绝
+
+**症状**: V6 表格虽然标了 macOS/Windows 不支持 image/tmpfs，但创建命令是否真的拒绝、错误消息是否明确，需要确认。
+
+**根因**: 平台门禁逻辑可能放在 use 时而非 new 时，导致用户能创建一个"在本平台永远用不了"的 subos。
+
+**修复**: `subos new` 校验链路加：
+```cpp
+if (storage != StorageMode::Shared && !platform::is_linux()) {
+    error("storage=image|tmpfs is Linux-only; "
+          "macOS/Windows sandbox uses HOME redirect (L2) which has no "
+          "private FS image");
+}
+```
+
+**跨平台影响**:
+- 🌐 三平台都需要这条门禁；错误消息应说明原因，不是"unsupported"。
+
+---
+
+### P2-7 🐧 install hook 的 sudo prompt 体验
+
+**症状**: `xlings install bwrap` 中途突然弹 sudo password prompt，没有前置说明。
+
+**根因**: `xim-pkgindex/pkgs/b/bwrap.lua:64-66`:
+```lua
+log.info("Setting bwrap setuid root (sudo required)...")
+os.exec("sudo chown root:root " .. bwrap)
+os.exec("sudo chmod 4755 " .. bwrap)
+```
+
+修了 P0-2 后 `chmod 4755` 仍必须 sudo（setuid root 是真需要 root 写）。
+
+**修复**:
+- install 开始时提前提示"本次安装将设置 setuid root，需要 sudo 密码"
+- 检测 `sudo -n true`，若已缓存则静默，未缓存则提示用户即将输入密码
+- 提供 link 到设计文档说明为什么需要 setuid
+
+**跨平台影响**:
+- 🐧 仅 Linux 需要
+
+---
+
+### P2-8 🌐 文档/注释同步
+
+修完上面几条后，以下文档/注释会与实际行为脱节，需同步：
+
+| 文件 | 当前内容 | 修订要点 |
+|---|---|---|
+| `.agents/docs/sandbox-v6-storage-isolation-design.md:16,33,57-65` | "非 shared 模式自动 sandbox" | 改为正交：storage 仅在 sandbox 路径消费；shell-level 永远只做 env 切换 |
+| `.agents/docs/sandbox-v6-storage-isolation-design.md:42-43` | "macOS/Windows 不支持" | 补充：拒绝在 `subos new` 时创建 |
+| `src/core/subos.cppm:770-774` | "xim:bwrap ... is the only one guaranteed to work" | 重 build 后该说法成立；注释保留但补 "requires `-Dpriv_mode=setuid` at build time" |
+| `xim-pkgindex/pkgs/b/bwrap.lua:5` | description "setuid-less namespace sandbox" | 改为 "namespace sandbox (setuid-enabled build for cross-distro reach)" |
+| `xim-pkgindex/pkgs/b/bwrap.lua:26-34` | xpkg 注释提及 musl-static prebuilt | 补一句 "built with `-Dpriv_mode=setuid` meson option" |
+| `.agents/docs/changelog.md:11` | "Ubuntu 24+ bwrap namespace 受限时提示 `sudo apt install bubblewrap`,自动用 proot" | 当前已无该 fallback，删掉或改为"自动 install xim:bwrap" |
+
+---
+
+## 三、跨平台行为矩阵（修后预期）
+
+```
+xlings subos use <name>                  # L1 (shell-level, 三平台一致)
+xlings subos use <name> --sandbox        # 🐧 L3 (bwrap/proot)  🍎 🪟 L2 (env redirect)
+
+xlings subos new <name>                  # 🌐 storage=shared (默认)
+xlings subos new <name> --storage shared # 🌐 三平台支持
+xlings subos new <name> --storage image  # 🐧 仅 Linux ── 🍎 🪟 拒绝创建
+xlings subos new <name> --storage tmpfs  # 🐧 仅 Linux ── 🍎 🪟 拒绝创建
+```
+
+**L1 行为对所有平台、所有 storage 一致**：
+- 设置 `XLINGS_ACTIVE_SUBOS`、`PATH`、prompt 标识
+- 不挂载、不重定向、不调用任何特权操作
+- image / tmpfs storage 在 L1 路径下"存在但不激活"，仅提示
+
+**L2/L3 行为按平台分化**：
+- 🐧 L3: bwrap (setuid 模式) 优先，proot fallback；image/tmpfs 通过 bwrap mount namespace 实现
+- 🍎 L2: `HOME` `TMPDIR` `XDG_*` env redirect 到 subos 目录（已实现 in v0.4.28）
+- 🪟 L2: `USERPROFILE` `%TEMP%` env redirect（已实现 in v0.4.28）
+
+---
+
+## 四、执行顺序
+
+### Batch A (hotfix, 1-2 天) — 立刻见效，不依赖 bwrap 修好
+
+```
+P0-1  解耦 storage/sandbox          subos.cppm:1307-1318 删除 + new 加跨平台校验
+P0-3  probe stderr 透出 + 错误分流   subos.cppm:795-799, 1142
+P0-4  remove 先 umount              subos remove 实现
+P2-8  文档/注释同步                  设计文档 + bwrap.lua + changelog
+```
+
+完成 Batch A 后用户的实测序列变成：
+```fish
+$ xlings subos use mode-image-test
+[info] storage=image is sandbox-only; entering shell-level (use --sandbox to activate)
+<xsubos:mode-image-test>$    # 直接进 shell，无 sudo、无 bwrap 错误
+
+$ xlings subos remove mode-image-test
+✓ subos removed              # 内部先 umount，rm 顺畅
+```
+
+—— **bwrap 还没修，但用户路径已经不撞坑**。
+
+### Batch B (main, 1 周) — 真正修 bwrap
+
+```
+P0-2  xlings-res/bwrap 重 build (priv_mode=setuid)
+      ↓ 发布 0.11.3 资产
+      ↓ 跨发行版测试矩阵
+```
+
+发完之后 `--sandbox` 路径在 Linux 全发行版打通。
+
+### Batch C (polish, 接下来 1-2 周)
+
+```
+P1-5  sandbox 入口扫 stale mount
+P1-6  new 时跨平台 storage 校验（如果 Batch A 没一起做掉）
+P2-7  install hook sudo prompt 体验
+```
+
+---
+
+## 五、不做的事
+
+- ❌ `xlings subos doctor` 子命令 —— V6 没存量用户，不需要诊断兜底；probe stderr 透出（P0-3）已足够定位
+- ❌ 回滚 `b491887` 添加 `/usr/bin/bwrap` fallback —— 违反"跨发行版一致"原则；P0-2 修完后没必要
+- ❌ 让用户改 `apparmor_restrict_unprivileged_userns=0` —— 设计已否决（要求宿主配置）
+- ❌ image 失败时降级 shared —— 解耦后用户可直接 shell-level 进入，不需要"自动降级"
+
+---
+
+## 六、附录：本次会话定位过程（用于 onboarding）
+
+### 关键证据
+```
+$ /home/speak/.xlings/data/xpkgs/xim-x-bwrap/0.11.2/bin/bwrap --ro-bind / / -- /bin/true
+bwrap: setuid use of bubblewrap is not supported in this build       ← 关键
+exit=1
+
+$ cp <bwrap> /tmp/x && chmod 0755 /tmp/x && /tmp/x --ro-bind / / -- /bin/true
+bwrap: setting up uid map: Permission denied                          ← AppArmor 拦截
+exit=1
+
+$ /usr/bin/bwrap --ro-bind / / -- /bin/true
+exit=0                                                                 ← 系统 0.9.0 能跑
+```
+
+### 触发提交
+| Commit | 仓库 | 时间 | 改动 |
+|---|---|---|---|
+| `ba54990` | xim-pkgindex | 2026-05-14 19:23 | install hook 加 `chmod 4755` (#193) |
+| `b491887` | xlings | 2026-05-14 19:48 | 砍掉 `/usr/bin/bwrap` fallback，xim 池独占 |
+
+两者叠加的设计假设是"xim:bwrap 自带 setuid → 跨 distro 通用"，但 bubblewrap 0.10+ 默认 `priv_mode=none` 让 binary 自带"反 setuid"，假设失效。
+
+### 上游 build option
+bubblewrap `meson_options.txt`:
+```
+option('priv_mode', type: 'combo',
+       choices: ['none', 'setuid', 'setcap'], value: 'none',
+       description: 'how the bwrap binary obtains privileges')
+```
+P0-2 的本质就是把这个选项从 `none` 改回 `setuid`。

--- a/.agents/docs/sandbox-v6-storage-isolation-design.md
+++ b/.agents/docs/sandbox-v6-storage-isolation-design.md
@@ -13,10 +13,12 @@ host 上可以直接浏览沙箱内的文件和目录结构。对于隐私敏感
 ## 二、设计原则
 
 1. **storage 是 subos 的创建时属性**，不是运行时选项
-2. **非 shared 模式自动进入 sandbox**，用户无需手动加 `--sandbox`
+2. **storage 与 sandbox 是正交两个维度**（V4 一致）：shell-level 永远只换 env/PATH；image / tmpfs 只在 `--sandbox` 路径里被消费
 3. **xlings 共享部分（`~/.xlings`）始终复用**，不受 storage 模式影响
 4. **向后兼容**，现有 subos 默认 `shared`，行为不变
 5. **工具链自管理**，所有依赖通过 xim 包生态安装
+
+> **设计变更**: 早期 V6 (2026-05) 让"非 shared 自动进入 sandbox"，把 storage 和 sandbox 焊死成一个轴，违反 V4 正交原则。该耦合已在 followup PR (`fix/subos-sandbox-ux-hotfix`) 移除 — 详见 `sandbox-v6-followup-fixes-2026-05-15.md`。
 
 ## 三、存储模式
 
@@ -28,10 +30,16 @@ xlings subos new dev                          # 默认 shared
 xlings subos new dev --storage image          # ext4 镜像
 xlings subos new dev --storage tmpfs          # 内存盘
 
-# 使用时行为由 storage 自动决定
-xlings subos use dev                          # shared → shell 或 sandbox 皆可
-xlings subos use dev                          # image  → 自动 sandbox，提示用户
-xlings subos use dev --sandbox                # 任意模式均可显式指定 sandbox
+# 使用时 storage 与 sandbox 维度正交（修订自早期 V6 设计）
+xlings subos use dev                          # shell-level（env/PATH 切换）
+                                              # storage=image|tmpfs 时打 info：
+                                              #   "storage=X is sandbox-only;
+                                              #    entering shell-level
+                                              #    (use --sandbox to activate)"
+xlings subos use dev --sandbox                # sandbox-level
+                                              # storage=image → 挂 image
+                                              # storage=tmpfs → tmpfs
+                                              # storage=shared → 普通 bind
 ```
 
 ### 3.2 模式对比
@@ -42,26 +50,24 @@ xlings subos use dev --sandbox                # 任意模式均可显式指定 s
 | `image` | 一个 `.img` 文件 | 是 | ~0% | mount 时 | 支持 | 不支持 |
 | `tmpfs` | 无（内存中） | 否 | 0% | 否 | 支持 | 不支持 |
 
-### 3.3 use 时的 storage → sandbox 自动映射
+### 3.3 use 时的 storage / sandbox 维度（修订）
 
 ```
 use_spawn_shell() 入口:
     ↓
-读取 subos/.xlings.json → storage = ?
+sandbox 参数 = 用户显式提供 (--sandbox or not)，与 storage 无关
     ↓
-shared:
-    sandbox 参数为准（当前行为不变）
-    ├── 用户加了 --sandbox → sandbox 模式
-    └── 用户没加 --sandbox → shell 模式
-    
-image / tmpfs:
-    强制走 sandbox 模式（数据隔离依赖 mount namespace）
-    ├── 用户没加 --sandbox → 自动启用，输出提示：
-    │   "[info] storage=image requires sandbox, entering sandbox mode..."
-    └── 用户加了 --sandbox → 正常进入
-    
-    若 sandbox backend 不可用（如只有 proot）:
-    → 报错："image/tmpfs storage requires bwrap sandbox backend"
+sandbox=false:
+    走 shell-level 路径 (env/PATH 切换，无挂载、无特权操作)
+    ├── storage=shared → 直接进
+    └── storage=image|tmpfs → 打一行 info 提示 storage 未激活，进 shell
+
+sandbox=true:
+    走 sandbox 路径 (bwrap 优先, proot fallback)
+    ├── storage=shared → 普通 bind mount 模板
+    ├── storage=image  → 挂 home.img 到 .mountpoint
+    ├── storage=tmpfs  → bwrap --tmpfs
+    └── image/tmpfs + backend=proot → 拒绝，提示 bwrap 不可用真实原因
 ```
 
 ## 四、磁盘布局

--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -4,6 +4,7 @@ module;
 // pull these in, and we want execl/errno (POSIX) or CreateProcess
 // (Win32) without #include in the named-module purview (which the
 // standard forbids for headers that aren't importable units).
+#include <cstdio>  // stderr (used by std::println(stderr, ...))
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -127,7 +128,9 @@ void update_current_symlink_(EventStream& stream,
 // ── Storage mode (V6) ──────────────────────────────────────────────
 // Storage isolation mode for sandbox data. Set at subos creation time
 // via `--storage <mode>`, persisted in subos/.xlings.json["storage"].
-// Non-shared modes force sandbox entry (mount namespace required).
+// `image` and `tmpfs` are consumed only on the sandbox path; shell-
+// level entry stays env/PATH-only regardless of storage mode (the two
+// axes are orthogonal per V4 design — see use_spawn_shell).
 enum class StorageMode { Shared, Image, Tmpfs };
 
 inline std::string storage_to_string_(StorageMode m) {
@@ -535,10 +538,26 @@ int use_global(const std::string& name, EventStream& stream) {
 // kept available for tests and power users that want eval-able output
 // without a sub-shell layer. The default user-facing path is
 // use_spawn_shell; --shell is intentionally not in the help text.
+// Shell-level entry never activates storage isolation (V4 orthogonality
+// — see use_spawn_shell). Emit a single hint to stderr if the subos
+// was created with image/tmpfs storage so the user understands the
+// attribute is dormant in this entry. Writes to stderr (not stdout)
+// so the --shell <kind> path stays eval-safe.
+void warn_storage_dormant_on_shell_(const std::string& name) {
+    auto& p = Config::paths();
+    auto storage = read_storage_mode_(p.homeDir / "subos" / name);
+    if (storage == StorageMode::Shared) return;
+    std::println(stderr,
+                 "[xlings] storage={} is sandbox-only; entering "
+                 "shell-level (use --sandbox to activate)",
+                 storage_to_string_(storage));
+}
+
 int use_emit_shell(const std::string& name,
                           std::string_view shell_kind,
                           EventStream& stream) {
     if (auto rc = use_detail_::validate_subos_(name, stream); rc != 0) return rc;
+    warn_storage_dormant_on_shell_(name);
 
     auto& p = Config::paths();
     auto bin_dir = p.homeDir / "subos" / name / "bin";
@@ -769,9 +788,12 @@ build_proot_argv_(const fs::path& proot_bin,
 // Locate bwrap binary — only searches xim:bwrap pool.
 // System-installed bwrap (/usr/bin/bwrap) is intentionally skipped:
 // distro packages lack setuid, and AppArmor/kernel restrictions on
-// unprivileged user namespaces make them unreliable on Ubuntu 24+,
-// Fedora, etc. xim:bwrap sets setuid in its config() hook, so the
-// xim-managed binary is the only one guaranteed to work.
+// unprivileged user namespaces make system binaries unreliable on
+// Ubuntu 24+, Fedora, etc. xim:bwrap is built with
+// `-Dsupport_setuid=true` (xlings-res/bwrap mirror) and its install
+// hook sets the binary setuid root (chmod 4755) — that combination is
+// what makes the xim-managed binary work across distros where unpriv
+// userns is restricted.
 std::expected<fs::path, std::string>
 locate_bwrap_(const fs::path& home_dir) {
     std::error_code ec;
@@ -793,10 +815,57 @@ locate_bwrap_(const fs::path& home_dir) {
 }
 
 // Probe whether a bwrap binary can actually create a sandbox.
-bool probe_bwrap_(const fs::path& bwrap_bin) {
-    auto cmd = bwrap_bin.string()
-             + " --ro-bind / / -- /bin/true 2>/dev/null";
-    return std::system(cmd.c_str()) == 0;
+// Returns {ok, output}. `output` captures stdout+stderr (the platform
+// helper appends `2>&1` internally) so callers can classify the
+// failure cause — see classify_bwrap_probe_error_ for the known modes.
+std::pair<bool, std::string>
+probe_bwrap_(const fs::path& bwrap_bin) {
+    auto cmd = platform::shell_quote(bwrap_bin.string())
+             + " --ro-bind / / -- /bin/true";
+    auto [status, output] = platform::run_command_capture(cmd);
+    return { status == 0, std::move(output) };
+}
+
+// Translate a failed bwrap probe's captured output into an actionable
+// hint. Three known modes; anything else falls through to "show the
+// raw stderr" so users always see the truth instead of a stale
+// "xlings install bwrap" suggestion that won't help.
+std::string classify_bwrap_probe_error_(const std::string& output,
+                                         const fs::path& bin) {
+    if (output.find("setuid use of bubblewrap is not supported")
+        != std::string::npos)
+    {
+        return "xim:bwrap binary was built without setuid support; "
+               "rebuild xlings-res/bwrap mirror with "
+               "`-Dsupport_setuid=true` and bump the version\n"
+               "  binary: " + bin.string();
+    }
+    if (output.find("setting up uid map: Permission denied")
+        != std::string::npos
+        || output.find("write to uid_map failed")
+        != std::string::npos)
+    {
+        return "kernel restricts unprivileged user namespaces "
+               "(LSM/AppArmor)\n"
+               "  check: cat /proc/sys/kernel/"
+               "apparmor_restrict_unprivileged_userns\n"
+               "  workaround: sudo sysctl -w "
+               "kernel.apparmor_restrict_unprivileged_userns=0";
+    }
+    if (output.find("clone() failed: Operation not permitted")
+        != std::string::npos
+        || output.find("user namespaces are not enabled")
+        != std::string::npos)
+    {
+        return "kernel disables unprivileged_userns_clone\n"
+               "  check: cat /proc/sys/kernel/"
+               "unprivileged_userns_clone";
+    }
+    auto trimmed = output;
+    while (!trimmed.empty() &&
+           (trimmed.back() == '\n' || trimmed.back() == '\r'))
+        trimmed.pop_back();
+    return "bwrap probe failed; raw output:\n  " + trimmed;
 }
 
 // Build bwrap argv from unified bind list. Uses targeted --ro-bind
@@ -867,7 +936,7 @@ detect_backend_(const fs::path& home_dir,
                 const fs::path& subos_dir = {}) {
     // 1. bwrap (xim pool) — preferred for native compat
     if (auto bin = locate_bwrap_(home_dir)) {
-        if (probe_bwrap_(*bin))
+        if (probe_bwrap_(*bin).first)
             return BackendInfo{ SandboxBackend::Bwrap, *bin };
     }
 
@@ -890,7 +959,7 @@ int auto_install_backend_(const fs::path& home_dir, EventStream& stream) {
         std::vector<std::string> t = {"xim:bwrap"};
         xim::cmd_install(t, /*yes=*/true, /*noDeps=*/false, stream);
         auto bin = locate_bwrap_(home_dir);
-        if (bin && probe_bwrap_(*bin)) return 0;
+        if (bin && probe_bwrap_(*bin).first) return 0;
     }
 
     // bwrap installed but namespace restricted → proot fallback
@@ -1089,13 +1158,13 @@ int use_sandbox_mode_(const std::string& name, EventStream& stream,
             });
             return 1;
         }
-        if (!sandbox_detail_::probe_bwrap_(*bin)) {
+        if (auto probe = sandbox_detail_::probe_bwrap_(*bin); !probe.first) {
             stream.emit(ErrorEvent{
                 .code = ErrorCode::NotFound,
-                .message = "bwrap namespace probe failed (permission denied)",
+                .message = "bwrap probe failed",
                 .recoverable = false,
-                .hint = "try: sudo chmod 4755 " + bin->string()
-                        + "\n  or: xlings install bwrap  (auto-configures setuid)",
+                .hint = sandbox_detail_::classify_bwrap_probe_error_(
+                            probe.second, *bin),
             });
             return 1;
         }
@@ -1139,12 +1208,25 @@ int use_sandbox_mode_(const std::string& name, EventStream& stream,
     // image/tmpfs requires bwrap — reject proot after auto-detect
     if (storage != StorageMode::Shared
         && backend->type != SandboxBackend::Bwrap) {
+        // If bwrap is actually installed but probe failed (the common
+        // case that triggers the proot fallback), surface the real
+        // probe error rather than the misleading "xlings install bwrap"
+        // suggestion that won't help.
+        std::string hint = "run: xlings install bwrap";
+        if (auto bin = sandbox_detail_::locate_bwrap_(p.homeDir)) {
+            if (auto probe = sandbox_detail_::probe_bwrap_(*bin);
+                !probe.first)
+            {
+                hint = sandbox_detail_::classify_bwrap_probe_error_(
+                            probe.second, *bin);
+            }
+        }
         stream.emit(ErrorEvent{
             .code = ErrorCode::InvalidInput,
             .message = storage_to_string_(storage)
                        + " storage requires bwrap (proot does not support mount namespace)",
             .recoverable = false,
-            .hint = "run: xlings install bwrap",
+            .hint = std::move(hint),
         });
         if (storage == StorageMode::Image)
             sandbox_detail_::unmount_image_(image_mountpoint);
@@ -1304,23 +1386,18 @@ int use_spawn_shell(const std::string& name, EventStream& stream,
                     bool sandbox = false,
                     const std::string& sandbox_backend = "")
 {
-    // V6: non-shared storage modes force sandbox entry (mount namespace
-    // required for image mount / tmpfs). Auto-enable with a hint.
-    {
-        auto& p = Config::paths();
-        auto subos_dir = p.homeDir / "subos" / name;
-        auto storage = read_storage_mode_(subos_dir);
-        if (storage != StorageMode::Shared && !sandbox) {
-            log::info("storage={} requires sandbox, entering sandbox mode...",
-                      storage_to_string_(storage));
-            sandbox = true;
-        }
-    }
-
     // V5: --sandbox [backend] is a `use`-time modifier. Dispatch to the
     // sandbox path when set; auto-detect backend (bwrap preferred, proot
     // fallback) or use the explicitly requested one.
+    //
+    // Storage mode (image/tmpfs) and sandbox are orthogonal axes per
+    // V4 design: shell-level entry only swaps env/PATH and never
+    // mounts. Image / tmpfs only take effect when `--sandbox` is
+    // explicitly passed — earlier V6 auto-upgrade fused the two axes
+    // and made `subos use <image-subos>` silently require root, bwrap,
+    // and a working mount namespace just to switch shells.
     if (sandbox) return use_sandbox_mode_(name, stream, sandbox_backend);
+    warn_storage_dormant_on_shell_(name);
 
     if (auto rc = use_detail_::validate_subos_(name, stream); rc != 0) return rc;
 
@@ -1453,6 +1530,32 @@ export int remove(const std::string& name, EventStream& stream) {
 
     auto dir = Config::subos_dir(name);
     if (fs::exists(dir)) {
+        // V6: image-storage subos has an ext4 mount at <subos>/.mountpoint.
+        // remove_all would either (a) hit EBUSY at the mountpoint, leaving
+        // a half-cleaned tree behind, or (b) silently recurse into the
+        // live mount and erase the image's contents before EBUSY surfaces.
+        // Detect and umount first.
+#if defined(__linux__)
+        auto mountpoint = dir / ".mountpoint";
+        if (fs::exists(mountpoint)
+            && sandbox_detail_::is_mounted_(mountpoint))
+        {
+            if (sandbox_detail_::unmount_image_(mountpoint) != 0) {
+                stream.emit(ErrorEvent{
+                    .code = ErrorCode::Permission,
+                    .message = "failed to unmount " + mountpoint.string()
+                               + " (image storage subos); refusing to "
+                                 "remove to avoid corrupting the live "
+                                 "filesystem",
+                    .recoverable = true,
+                    .hint = "ensure no shell is inside this subos, then "
+                            "retry — or manually: sudo umount "
+                            + mountpoint.string(),
+                });
+                return 1;
+            }
+        }
+#endif
         std::error_code ec;
         fs::remove_all(dir, ec);
         if (ec) {

--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -877,6 +877,7 @@ build_bwrap_argv_(const fs::path& bwrap_bin,
                   const fs::path& host_xlings_home,
                   const std::string& user,
                   const std::string& shell_path,
+                  bool interactive_shell,
                   StorageMode storage = StorageMode::Shared,
                   const fs::path& mountpoint = {})
 {
@@ -906,7 +907,8 @@ build_bwrap_argv_(const fs::path& bwrap_bin,
         argv.insert(argv.end(), {"--tmpfs", "/tmp"});
     }
 
-    argv.insert(argv.end(), {"--chdir", user_home, "--", shell_path, "-i"});
+    argv.insert(argv.end(), {"--chdir", user_home, "--", shell_path});
+    if (interactive_shell) argv.push_back("-i");
     return argv;
 }
 
@@ -1250,12 +1252,15 @@ int use_sandbox_mode_(const std::string& name, EventStream& stream,
     platform::set_env_variable("PATH", std::format(
         "{}/.xlings/subos/{}/bin:{}/.xlings/bin:/usr/local/bin:/usr/bin:/bin",
         user_home, name, user_home));
+    // bwrap `sh -i` prints prompts/job-control warnings into piped CI
+    // commands; keep `-i` only for real terminal sessions.
+    const bool interactive_shell = ::isatty(STDIN_FILENO) == 1;
 
     std::vector<std::string> argv;
     if (backend->type == SandboxBackend::Bwrap) {
         argv = sandbox_detail_::build_bwrap_argv_(
             backend->binary, subos_dir, p.homeDir, user, shell,
-            storage, image_mountpoint);
+            interactive_shell, storage, image_mountpoint);
     } else {
         argv = sandbox_detail_::build_proot_argv_(
             backend->binary, subos_dir, p.homeDir, user, shell);

--- a/tests/e2e/subos_sandbox_test.sh
+++ b/tests/e2e/subos_sandbox_test.sh
@@ -141,6 +141,28 @@ echo "$out_passwd" | grep -q "^$USER:x:$(id -u):" \
 $out_passwd"
 log "  ✓ /etc/passwd: only root + $USER, no host user leak"
 
+# ── S6b: bwrap must not force an interactive prompt for piped commands
+log "S6b: bwrap backend keeps non-interactive command output prompt-free"
+out_bwrap_probe="$(echo 'echo BWRAP_BACKEND_OK; exit' | \
+  ( cd /tmp && env -i HOME="$HOME" USER="$USER" SHELL=/bin/sh \
+      PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
+      timeout 10 "$XLINGS_BIN" subos use mybox --sandbox bwrap ) 2>&1 || true)"
+if echo "$out_bwrap_probe" | grep -q "BWRAP_BACKEND_OK"; then
+  out_bwrap_passwd="$(echo 'cat /etc/passwd; echo MARKER_END; exit' | \
+    ( cd /tmp && env -i HOME="$HOME" USER="$USER" SHELL=/bin/sh \
+        PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" \
+        timeout 10 "$XLINGS_BIN" subos use mybox --sandbox bwrap ) 2>&1 || true)"
+  echo "$out_bwrap_passwd" | grep -q "^root:x:0:0:root:" \
+    || fail "S6b: bwrap non-interactive output was prompt-polluted:
+$out_bwrap_passwd"
+  echo "$out_bwrap_passwd" | grep -q "^$USER:x:$(id -u):" \
+    || fail "S6b: bwrap missing real-user entry:
+$out_bwrap_passwd"
+  log "  ✓ bwrap non-interactive output starts at real command output"
+else
+  log "  (skip: bwrap backend unavailable in this environment)"
+fi
+
 # ── S7: dotfile isolation — sandbox writes to /home/<user> stay private
 log "S7: writing to ~/ inside sandbox doesn't pollute host"
 marker_file="$HOME/.xlings-sandbox-test-marker-$$"


### PR DESCRIPTION
## Summary

V6 storage isolation auto-forced `--sandbox` entry when `storage=image|tmpfs`, fusing two axes that V4 design kept orthogonal. Result: `xlings subos use <image-subos>` silently required root + bwrap + working mount namespace just to switch shells, and any failure cascaded into a `run: xlings install bwrap` loop with no real diagnostic.

This PR is a UX hotfix covering four items from `.agents/docs/sandbox-v6-followup-fixes-2026-05-15.md`:

- **P0-1 — Decouple storage from sandbox**: `subos use <name>` without `--sandbox` always enters shell-level regardless of storage. Image / tmpfs only take effect on the explicit `--sandbox` path. New `warn_storage_dormant_on_shell_` helper emits a one-line stderr hint (eval-safe for `--shell <kind>` output mode).

- **P0-3 — `probe_bwrap_` transparency**: replaced `system() + 2>/dev/null + bool` with `platform::run_command_capture + platform::shell_quote`, returning `(ok, output)`. New `classify_bwrap_probe_error_` matches three known failure modes (setuid build-mode mismatch, AppArmor uid_map block, kernel-disabled userns) and returns actionable hints; unmatched output falls through to raw stderr so users always see the truth.

- **P0-3 (continued) — Re-probe on image-rejects-proot**: when image/tmpfs hits the proot fallback rejection, re-probe bwrap and surface the classified error instead of the stale `xlings install bwrap` suggestion.

- **P0-4 — `subos remove` umounts image first**: detect a live `<subos>/.mountpoint` and `unmount_image_` before `rm -rf`. Without this, `rm -rf` either hit EBUSY at the mountpoint or recursed into the live filesystem and erased image contents (home.img marked `(deleted)`). Linux-guarded.

## Cross-platform impact

- 🐧 Linux: image/tmpfs storage no longer touches sandbox code path on shell-level entry; bwrap probe failures now show real causes; `remove` safely umounts before `rm`.
- 🍎 🪟 macOS/Windows: shell-level path unchanged (env/PATH only); image/tmpfs storage was already unsupported on these platforms, P1-6 (cross-platform storage validation on `subos new`) is tracked as a separate followup.

## User-facing behavior change

Before:
```
$ xlings subos use mode-image-test
[xlings] storage=image requires sandbox, entering sandbox mode...
[sudo] password for speak:
[error] image storage requires bwrap (proot does not support mount namespace)
[error]   run: xlings install bwrap     ← misleading, bwrap was already installed
```

After (with bwrap broken/missing on host, but user wanted shell-level only):
```
$ xlings subos use mode-image-test
[xlings] storage=image is sandbox-only; entering shell-level (use --sandbox to activate)
<xsubos:mode-image-test>$           ← directly enters, no sudo, no bwrap touch
```

After (when user explicitly does `--sandbox` but bwrap build is broken):
```
$ xlings subos use mode-image-test --sandbox
[error] image storage requires bwrap (proot does not support mount namespace)
        xim:bwrap binary was built without setuid support; rebuild xlings-res/bwrap mirror with `-Dsupport_setuid=true` and bump the version
          binary: /home/speak/.xlings/data/xpkgs/xim-x-bwrap/0.11.2/bin/bwrap
```

## Test plan

- [x] `xmake build xlings` — clean compile (subos.cppm rebuilt, no errors/warnings on changed code)
- [x] `bash tests/e2e/subos_sandbox_test.sh` — passes (S1-S2 verified; S3+ skipped pending live backend, which is the existing behavior)
- [x] `bash tests/e2e/subos_install_remove_isolation_test.sh` — passes (remove path unchanged for shared-storage subos)
- [x] `bash tests/e2e/subos_workspace_c2_schema_test.sh` — passes (workspace schema unaffected)
- [x] Manual: image-storage subos + `subos use --shell sh` — stdout is eval-safe (exports only), stderr has the storage hint, `eval "$out"` then `echo $XLINGS_ACTIVE_SUBOS` returns the subos name
- [x] Manual: image-storage subos + `subos remove` (no live mount) — succeeds cleanly, directory removed
- [x] Manual: shared-storage subos + `subos use --shell sh` — no storage hint emitted (correct)
- [ ] CI: full Linux/macOS/Windows/ArchLinux matrix

## Followups (separate PRs)

Tracked in `.agents/docs/sandbox-v6-followup-fixes-2026-05-15.md`:

- P1-5: scan stale `.mountpoint` on sandbox entry (kill -9 / force-close recovery)
- P1-6: `subos new --storage image|tmpfs` cross-platform validation (reject at create time on macOS/Windows)
- P2-7: `xim:bwrap` install hook sudo prompt UX