### PR TITLE
chore(subos): silence storage-dormant hint on shell-level entry

### DIFF
--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -547,10 +547,16 @@ void warn_storage_dormant_on_shell_(const std::string& name) {
     auto& p = Config::paths();
     auto storage = read_storage_mode_(p.homeDir / "subos" / name);
     if (storage == StorageMode::Shared) return;
-    std::println(stderr,
-                 "[xlings] storage={} is sandbox-only; entering "
-                 "shell-level (use --sandbox to activate)",
-                 storage_to_string_(storage));
+    // Hint disabled: wording was ambiguous ("use --sandbox to activate"
+    // reads as either the verb or the `subos use` command) and it fired
+    // on every shell-level entry for image/tmpfs subos, becoming noise
+    // once the user already knows the layout. Revisit with a clearer
+    // one-time / opt-in form before re-enabling.
+    // std::println(stderr,
+    //              "[xlings] storage={} is sandbox-only; entering "
+    //              "shell-level (use --sandbox to activate)",
+    //              storage_to_string_(storage));
+    (void)storage;
 }
 
 int use_emit_shell(const std::string& name,


### PR DESCRIPTION
## Summary
- 注释掉 `warn_storage_dormant_on_shell_()` 里的 stderr 提示
- 不删函数 / 不动调用点,后面想换更清楚的措辞时可以原地替换

## 起因
当前提示:
```
[xlings] storage=image is sandbox-only; entering shell-level (use --sandbox to activate)
```
两个问题:
1. **措辞歧义** — `use --sandbox to activate` 在中英文里都容易被读成动词 vs `xlings subos use` 命令名;`activate` 没说激活的是 storage 隔离。
2. **噪音** — 每次 shell-level 进 image/tmpfs subos 都打一次,用户知道布局后纯打扰。

## 状态
**Draft — 暂不合入**,先放着观察一下要不要顺手做更彻底的 UX 改造(一次性提示 / 仅在 `--verbose` 下打 / 重写措辞)再决定合或者重写。

## Test plan
- [ ] `xlings subos use <image-subos>` 不再打出 hint
- [ ] `xlings subos use <image-subos> --sandbox` 行为不变
- [ ] `xlings subos use <shared-subos>` 行为不变(原本就 early-return)