### PR TITLE
[codex] Snapshot xpkg for uninstall

### DIFF
--- a/.agents/docs/xpkg-install-snapshot-minimal-design.md
+++ b/.agents/docs/xpkg-install-snapshot-minimal-design.md
@@ -1,0 +1,84 @@
+# xpkg Install Snapshot Minimal Design
+
+## Background
+
+`xlings remove` currently loads the package description from the latest local
+package index. If the index is updated after a package was installed, the
+uninstall hook can change even though the installed payload still belongs to the
+older package description.
+
+This document keeps the fix intentionally small:
+
+- after install, save the package description snapshot to `install_dir/.xpkg.lua`
+- during uninstall, prefer `install_dir/.xpkg.lua`
+- if the snapshot does not exist, keep the existing fallback to the current index
+
+## Goals
+
+1. Keep installed package lifecycle behavior stable after package index updates.
+2. Avoid branch-per-version or package-index history lookup logic.
+3. Keep the runtime compatibility model unchanged for now.
+4. Preserve existing uninstall behavior for packages installed before this change.
+
+## Non-Goals
+
+1. Do not solve old `xlings/libxpkg` parsing new xpkg files during install.
+   If an old runtime cannot parse a new package description, it should report the
+   incompatibility and ask the user to upgrade.
+2. Do not introduce `metadata.json`, install-plan snapshots, schema migration, or
+   versioned adapters in this change.
+3. Do not guarantee uninstall when both the snapshot is invalid and the current
+   index no longer supports the package. Snapshot existence means the snapshot is
+   the intended source of uninstall semantics.
+
+## Design
+
+### Install
+
+When a package reaches the successful install path, copy the xpkg file used by
+the resolver into:
+
+```text
+<install_dir>/.xpkg.lua
+```
+
+The copy uses overwrite semantics so reinstalling or remapping an existing
+package refreshes the snapshot from the resolved xpkg.
+
+Snapshot save is part of the install success path. If the copy fails, the install
+operation should fail before the package is marked installed. This avoids a state
+where xlings reports a successful install but cannot later use the expected
+snapshot for removal.
+
+### Uninstall
+
+Before creating the xpkg executor for uninstall:
+
+1. compute `snapshot = <install_dir>/.xpkg.lua`
+2. if `snapshot` exists, create the executor from `snapshot`
+3. if `snapshot` does not exist, create the executor from the current index xpkg
+
+The fallback is only for missing snapshots, which preserves compatibility with
+packages installed before this feature. If a snapshot exists but cannot be parsed
+or its uninstall hook fails, the uninstall should surface that error rather than
+silently falling back to a different package description.
+
+### Scope
+
+This feature intentionally snapshots only the package description file itself.
+That means the xpkg should be self-contained for uninstall hooks. Hooks that need
+external files from the package index remain dependent on the index layout, which
+is acceptable for this minimal change. The executor input is switched to the
+snapshot, while the existing package/index execution context remains unchanged.
+
+## Implementation Plan
+
+1. Add an e2e regression test that installs a fixture package, verifies
+   `install_dir/.xpkg.lua` exists, mutates the package index uninstall hook, then
+   verifies `xlings remove` still runs the snapshotted uninstall hook.
+2. Add a small helper in `src/core/xim/installer.cppm` to compute and save
+   `.xpkg.lua`.
+3. Call the helper on the install success path before `mark_installed`.
+4. In uninstall, select `install_dir/.xpkg.lua` as the executor input when it
+   exists; otherwise keep the current index path.
+5. Run the targeted e2e test and a focused existing remove/install regression.

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -60,6 +60,56 @@ std::filesystem::path runtime_dir_(const PlanNode& node,
     return dataRoot / "runtimedir";
 }
 
+std::filesystem::path xpkg_snapshot_file_(const std::filesystem::path& installDir) {
+    return installDir / ".xpkg.lua";
+}
+
+std::expected<void, std::string>
+save_xpkg_snapshot_(const std::filesystem::path& sourcePkgFile,
+                    const std::filesystem::path& installDir) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+
+    if (sourcePkgFile.empty()
+        || !fs::exists(sourcePkgFile, ec)
+        || !fs::is_regular_file(sourcePkgFile, ec)) {
+        return std::unexpected(
+            std::format("xpkg snapshot source not found: {}", sourcePkgFile.string()));
+    }
+
+    fs::create_directories(installDir, ec);
+    if (ec) {
+        return std::unexpected(
+            std::format("failed to create install dir for xpkg snapshot: {}", ec.message()));
+    }
+
+    auto snapshotFile = xpkg_snapshot_file_(installDir);
+    ec.clear();
+    if (fs::exists(snapshotFile, ec)) {
+        ec.clear();
+        if (fs::equivalent(sourcePkgFile, snapshotFile, ec) && !ec) return {};
+    }
+
+    ec.clear();
+    fs::copy_file(sourcePkgFile, snapshotFile, fs::copy_options::overwrite_existing, ec);
+    if (ec) {
+        return std::unexpected(
+            std::format("failed to save xpkg snapshot {}: {}",
+                        snapshotFile.string(), ec.message()));
+    }
+    return {};
+}
+
+std::filesystem::path uninstall_xpkg_file_(const std::filesystem::path& indexPkgFile,
+                                           const std::filesystem::path& installDir) {
+    std::error_code ec;
+    auto snapshotFile = xpkg_snapshot_file_(installDir);
+    if (std::filesystem::exists(snapshotFile, ec)) {
+        return snapshotFile;
+    }
+    return indexPkgFile;
+}
+
 bool is_archive_(const std::filesystem::path& path) {
     auto filename = path.filename().string();
     return filename.ends_with(".tar.gz")
@@ -1404,6 +1454,17 @@ public:
                 continue;
             }
 
+            if (auto snapshot = detail_::save_xpkg_snapshot_(node.pkgFile, ctx.install_dir);
+                !snapshot) {
+                log::error("failed to save xpkg snapshot for {}: {}",
+                           node.name, snapshot.error());
+                if (onStatus) {
+                    onStatus({ node.name, InstallPhase::Failed, 0.0f,
+                               snapshot.error() });
+                }
+                continue;
+            }
+
             if (catalog_) {
                 catalog_->mark_installed(PackageMatch{
                     .rawName = node.rawName,
@@ -1503,7 +1564,12 @@ public:
             return {};
         }
 
-        auto execResult = mcpplibs::xpkg::create_executor(pkgFile);
+        auto executorPkgFile = detail_::uninstall_xpkg_file_(pkgFile, installDir);
+        if (executorPkgFile != pkgFile) {
+            log::debug("using xpkg snapshot for uninstall: {}", executorPkgFile.string());
+        }
+
+        auto execResult = mcpplibs::xpkg::create_executor(executorPkgFile);
         if (!execResult) {
             return std::unexpected(execResult.error());
         }

--- a/tests/e2e/xpkg_snapshot_remove_test.sh
+++ b/tests/e2e/xpkg_snapshot_remove_test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# E2E regression: uninstall must use the package description snapshot saved
+# under install_dir/.xpkg.lua instead of the current package index when present.
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/xpkg_snapshot_remove"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+FIXTURE_PKG="$LOCAL_INDEX_DIR/pkgs/s/snapshot-fixture.lua"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+RUN() {
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
+}
+
+mkdir -p "$HOME_DIR"
+
+# Private copy of the shared fixture index and no nested index fetches, so the
+# test stays offline and can mutate its package definition safely.
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$(dirname "$FIXTURE_PKG")"
+
+cat > "$FIXTURE_PKG" <<'LUA'
+package = {
+    spec = "1",
+    name = "snapshot-fixture",
+    description = "Local fixture for tests/e2e/xpkg_snapshot_remove_test.sh",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+
+    xpm = {
+        linux   = { ["1.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {} },
+        windows = { ["1.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mkdir(dir)
+    io.writefile(path.join(dir, "VERSION"), pkginfo.version())
+    return true
+end
+
+function config()
+    xvm.add("snapshot-fixture", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    io.writefile(path.join(pkginfo.install_dir(), "..", "SNAPSHOT_UNINSTALL_USED"), pkginfo.version())
+    xvm.remove("snapshot-fixture")
+    return true
+end
+LUA
+
+mkdir -p "$HOME_DIR/subos/default/bin"
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
+EOF
+
+log "Initializing sandbox XLINGS_HOME at $HOME_DIR"
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+STORE_DIR="$HOME_DIR/data/xpkgs/xim-x-snapshot-fixture"
+INSTALL_DIR="$STORE_DIR/1.0.0"
+SNAPSHOT_FILE="$INSTALL_DIR/.xpkg.lua"
+SNAPSHOT_MARKER="$STORE_DIR/SNAPSHOT_UNINSTALL_USED"
+CURRENT_MARKER="$STORE_DIR/CURRENT_INDEX_UNINSTALL_USED"
+
+log "Install snapshot-fixture@1.0.0"
+RUN install snapshot-fixture@1.0.0 -y >/dev/null 2>&1 \
+  || fail "install snapshot-fixture@1.0.0 failed"
+
+[[ -f "$INSTALL_DIR/VERSION" ]] || fail "installed payload marker missing"
+[[ -f "$SNAPSHOT_FILE" ]] || fail "expected install snapshot at $SNAPSHOT_FILE"
+grep -q "SNAPSHOT_UNINSTALL_USED" "$SNAPSHOT_FILE" \
+  || fail "snapshot should contain the original uninstall hook"
+
+cat > "$FIXTURE_PKG" <<'LUA'
+package = {
+    spec = "1",
+    name = "snapshot-fixture",
+    description = "Mutated fixture used to verify uninstall does not load the current index",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+
+    xpm = {
+        linux   = { ["1.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {} },
+        windows = { ["1.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mkdir(dir)
+    io.writefile(path.join(dir, "VERSION"), pkginfo.version())
+    return true
+end
+
+function config()
+    xvm.add("snapshot-fixture", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    io.writefile(path.join(pkginfo.install_dir(), "..", "CURRENT_INDEX_UNINSTALL_USED"), pkginfo.version())
+    xvm.remove("snapshot-fixture")
+    return true
+end
+LUA
+
+log "Remove snapshot-fixture after mutating the current index"
+RUN remove snapshot-fixture -y >/dev/null 2>&1 \
+  || fail "remove snapshot-fixture failed"
+
+[[ -f "$SNAPSHOT_MARKER" ]] \
+  || fail "remove should have used the snapshotted uninstall hook"
+[[ ! -f "$CURRENT_MARKER" ]] \
+  || fail "remove used the mutated current-index uninstall hook"
+
+log "PASS: remove prefers install_dir/.xpkg.lua over the current index"


### PR DESCRIPTION
## Summary

- Add a minimal design note for install-time xpkg snapshots.
- Save the resolved package description to `install_dir/.xpkg.lua` on install success.
- Prefer the saved snapshot when running uninstall hooks, falling back to the current index only when the snapshot is missing.
- Add an e2e regression that mutates the current index after install and verifies remove still uses the snapshot.

## Validation

- `PATH="$HOME/.xlings/data/xpkgs/xim-x-xmake/3.0.8:$PATH" xmake build xlings`
- `bash tests/e2e/xpkg_snapshot_remove_test.sh`
- `bash tests/e2e/install_idempotent_test.sh`
- `bash tests/e2e/remove_multi_version_test.sh`
- `bash tests/e2e/update_package_test.sh`