### PR TITLE
feat(xim): auto-register marker binding root for unregistered packages

### DIFF
--- a/.agents/docs/xpkg-marker-auto-register-design.md
+++ b/.agents/docs/xpkg-marker-auto-register-design.md
@@ -1,0 +1,396 @@
+# xpkg Marker 自动注册设计文档
+
+> 问题分析 + 方案 A（compat 兼容性兜底）+ 方案 D（规范检测）
+
+---
+
+## 1. 问题描述
+
+当一个 xpkg 代表的是一个库或工具集（如 SDK），其 `package.name` 本身并非可执行文件。
+xpkg 作者在 config hook 中可能只注册了子工具（如 `tool-a`, `tool-b`），但忘记注册
+`package.name` 自身。或者包根本没有 config hook。
+
+### 1.1 当前检测机制（三层）
+
+| 层级 | 位置 | 检测方式 | 依赖 xvm:add() |
+|------|------|----------|----------------|
+| Tier 1 | `catalog.cppm:306-312` | install 目录存在且非空 | 否 |
+| Tier 2 | `installer.cppm:1235-1241` | `installed` hook 自定义检测 | 否 |
+| Tier 3 | `installer.cppm:1253-1276` | XVM VersionDB + payload 校验 | **是** |
+
+### 1.2 未注册时的具体影响
+
+| 功能 | 行为 | 根因 |
+|------|------|------|
+| `xlings install`（重复安装检测） | ✅ 正常（Tier 1 目录检查） | `catalog.cppm:306` |
+| `xlings list` | ❌ **不显示**（默认 subos 模式） | `commands.cppm:643` 要求 `workspace_installed` 有记录 |
+| `xlings list --all` | ✅ 正常 | 只检查 `match.installed`（目录存在） |
+| `xlings uninstall` | ❌ 不完整 | `detach_current_subos_` 操作 `workspace_installed`，无记录 |
+| `xlings use pkg@ver` 级联切换 | ❌ 不可用 | binding tree 无 root 节点 |
+| subos 间隔离追踪 | ❌ 失效 | `workspace_installed[pkg]` 为空 |
+
+### 1.3 关键代码路径
+
+```
+installer.cppm:1443-1473 — config 阶段分支：
+
+  Build deps       → skip config entirely
+  Script (no hook) → script::default_config()
+  Subos (no hook)  → subos::default_config()
+  Normal type      → run_config_hook_()
+                       ├─ line 757: no config hook → return true (不调用 process_xvm_operations_)
+                       └─ line 767: process_xvm_operations_(node, dataDir, executor, useAfterInstall)
+                                      └─ 遍历 xvm_ops，仅处理 hook 中显式 xvm:add() 的条目
+```
+
+**无论哪条路径，如果没有 `xvm:add(node.name, ...)`，`workspace_installed` 中就不会有 `node.name` 的记录。**
+
+---
+
+## 2. 方案 A：compat 兼容性自动补注册
+
+### 2.1 定位
+
+放入 **compat 模块**，作为一键兼容性处理。遵循 `xself/compat.cppm` 的既有模式：
+带版本号的命名空间，在未来版本中可一次性移除。
+
+### 2.2 设计
+
+在 config 阶段所有路径执行完毕后（`installer.cppm:1473` 后、snapshot 保存前），
+检查 `workspace_installed` 中是否已有 `node.name` 的记录。若没有，自动注入一条
+`type = "marker"` 的 VersionDB 条目 + workspace_installed 记录。
+
+### 2.3 marker 类型的语义
+
+- **不创建 PATH shim** — `process_xvm_operations_` 中 `line 600: if (type == "program")` 天然排除
+- **不安装 lib 符号链接** — `line 656: if (type == "lib")` 分支也不匹配
+- **作为 binding root** — 其他子工具通过 `binding="pkg-name@version"` 绑定到 marker，
+  `xlings use pkg-name@2.0` 即可级联切换所有绑定的工具（`commands.cppm:215-231` binding tree 遍历）
+- **参与 list/uninstall/subos 追踪** — `workspace_installed` 有记录，所有功能正常
+
+### 2.4 实现位置
+
+```
+src/core/xim/installer.cppm
+
+新增 compat 函数（建议放在 detail_ namespace 中）:
+```
+
+```cpp
+// COMPAT(0.4.37 → drop in 0.6.0): auto-register marker for packages
+// whose config hook didn't register package.name in xvm.
+// Once all existing xpkgs are updated to explicitly register their
+// binding root, this compat shim can be removed.
+namespace compat_marker_ {
+
+void ensure_binding_root_registered_(
+    const PlanNode& node,
+    const std::filesystem::path& dataDir)
+{
+    if (node.kind == DepKind::Build) return;
+
+    // Compute version_ns (same logic as process_xvm_operations_)
+    std::string version_ns;
+    {
+        auto& globalRepos = Config::global_index_repos();
+        bool isPrimary = !globalRepos.empty()
+            && node.namespaceName == globalRepos[0].name;
+        if (!isPrimary && !node.namespaceName.empty())
+            version_ns = node.namespaceName;
+    }
+
+    auto ver_key = xvm::make_ns_version(version_ns, node.version);
+    const auto& wsi = Config::workspace_installed();
+
+    // Check: is node.name already tracked in current subos?
+    if (auto it = wsi.find(node.name); it != wsi.end()) {
+        for (auto& v : it->second) {
+            if (v == ver_key || xvm::strip_namespace(v) == node.version)
+                return;  // already registered — nothing to do
+        }
+    }
+
+    // Also check VersionDB — another subos may have registered it
+    // but current subos hasn't opted in yet. In that case we still
+    // need the workspace_installed entry for this subos.
+    auto db = Config::versions();
+    auto resolved = xvm::match_version(db, node.name, node.version);
+
+    if (resolved.empty()) {
+        // Not in VersionDB at all — inject marker entry
+        std::string path = ((node.storeRoot.empty()
+            ? (dataDir / "xpkgs") : node.storeRoot)
+            / detail_::effective_store_name_(node)
+            / node.version).string();
+
+        xvm::add_version(Config::versions_mut(),
+                         node.name, node.version, path,
+                         "marker",  // type
+                         "",        // filename
+                         "",        // alias
+                         version_ns,
+                         "");       // binding
+        Config::save_versions();
+    }
+
+    // Ensure current subos tracks this version
+    Config::workspace_installed_mut()[node.name].push_back(ver_key);
+    Config::save_workspace();
+
+    log::debug("[{}] COMPAT: auto-registered as marker (binding root), ver={}",
+               node.name, ver_key);
+}
+
+} // namespace compat_marker_
+```
+
+### 2.5 调用位置
+
+```cpp
+// installer.cppm — 安装主循环中，config 阶段之后（约 line 1473 后）
+// 在 snapshot 保存之前插入：
+
+            // COMPAT(0.4.37 → drop in 0.6.0): ensure package.name is registered
+            // as a marker binding root if config hook didn't do it explicitly.
+            detail_::compat_marker_::ensure_binding_root_registered_(node, dataDir);
+
+            if (auto snapshot = detail_::save_xpkg_snapshot_(...)) {
+                // ...existing code...
+```
+
+### 2.6 移除条件
+
+当所有官方/社区 xpkg 都已更新为显式注册 binding root 后，
+按 `compat.cppm` 的既有模式删除 `compat_marker_` namespace 即可：
+
+1. 删除 `namespace compat_marker_ { ... }` 代码块
+2. 删除调用点的 `ensure_binding_root_registered_()` 和 COMPAT 注释
+3. 编译 — 所有引用自动报错，无需 grep
+
+### 2.7 version_ns 重复计算优化
+
+当前 `version_ns` 在 `process_xvm_operations_` 内部计算（line 562-571），
+compat 函数需要重复同样的逻辑。建议将 `version_ns` 的计算提取为独立函数：
+
+```cpp
+// detail_ namespace
+std::string compute_version_ns_(const PlanNode& node) {
+    auto& globalRepos = Config::global_index_repos();
+    bool isPrimary = !globalRepos.empty()
+        && node.namespaceName == globalRepos[0].name;
+    return (!isPrimary && !node.namespaceName.empty())
+        ? node.namespaceName : std::string{};
+}
+```
+
+然后 `process_xvm_operations_` 和 `ensure_binding_root_registered_` 都调用它。
+
+---
+
+## 3. 方案 D：xpkg 规范检测（Lint）
+
+### 3.1 定位
+
+作为 xpkg 质量检测工具，在安装时 warning + 独立 lint 命令。
+长期保留，属于开发者工具链的一部分。
+
+### 3.2 检测规则
+
+#### 规则 D1：package.name 未注册（严重度：Warning）
+
+**触发条件**：config hook 执行后，`xvm_operations()` 中没有任何 `op.name == node.name && op.op == "add"` 的条目。
+
+**输出**：
+```
+⚠ [xpkg-lint] 'my-sdk@1.0': config hook did not register package.name via xvm:add()
+  ├─ impact: package won't appear in `xlings list`, subos tracking broken
+  ├─ fix: add xvm:add("my-sdk", version, install_dir, "marker") in config hook
+  └─ note: auto-registered as marker by compat layer (temporary)
+```
+
+**实现位置**：`process_xvm_operations_` 末尾（line 748 前）
+
+```cpp
+// Lint D1: warn if package.name was not registered
+{
+    bool root_registered = false;
+    for (auto& op : xvm_ops) {
+        if (op.op == "add" && op.name == node.name) {
+            root_registered = true;
+            break;
+        }
+    }
+    if (!root_registered) {
+        log::warn("[xpkg-lint] '{}@{}': config hook did not register "
+                  "package.name via xvm:add() — package won't appear in "
+                  "`xlings list` without compat layer",
+                  node.name, node.version);
+    }
+}
+```
+
+#### 规则 D2：子工具未绑定到 package.name（严重度：Info）
+
+**触发条件**：config hook 注册了多个 `type="program"` 的条目，但没有任何条目的
+`binding` 指向 `package.name`。
+
+**输出**：
+```
+ℹ [xpkg-lint] 'my-sdk@1.0': 3 tools registered but none bound to package.name
+  ├─ registered: tool-a, tool-b, tool-c
+  ├─ impact: `xlings use my-sdk@2.0` won't cascade-switch these tools
+  └─ fix: add binding="my-sdk@1.0" to each xvm:add() call
+```
+
+**实现**：
+
+```cpp
+// Lint D2: warn about unbound tools
+{
+    bool has_root = false;
+    std::vector<std::string> unbound_tools;
+    for (auto& op : xvm_ops) {
+        if (op.op != "add") continue;
+        if (op.name == node.name) { has_root = true; continue; }
+        std::string type = op.type.empty() ? "program" : op.type;
+        if (type == "program" && op.binding.empty()) {
+            unbound_tools.push_back(op.name);
+        }
+    }
+    if (has_root && !unbound_tools.empty()) {
+        std::string names;
+        for (size_t i = 0; i < unbound_tools.size(); ++i) {
+            if (i > 0) names += ", ";
+            names += unbound_tools[i];
+        }
+        log::info("[xpkg-lint] '{}': {} tool(s) not bound to package.name: {} — "
+                  "`xlings use {}@<ver>` won't cascade-switch them",
+                  node.name, unbound_tools.size(), names, node.name);
+    }
+}
+```
+
+#### 规则 D3：无 config hook 且非 Script/Subos 类型（严重度：Info）
+
+**触发条件**：普通包没有 config hook，也没有 installed hook。
+
+**输出**：
+```
+ℹ [xpkg-lint] 'my-lib@1.0': no config hook defined
+  └─ hint: add a config hook with xvm:add() to enable version management
+```
+
+**实现位置**：`installer.cppm` config 阶段分支中（line 1466 前），
+当走到 `run_config_hook_` 且 `executor.has_hook(Config) == false` 时触发。
+
+实际上 `run_config_hook_` 内部 line 757 已经 early-return，可以在调用前检查：
+
+```cpp
+} else {
+    // Lint D3
+    if (!executor.has_hook(mcpplibs::xpkg::HookType::Config)) {
+        log::info("[xpkg-lint] '{}@{}': no config hook — version management "
+                  "features (list, use, uninstall) rely on compat auto-marker",
+                  node.name, node.version);
+    }
+    if (!detail_::run_config_hook_(node, dataDir, executor, ctx,
+                                    onStatus, useAfterInstall)) {
+        // ...existing error handling...
+    }
+}
+```
+
+### 3.3 独立 lint 子命令（可选，未来增强）
+
+```
+xlings lint <pkg>.lua
+```
+
+在不执行安装的情况下，对 xpkg 文件进行静态分析：
+- 沙箱执行 config hook，收集 xvm_operations
+- 运行 D1/D2/D3 规则
+- 输出检测报告
+
+这需要对 `PackageExecutor` 做 dry-run 模式支持，属于较大改动，建议作为后续迭代。
+
+### 3.4 完整规则汇总
+
+| 规则 | 严重度 | 触发条件 | 实现位置 |
+|------|--------|----------|----------|
+| D1 | Warning | config hook 未注册 package.name | `process_xvm_operations_` 末尾 |
+| D2 | Info | 子工具未绑定到 package.name | `process_xvm_operations_` 末尾 |
+| D3 | Info | 无 config hook（普通包） | `installer.cppm` config 分支 |
+
+---
+
+## 4. 整体实施路径
+
+```
+Phase 1 (当前版本, e.g. 0.4.37):
+  ├─ 实现 A: compat_marker_::ensure_binding_root_registered_()
+  ├─ 实现 D1/D3: 安装时 warning 输出
+  └─ 提取 compute_version_ns_() 公共函数
+
+Phase 2 (下一版本):
+  ├─ 实现 D2: 子工具绑定检测
+  ├─ 更新官方 xpkg 仓库中的包，显式注册 marker + binding
+  └─ 文档：xpkg 编写规范中增加 binding root 最佳实践
+
+Phase 3 (0.6.0+):
+  ├─ 确认社区 xpkg 已更新
+  ├─ D1 严重度从 Warning 提升为 Error（可选）
+  └─ 移除 compat_marker_ 兼容层
+```
+
+---
+
+## 5. marker 作为 binding root 的完整示例
+
+### xpkg config hook 最佳实践
+
+```lua
+function config(ctx)
+    local ver = ctx.version
+    local dir = ctx.install_dir
+
+    -- 1. 注册 binding root（marker，不创建 shim）
+    xvm:add("my-sdk", ver, dir, "marker")
+
+    -- 2. 注册子工具，绑定到 root
+    xvm:add("tool-a", ver, dir .. "/bin", "program", {
+        binding = "my-sdk@" .. ver
+    })
+    xvm:add("tool-b", ver, dir .. "/bin", "program", {
+        binding = "my-sdk@" .. ver
+    })
+
+    -- 3. 注册库（可选）
+    xvm:add("libsdk", ver, dir .. "/lib", "lib", {
+        filename = "libsdk.so",
+        binding = "my-sdk@" .. ver
+    })
+end
+```
+
+### 版本切换行为
+
+```bash
+$ xlings use my-sdk@2.0
+# binding tree 遍历 (commands.cppm:215-231):
+#   my-sdk@2.0 (marker, no shim)
+#   ├─ tool-a@2.0 (program, shim updated)
+#   ├─ tool-b@2.0 (program, shim updated)
+#   └─ libsdk@2.0 (lib, symlink updated)
+```
+
+---
+
+## 6. 影响范围
+
+| 组件 | 变更类型 | 文件 |
+|------|----------|------|
+| installer | 新增 compat 函数 + lint warn | `src/core/xim/installer.cppm` |
+| xvm/db | 无变更（"marker" 只是 type 字符串） | — |
+| xvm/commands | 无变更（binding tree 遍历不区分 type） | — |
+| xvm/shim | 无变更（`type != "program"` 不创建 shim） | — |
+| cmd_list | 可选：marker 类型显示 `[lib/sdk]` 标签 | `src/core/xim/commands.cppm` |

--- a/src/core/compat/xim.cppm
+++ b/src/core/compat/xim.cppm
@@ -1,16 +1,15 @@
 // xim-specific cross-version compatibility shim collection.
 //
-// Follows the same convention as xself/compat.cppm: each compat feature
-// lives in its own `vX_Y_Z` sub-namespace so the version it dates from
-// is visible at every call site, and so a clean removal is a one-shot
-// operation:
+// Each compat feature lives in its own `vX_Y_Z` sub-namespace so the
+// version it dates from is visible at every call site, and so a clean
+// removal is a one-shot operation:
 //
 //   1. Bump the codebase past the removal target.
 //   2. Delete the matching `namespace vX_Y_Z { ... }` block in this file.
-//   3. Rebuild — every reference to `xim::compat::vX_Y_Z::*` surfaces as
+//   3. Rebuild — every reference to `compat::xim::vX_Y_Z::*` surfaces as
 //      a hard build error. Delete the call and any surrounding
 //      `COMPAT(X.Y.Z → drop in A.B.C)` marker comment. No grep needed.
-export module xlings.core.xim.compat;
+export module xlings.core.compat.xim;
 
 import std;
 import xlings.core.log;
@@ -20,7 +19,7 @@ import xlings.core.xvm.db;
 import xlings.core.xim.libxpkg.types.type;
 import xlings.core.xim.catalog;
 
-namespace xlings::xim::compat {
+namespace xlings::compat::xim {
 
 // =======================================================================
 // COMPAT(0.4.37 → drop in 0.6.0)  removal_target: 0.6.0
@@ -48,7 +47,7 @@ export namespace v0_4_37 {
 // get bare versions; other repos get "ns:version" to allow coexistence.
 // Shared with process_xvm_operations_ (which duplicates this logic
 // internally; a future cleanup can unify them).
-inline std::string compute_version_ns(const PlanNode& node) {
+inline std::string compute_version_ns(const ::xlings::xim::PlanNode& node) {
     auto& globalRepos = Config::global_index_repos();
     bool isPrimary = !globalRepos.empty()
         && node.namespaceName == globalRepos[0].name;
@@ -56,9 +55,9 @@ inline std::string compute_version_ns(const PlanNode& node) {
         ? node.namespaceName : std::string{};
 }
 
-void ensure_binding_root_registered(const PlanNode& node,
+void ensure_binding_root_registered(const ::xlings::xim::PlanNode& node,
                                     const std::filesystem::path& dataDir) {
-    if (node.kind == DepKind::Build) return;
+    if (node.kind == ::xlings::xim::DepKind::Build) return;
 
     std::string version_ns = compute_version_ns(node);
     auto ver_key = xvm::make_ns_version(version_ns, node.version);
@@ -81,7 +80,7 @@ void ensure_binding_root_registered(const PlanNode& node,
         // Not in VersionDB at all — inject marker entry
         std::string path = ((node.storeRoot.empty()
             ? (dataDir / "xpkgs") : node.storeRoot)
-            / xim::package_store_name(node.namespaceName, node.name)
+            / ::xlings::xim::package_store_name(node.namespaceName, node.name)
             / node.version).string();
 
         xvm::add_version(Config::versions_mut(),
@@ -103,4 +102,4 @@ void ensure_binding_root_registered(const PlanNode& node,
 
 } // namespace v0_4_37
 
-} // namespace xlings::xim::compat
+} // namespace xlings::compat::xim

--- a/src/core/compat/xself.cppm
+++ b/src/core/compat/xself.cppm
@@ -1,4 +1,4 @@
-// Cross-version compatibility shim collection.
+// xself-specific cross-version compatibility shim collection.
 //
 // Each compat feature lives in its own `vX_Y_Z` sub-namespace so the
 // version it dates from is visible at every call site, and so a clean
@@ -6,7 +6,7 @@
 //
 //   1. Bump the codebase past the removal target.
 //   2. Delete the matching `namespace vX_Y_Z { ... }` block in this file.
-//   3. Rebuild — every reference to `xself::compat::vX_Y_Z::*` surfaces as
+//   3. Rebuild — every reference to `compat::xself::vX_Y_Z::*` surfaces as
 //      a hard build error. Delete the call and any surrounding
 //      `COMPAT(X.Y.Z → drop in A.B.C)` marker comment. No grep needed.
 //
@@ -15,14 +15,14 @@
 //   * permanent self-heal  (profile auto-upgrade — keeps paying off as
 //                           the embedded resource version evolves)
 // The `removal_target` line in each block tells you which is which.
-export module xlings.core.xself.compat;
+export module xlings.core.compat.xself;
 
 import std;
 import xlings.core.log;
 import xlings.platform;
 import xlings.core.xself.profile_resources;
 
-namespace xlings::xself::compat {
+namespace xlings::compat::xself {
 
 namespace fs = std::filesystem;
 
@@ -141,11 +141,11 @@ bool report_deprecated_alias_if_match(std::string_view program_name);
 // `v0_4_17::auto_upgrade_profiles_if_stale` is therefore wired into the
 // xlings binary's startup so that the new binary, on its first run after
 // a self-update, brings the on-disk profiles up to whatever
-// `profile_resources::kVersion` it was compiled with. Idempotent — same
+// `::xlings::xself::profile_resources::kVersion` it was compiled with. Idempotent — same
 // version is a no-op, mismatched version overwrites with the new bytes
 // (preserving any user comments below the marker line).
 //
-// Lives in compat.cppm because it's how we paper over the "old xlings's
+// Lives in compat because it's how we paper over the "old xlings's
 // install path didn't propagate profile content" gap. Stays permanently:
 // every time we bump kVersion in a future release, the same hook delivers
 // the new profile to existing users without requiring a manual
@@ -155,7 +155,7 @@ bool report_deprecated_alias_if_match(std::string_view program_name);
 export namespace v0_4_17 {
 
 // Cheap startup hook: if any of the three shell profiles have a version
-// marker that differs from `profile_resources::kVersion`, rewrite them.
+// marker that differs from `::xlings::xself::profile_resources::kVersion`, rewrite them.
 // Otherwise no-op (single small read per file). Safe to call on every
 // xlings invocation — total cost on the unchanged path is well under 1 ms.
 //
@@ -271,19 +271,19 @@ void auto_upgrade_profiles_if_stale(const fs::path& home_dir) {
         std::string_view  bytes;
     };
     const Slot slots[] = {
-        { "xlings-profile.sh",   profile_resources::bash_sh },
-        { "xlings-profile.fish", profile_resources::fish    },
-        { "xlings-profile.ps1",  profile_resources::pwsh    },
+        { "xlings-profile.sh",   ::xlings::xself::profile_resources::bash_sh },
+        { "xlings-profile.fish", ::xlings::xself::profile_resources::fish    },
+        { "xlings-profile.ps1",  ::xlings::xself::profile_resources::pwsh    },
     };
 
     for (auto& s : slots) {
         auto path = config_dir / s.filename;
-        if (!detail_::needs_profile_upgrade(path, profile_resources::kVersion))
+        if (!detail_::needs_profile_upgrade(path, ::xlings::xself::profile_resources::kVersion))
             continue;
         try {
             platform::write_string_to_file(path.string(), std::string(s.bytes));
             log::debug("[compat] upgraded {} to profile version {}",
-                       path.string(), profile_resources::kVersion);
+                       path.string(), ::xlings::xself::profile_resources::kVersion);
         } catch (...) {
             // Profile upgrade is opportunistic — failure shouldn't block
             // the actual command the user invoked.
@@ -293,4 +293,4 @@ void auto_upgrade_profiles_if_stale(const fs::path& home_dir) {
 
 } // namespace v0_4_17
 
-} // namespace xlings::xself::compat
+} // namespace xlings::compat::xself

--- a/src/core/xim/compat.cppm
+++ b/src/core/xim/compat.cppm
@@ -1,0 +1,106 @@
+// xim-specific cross-version compatibility shim collection.
+//
+// Follows the same convention as xself/compat.cppm: each compat feature
+// lives in its own `vX_Y_Z` sub-namespace so the version it dates from
+// is visible at every call site, and so a clean removal is a one-shot
+// operation:
+//
+//   1. Bump the codebase past the removal target.
+//   2. Delete the matching `namespace vX_Y_Z { ... }` block in this file.
+//   3. Rebuild — every reference to `xim::compat::vX_Y_Z::*` surfaces as
+//      a hard build error. Delete the call and any surrounding
+//      `COMPAT(X.Y.Z → drop in A.B.C)` marker comment. No grep needed.
+export module xlings.core.xim.compat;
+
+import std;
+import xlings.core.log;
+import xlings.core.config;
+import xlings.core.xvm.types;
+import xlings.core.xvm.db;
+import xlings.core.xim.libxpkg.types.type;
+import xlings.core.xim.catalog;
+
+namespace xlings::xim::compat {
+
+// =======================================================================
+// COMPAT(0.4.37 → drop in 0.6.0)  removal_target: 0.6.0
+//
+// Library/toolkit xpkgs whose config hook doesn't call xvm:add() for
+// package.name silently break subos-scoped `xlings list`, `xlings
+// uninstall`, and binding-root version switching — because
+// `workspace_installed` has no entry for the package.
+//
+// `ensure_binding_root_registered` is called after every config-hook
+// phase in installer.cppm. It checks whether `node.name` was registered
+// in the current subos's `workspace_installed`. If not, it injects a
+// `type="marker"` entry that:
+//   * Acts as a binding root for `xlings use pkg@ver` cascade switching
+//   * Does NOT create PATH shims (type != "program")
+//   * Enables subos-scoped list / uninstall / tracking
+//
+// Once all xpkgs explicitly register a binding root (aided by the lint
+// warning D1 in process_xvm_operations_), this compat shim can be
+// deleted by removing the entire v0_4_37 namespace.
+// =======================================================================
+export namespace v0_4_37 {
+
+// Compute the namespace prefix for version keys. Primary-repo packages
+// get bare versions; other repos get "ns:version" to allow coexistence.
+// Shared with process_xvm_operations_ (which duplicates this logic
+// internally; a future cleanup can unify them).
+inline std::string compute_version_ns(const PlanNode& node) {
+    auto& globalRepos = Config::global_index_repos();
+    bool isPrimary = !globalRepos.empty()
+        && node.namespaceName == globalRepos[0].name;
+    return (!isPrimary && !node.namespaceName.empty())
+        ? node.namespaceName : std::string{};
+}
+
+void ensure_binding_root_registered(const PlanNode& node,
+                                    const std::filesystem::path& dataDir) {
+    if (node.kind == DepKind::Build) return;
+
+    std::string version_ns = compute_version_ns(node);
+    auto ver_key = xvm::make_ns_version(version_ns, node.version);
+    const auto& wsi = Config::workspace_installed();
+
+    // Check: is node.name already tracked in current subos?
+    if (auto it = wsi.find(node.name); it != wsi.end()) {
+        for (auto& v : it->second) {
+            if (v == ver_key || xvm::strip_namespace(v) == node.version)
+                return;  // already registered — nothing to do
+        }
+    }
+
+    // Check VersionDB — another subos may have registered it but this
+    // subos hasn't opted in yet.
+    auto db = Config::versions();
+    auto resolved = xvm::match_version(db, node.name, node.version);
+
+    if (resolved.empty()) {
+        // Not in VersionDB at all — inject marker entry
+        std::string path = ((node.storeRoot.empty()
+            ? (dataDir / "xpkgs") : node.storeRoot)
+            / xim::package_store_name(node.namespaceName, node.name)
+            / node.version).string();
+
+        xvm::add_version(Config::versions_mut(),
+                         node.name, node.version, path,
+                         "marker", "", "", version_ns, "");
+        Config::save_versions();
+    }
+
+    // Ensure current subos tracks this version
+    auto& list = Config::workspace_installed_mut()[node.name];
+    if (std::find(list.begin(), list.end(), ver_key) == list.end()) {
+        list.push_back(ver_key);
+    }
+    Config::save_workspace();
+
+    log::debug("[{}] COMPAT(0.4.37): auto-registered as marker (binding root), ver={}",
+               node.name, ver_key);
+}
+
+} // namespace v0_4_37
+
+} // namespace xlings::xim::compat

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -21,6 +21,7 @@ import xlings.core.xvm.commands;
 import xlings.core.xvm.shim;
 import xlings.core.xim.libxpkg.types.script;
 import xlings.core.xim.libxpkg.types.subos;
+import xlings.core.xim.compat;
 import xlings.runtime.cancellation;
 
 export namespace xlings::xim {
@@ -538,16 +539,6 @@ void detach_current_subos_(const std::string& target, const std::string& version
     if (wasActive || installedChanged) Config::save_workspace();
 }
 
-// Compute the namespace prefix for version keys. Primary-repo packages
-// get bare versions; other repos get "ns:version" to allow coexistence.
-std::string compute_version_ns_(const PlanNode& node) {
-    auto& globalRepos = Config::global_index_repos();
-    bool isPrimary = !globalRepos.empty()
-        && node.namespaceName == globalRepos[0].name;
-    return (!isPrimary && !node.namespaceName.empty())
-        ? node.namespaceName : std::string{};
-}
-
 void process_xvm_operations_(const PlanNode& node,
                              const std::filesystem::path& dataDir,
                              mcpplibs::xpkg::PackageExecutor& executor,
@@ -568,7 +559,7 @@ void process_xvm_operations_(const PlanNode& node,
     if (!std::filesystem::exists(xlings_bin))
         xlings_bin = paths.homeDir / "xlings";
 
-    std::string version_ns = compute_version_ns_(node);
+    std::string version_ns = compat::v0_4_37::compute_version_ns(node);
 
     for (auto& op : xvm_ops) {
         if (op.op == "add") {
@@ -789,58 +780,6 @@ bool run_config_hook_(const PlanNode& node,
     }
     process_xvm_operations_(node, dataDir, executor, useAfterInstall);
     return true;
-}
-
-// COMPAT(0.4.37 → drop in 0.6.0): auto-register a "marker" entry for
-// packages whose config hook (or lack thereof) didn't register
-// package.name in the XVM database. Without this, subos-scoped
-// `xlings list`, `xlings uninstall`, and binding-root version switching
-// silently fail for library/toolkit packages that only register their
-// sub-tools. Once all xpkgs explicitly register a binding root, this
-// compat shim can be removed.
-void ensure_binding_root_registered_(const PlanNode& node,
-                                     const std::filesystem::path& dataDir) {
-    if (node.kind == DepKind::Build) return;
-
-    std::string version_ns = compute_version_ns_(node);
-    auto ver_key = xvm::make_ns_version(version_ns, node.version);
-    const auto& wsi = Config::workspace_installed();
-
-    // Check: is node.name already tracked in current subos?
-    if (auto it = wsi.find(node.name); it != wsi.end()) {
-        for (auto& v : it->second) {
-            if (v == ver_key || xvm::strip_namespace(v) == node.version)
-                return;  // already registered — nothing to do
-        }
-    }
-
-    // Check VersionDB — another subos may have registered it but this
-    // subos hasn't opted in yet.
-    auto db = Config::versions();
-    auto resolved = xvm::match_version(db, node.name, node.version);
-
-    if (resolved.empty()) {
-        // Not in VersionDB at all — inject marker entry
-        std::string path = ((node.storeRoot.empty()
-            ? (dataDir / "xpkgs") : node.storeRoot)
-            / detail_::effective_store_name_(node)
-            / node.version).string();
-
-        xvm::add_version(Config::versions_mut(),
-                         node.name, node.version, path,
-                         "marker", "", "", version_ns, "");
-        Config::save_versions();
-    }
-
-    // Ensure current subos tracks this version
-    auto& list = Config::workspace_installed_mut()[node.name];
-    if (std::find(list.begin(), list.end(), ver_key) == list.end()) {
-        list.push_back(ver_key);
-    }
-    Config::save_workspace();
-
-    log::debug("[{}] COMPAT: auto-registered as marker (binding root), ver={}",
-               node.name, ver_key);
 }
 
 bool register_platform_loader_sandbox_(lua::State* L, const std::string& platform) {
@@ -1550,7 +1489,7 @@ public:
             // COMPAT(0.4.37 → drop in 0.6.0): ensure package.name is
             // registered as a marker binding root if the config hook
             // (or default config) didn't register it explicitly.
-            detail_::ensure_binding_root_registered_(node, dataDir);
+            compat::v0_4_37::ensure_binding_root_registered(node, dataDir);
 
             if (auto snapshot = detail_::save_xpkg_snapshot_(node.pkgFile, ctx.install_dir);
                 !snapshot) {

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -21,7 +21,8 @@ import xlings.core.xvm.commands;
 import xlings.core.xvm.shim;
 import xlings.core.xim.libxpkg.types.script;
 import xlings.core.xim.libxpkg.types.subos;
-import xlings.core.xim.compat;
+import xlings.core.compat.xim;
+import xlings.core.compat.xself;
 import xlings.runtime.cancellation;
 
 export namespace xlings::xim {
@@ -559,7 +560,7 @@ void process_xvm_operations_(const PlanNode& node,
     if (!std::filesystem::exists(xlings_bin))
         xlings_bin = paths.homeDir / "xlings";
 
-    std::string version_ns = compat::v0_4_37::compute_version_ns(node);
+    std::string version_ns = compat::xim::v0_4_37::compute_version_ns(node);
 
     for (auto& op : xvm_ops) {
         if (op.op == "add") {
@@ -642,7 +643,7 @@ void process_xvm_operations_(const PlanNode& node,
                     }
                     // COMPAT(0.4.8 → drop in 0.6.0): opportunistic legacy
                     // alias cleanup, alongside the bootstrap replacement.
-                    xself::compat::v0_4_8::cleanup_legacy_alias_shims(paths.binDir, xlings_bin);
+                    compat::xself::v0_4_8::cleanup_legacy_alias_shims(paths.binDir, xlings_bin);
                 }
             } else if (type == "lib" && !op.bindir.empty()) {
                 // Install lib symlink to subos lib dir
@@ -1489,7 +1490,7 @@ public:
             // COMPAT(0.4.37 → drop in 0.6.0): ensure package.name is
             // registered as a marker binding root if the config hook
             // (or default config) didn't register it explicitly.
-            compat::v0_4_37::ensure_binding_root_registered(node, dataDir);
+            compat::xim::v0_4_37::ensure_binding_root_registered(node, dataDir);
 
             if (auto snapshot = detail_::save_xpkg_snapshot_(node.pkgFile, ctx.install_dir);
                 !snapshot) {

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -538,6 +538,16 @@ void detach_current_subos_(const std::string& target, const std::string& version
     if (wasActive || installedChanged) Config::save_workspace();
 }
 
+// Compute the namespace prefix for version keys. Primary-repo packages
+// get bare versions; other repos get "ns:version" to allow coexistence.
+std::string compute_version_ns_(const PlanNode& node) {
+    auto& globalRepos = Config::global_index_repos();
+    bool isPrimary = !globalRepos.empty()
+        && node.namespaceName == globalRepos[0].name;
+    return (!isPrimary && !node.namespaceName.empty())
+        ? node.namespaceName : std::string{};
+}
+
 void process_xvm_operations_(const PlanNode& node,
                              const std::filesystem::path& dataDir,
                              mcpplibs::xpkg::PackageExecutor& executor,
@@ -558,17 +568,7 @@ void process_xvm_operations_(const PlanNode& node,
     if (!std::filesystem::exists(xlings_bin))
         xlings_bin = paths.homeDir / "xlings";
 
-    // Determine namespace for version keys: primary repo gets bare versions,
-    // other repos get "ns:version" to allow coexistence.
-    std::string version_ns;
-    {
-        auto& globalRepos = Config::global_index_repos();
-        bool isPrimary = !globalRepos.empty()
-            && node.namespaceName == globalRepos[0].name;
-        if (!isPrimary && !node.namespaceName.empty()) {
-            version_ns = node.namespaceName;
-        }
-    }
+    std::string version_ns = compute_version_ns_(node);
 
     for (auto& op : xvm_ops) {
         if (op.op == "add") {
@@ -744,6 +744,29 @@ void process_xvm_operations_(const PlanNode& node,
             }
         }
     }
+
+    // Lint D1: warn if config hook registered tools but not package.name itself.
+    // This helps xpkg authors discover the binding-root pattern.
+    {
+        bool root_registered = false;
+        bool has_any_add = false;
+        for (auto& op : xvm_ops) {
+            if (op.op == "add") {
+                has_any_add = true;
+                if (op.name == node.name) {
+                    root_registered = true;
+                    break;
+                }
+            }
+        }
+        if (has_any_add && !root_registered) {
+            log::warn("[xpkg-lint] '{}@{}': config hook registered tool(s) but "
+                      "not package.name — consider adding xvm:add(\"{}\", ..., "
+                      "\"marker\") as binding root",
+                      node.name, node.version, node.name);
+        }
+    }
+
     Config::save_versions();
     Config::save_workspace();
 }
@@ -766,6 +789,58 @@ bool run_config_hook_(const PlanNode& node,
     }
     process_xvm_operations_(node, dataDir, executor, useAfterInstall);
     return true;
+}
+
+// COMPAT(0.4.37 → drop in 0.6.0): auto-register a "marker" entry for
+// packages whose config hook (or lack thereof) didn't register
+// package.name in the XVM database. Without this, subos-scoped
+// `xlings list`, `xlings uninstall`, and binding-root version switching
+// silently fail for library/toolkit packages that only register their
+// sub-tools. Once all xpkgs explicitly register a binding root, this
+// compat shim can be removed.
+void ensure_binding_root_registered_(const PlanNode& node,
+                                     const std::filesystem::path& dataDir) {
+    if (node.kind == DepKind::Build) return;
+
+    std::string version_ns = compute_version_ns_(node);
+    auto ver_key = xvm::make_ns_version(version_ns, node.version);
+    const auto& wsi = Config::workspace_installed();
+
+    // Check: is node.name already tracked in current subos?
+    if (auto it = wsi.find(node.name); it != wsi.end()) {
+        for (auto& v : it->second) {
+            if (v == ver_key || xvm::strip_namespace(v) == node.version)
+                return;  // already registered — nothing to do
+        }
+    }
+
+    // Check VersionDB — another subos may have registered it but this
+    // subos hasn't opted in yet.
+    auto db = Config::versions();
+    auto resolved = xvm::match_version(db, node.name, node.version);
+
+    if (resolved.empty()) {
+        // Not in VersionDB at all — inject marker entry
+        std::string path = ((node.storeRoot.empty()
+            ? (dataDir / "xpkgs") : node.storeRoot)
+            / detail_::effective_store_name_(node)
+            / node.version).string();
+
+        xvm::add_version(Config::versions_mut(),
+                         node.name, node.version, path,
+                         "marker", "", "", version_ns, "");
+        Config::save_versions();
+    }
+
+    // Ensure current subos tracks this version
+    auto& list = Config::workspace_installed_mut()[node.name];
+    if (std::find(list.begin(), list.end(), ver_key) == list.end()) {
+        list.push_back(ver_key);
+    }
+    Config::save_workspace();
+
+    log::debug("[{}] COMPAT: auto-registered as marker (binding root), ver={}",
+               node.name, ver_key);
 }
 
 bool register_platform_loader_sandbox_(lua::State* L, const std::string& platform) {
@@ -1471,6 +1546,11 @@ public:
                 }
                 continue;
             }
+
+            // COMPAT(0.4.37 → drop in 0.6.0): ensure package.name is
+            // registered as a marker binding root if the config hook
+            // (or default config) didn't register it explicitly.
+            detail_::ensure_binding_root_registered_(node, dataDir);
 
             if (auto snapshot = detail_::save_xpkg_snapshot_(node.pkgFile, ctx.install_dir);
                 !snapshot) {

--- a/src/core/xself.cppm
+++ b/src/core/xself.cppm
@@ -15,10 +15,10 @@
 //   xself/clean.cppm            — `self clean [--dry-run]`
 //   xself/migrate.cppm          — `self migrate`
 //   xself/doctor.cppm           — `self doctor [--fix]`
-//   xself/compat.cppm           — cross-version compat shims, organized
-//                                 into vX_Y_Z sub-namespaces. See its
-//                                 header for the removal procedure when
-//                                 a compat block expires.
+//   compat/xself.cppm           — cross-version xself compat shims,
+//                                 organized into vX_Y_Z sub-namespaces.
+//                                 See its header for the removal
+//                                 procedure when a compat block expires.
 
 export module xlings.core.xself;
 
@@ -33,9 +33,9 @@ export import xlings.core.xself.clean;
 export import xlings.core.xself.migrate;
 export import xlings.core.xself.doctor;
 // Re-exported so external callers (main.cpp, xvm/commands.cppm,
-// xim/installer.cppm) reach `xself::compat::v*::*` through the umbrella
-// module without depending on the partition file directly.
-export import xlings.core.xself.compat;
+// xim/installer.cppm) reach `compat::xself::v*::*` through the umbrella
+// module without depending on the compat file directly.
+export import xlings.core.compat.xself;
 
 import xlings.libs.json;
 import xlings.runtime;

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -3,8 +3,8 @@ export module xlings.core.xself.doctor;
 import std;
 import xlings.core.xself.init;   // create_shim, LinkResult
 // Cross-version compat module (legacy alias names + safety predicate
-// live under v0_4_8). See xself/compat.cppm.
-import xlings.core.xself.compat;
+// live under v0_4_8). See compat/xself.cppm.
+import xlings.core.compat.xself;
 
 import xlings.core.config;
 import xlings.libs.json;
@@ -160,7 +160,7 @@ export int cmd_doctor(EventStream& stream, bool fix) {
     // COMPAT(0.4.8 → drop in 0.6.0): Check 2.5 — legacy alias shims
     // (xim/xvm/xself/xsubos/xinstall).
     //
-    // Names + predicate are owned by xself::compat. Doctor differs from
+    // Names + predicate are owned by compat::xself. Doctor differs from
     // the silent cleanup helper only in that it reports each finding and
     // gates removal on `--fix`. Both share the safety predicate so they
     // agree on what counts as "safe to remove".
@@ -169,9 +169,9 @@ export int cmd_doctor(EventStream& stream, bool fix) {
     if (fs::exists(p.binDir)) {
         std::error_code bec;
         auto canonical_bootstrap = fs::weakly_canonical(xlings_bin, bec);
-        for (auto alias : compat::v0_4_8::LEGACY_ALIAS_NAMES) {
+        for (auto alias : compat::xself::v0_4_8::LEGACY_ALIAS_NAMES) {
             auto path = p.binDir / shim_filename(std::string(alias));
-            if (!compat::v0_4_8::is_legacy_alias_symlink_to_bootstrap(path,
+            if (!compat::xself::v0_4_8::is_legacy_alias_symlink_to_bootstrap(path,
                     canonical_bootstrap)) continue;
 
             ++orphans;

--- a/src/core/xself/init.cppm
+++ b/src/core/xself/init.cppm
@@ -7,8 +7,8 @@ import xlings.libs.json;
 import xlings.core.log;
 import xlings.platform;
 // Cross-version compat (currently: legacy alias cleanup, profile upgrade).
-// See xself/compat.cppm — each compat lives in its own version sub-namespace.
-import xlings.core.xself.compat;
+// See compat/xself.cppm — each compat lives in its own version sub-namespace.
+import xlings.core.compat.xself;
 // Generated at build time from config/shell/*.{sh,fish,ps1}; see xmake.lua.
 import xlings.core.xself.profile_resources;
 
@@ -134,7 +134,7 @@ void ensure_subos_shims(const fs::path& target_bin_dir,
     }
 
     // COMPAT(0.4.8 → drop in 0.6.0): one-shot migration cleanup.
-    compat::v0_4_8::cleanup_legacy_alias_shims(target_bin_dir, shim_src);
+    compat::xself::v0_4_8::cleanup_legacy_alias_shims(target_bin_dir, shim_src);
 
     platform::make_files_executable(target_bin_dir);
 }

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -307,7 +307,7 @@ int cmd_use(const std::string& target, const std::string& version, EventStream& 
         // alias symlinks (xim/xvm/...) left over from xlings ≤ 0.4.7.
         // Lands on this path during `xlings self update`, which ends with
         // `xlings use xlings latest` — so first-upgrade self-heals.
-        xself::compat::v0_4_8::cleanup_legacy_alias_shims(p.binDir, xlings_bin);
+        compat::xself::v0_4_8::cleanup_legacy_alias_shims(p.binDir, xlings_bin);
     }
 
     log::info("{} -> {}", target, resolved);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,8 +5,8 @@ import xlings.core.config;
 import xlings.platform;
 import xlings.core.xvm.shim;
 // Cross-version compat shims (alias migrations, profile auto-upgrade).
-// See xself/compat.cppm — each compat lives in its own version sub-namespace.
-import xlings.core.xself.compat;
+// See compat/ directory — each compat lives in its own version sub-namespace.
+import xlings.core.compat.xself;
 
 #ifdef _WIN32
 #include <io.h>
@@ -41,10 +41,10 @@ int main(int argc, char* argv[]) {
     // COMPAT(0.4.8 → drop in 0.6.0): short-command aliases (xim/xvm/xself/
     // xsubos/xinstall) were removed in 0.4.8. If the user invoked one —
     // usually via a leftover symlink from an older install or a hand-typed
-    // habit — print a migration error (centralized in xself::compat::v0_4_8)
+    // habit — print a migration error (centralized in compat::xself::v0_4_8)
     // and exit with code 2 instead of falling through to shim_dispatch's
     // cryptic "no version set for X".
-    if (xlings::xself::compat::v0_4_8::report_deprecated_alias_if_match(program_name)) {
+    if (xlings::compat::xself::v0_4_8::report_deprecated_alias_if_match(program_name)) {
         return 2;
     }
 
@@ -53,7 +53,7 @@ int main(int argc, char* argv[]) {
     // call ensure_home_layout), the on-disk shell profiles will be stale.
     // Have the new binary auto-upgrade them on its first run. Cheap on the
     // unchanged path (one read + version compare per profile file).
-    xlings::xself::compat::v0_4_17::auto_upgrade_profiles_if_stale(p.homeDir);
+    xlings::compat::xself::v0_4_17::auto_upgrade_profiles_if_stale(p.homeDir);
 
     int rc;
     if (xlings::xvm::is_xlings_binary(program_name)) {

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -3228,6 +3228,166 @@ TEST(ThemeIcons, InfoPanelEmitsIconBytesToStdout) {
 }
 
 // ============================================================
+// marker binding-root tests (COMPAT 0.4.37)
+// ============================================================
+
+TEST(XvmDbTest, AddMarkerType) {
+    xlings::xvm::VersionDB db;
+
+    // Register a marker entry (library/toolkit package, not an executable)
+    xlings::xvm::add_version(db, "my-sdk", "1.0.0", "/pkg/my-sdk-1.0", "marker");
+
+    EXPECT_TRUE(xlings::xvm::has_target(db, "my-sdk"));
+    EXPECT_TRUE(xlings::xvm::has_version(db, "my-sdk", "1.0.0"));
+
+    auto* vinfo = xlings::xvm::get_vinfo(db, "my-sdk");
+    ASSERT_NE(vinfo, nullptr);
+    EXPECT_EQ(vinfo->type, "marker");
+
+    auto* vdata = xlings::xvm::get_vdata(db, "my-sdk", "1.0.0");
+    ASSERT_NE(vdata, nullptr);
+    EXPECT_EQ(vdata->path, "/pkg/my-sdk-1.0");
+}
+
+TEST(XvmDbTest, MarkerAsBindingRoot) {
+    xlings::xvm::VersionDB db;
+
+    // Register marker as binding root
+    xlings::xvm::add_version(db, "my-sdk", "1.0.0", "/pkg/my-sdk-1.0", "marker");
+
+    // Register tools bound to the marker
+    xlings::xvm::add_version(db, "tool-a", "1.0.0", "/pkg/my-sdk-1.0/bin",
+                             "program", "tool-a", "tool-a", "", "my-sdk@1.0.0");
+    xlings::xvm::add_version(db, "tool-b", "1.0.0", "/pkg/my-sdk-1.0/bin",
+                             "program", "tool-b", "tool-b", "", "my-sdk@1.0.0");
+
+    // Verify bidirectional bindings: my-sdk <-> tool-a, my-sdk <-> tool-b
+    auto* sdk_info = xlings::xvm::get_vinfo(db, "my-sdk");
+    ASSERT_NE(sdk_info, nullptr);
+    EXPECT_TRUE(sdk_info->bindings.contains("tool-a"));
+    EXPECT_TRUE(sdk_info->bindings.contains("tool-b"));
+
+    auto* tool_a_info = xlings::xvm::get_vinfo(db, "tool-a");
+    ASSERT_NE(tool_a_info, nullptr);
+    EXPECT_TRUE(tool_a_info->bindings.contains("my-sdk"));
+
+    // Verify binding tree traversal starting from marker root
+    std::map<std::string, std::string> to_switch;
+    std::set<std::string> visited;
+    std::function<void(const std::string&, const std::string&)> collect;
+    collect = [&](const std::string& node, const std::string& ver) {
+        if (visited.contains(node)) return;
+        visited.insert(node);
+        to_switch[node] = ver;
+        auto info = xlings::xvm::get_vinfo(db, node);
+        if (!info) return;
+        for (auto& [peer, vermap] : info->bindings) {
+            auto it = vermap.find(ver);
+            if (it != vermap.end()) collect(peer, it->second);
+        }
+    };
+    collect("my-sdk", "1.0.0");
+
+    // All three should be collected: marker + 2 tools
+    EXPECT_EQ(to_switch.size(), 3u);
+    EXPECT_TRUE(to_switch.contains("my-sdk"));
+    EXPECT_TRUE(to_switch.contains("tool-a"));
+    EXPECT_TRUE(to_switch.contains("tool-b"));
+}
+
+TEST(XvmDbTest, MarkerMultipleVersionsBinding) {
+    xlings::xvm::VersionDB db;
+
+    // Install v1.0
+    xlings::xvm::add_version(db, "my-sdk", "1.0.0", "/pkg/v1", "marker");
+    xlings::xvm::add_version(db, "tool-a", "1.0.0", "/pkg/v1/bin",
+                             "program", "tool-a", "", "", "my-sdk@1.0.0");
+
+    // Install v2.0
+    xlings::xvm::add_version(db, "my-sdk", "2.0.0", "/pkg/v2", "marker");
+    xlings::xvm::add_version(db, "tool-a", "2.0.0", "/pkg/v2/bin",
+                             "program", "tool-a", "", "", "my-sdk@2.0.0");
+
+    // Switching to my-sdk@2.0.0 should cascade to tool-a@2.0.0
+    std::map<std::string, std::string> to_switch;
+    std::set<std::string> visited;
+    std::function<void(const std::string&, const std::string&)> collect;
+    collect = [&](const std::string& node, const std::string& ver) {
+        if (visited.contains(node)) return;
+        visited.insert(node);
+        to_switch[node] = ver;
+        auto info = xlings::xvm::get_vinfo(db, node);
+        if (!info) return;
+        for (auto& [peer, vermap] : info->bindings) {
+            auto it = vermap.find(ver);
+            if (it != vermap.end()) collect(peer, it->second);
+        }
+    };
+    collect("my-sdk", "2.0.0");
+
+    EXPECT_EQ(to_switch.size(), 2u);
+    EXPECT_EQ(to_switch["my-sdk"], "2.0.0");
+    EXPECT_EQ(to_switch["tool-a"], "2.0.0");
+
+    // Switching to my-sdk@1.0.0 should cascade to tool-a@1.0.0
+    to_switch.clear();
+    visited.clear();
+    collect("my-sdk", "1.0.0");
+
+    EXPECT_EQ(to_switch.size(), 2u);
+    EXPECT_EQ(to_switch["my-sdk"], "1.0.0");
+    EXPECT_EQ(to_switch["tool-a"], "1.0.0");
+}
+
+TEST(XvmDbTest, MarkerJsonRoundTrip) {
+    xlings::xvm::VersionDB db;
+
+    xlings::xvm::add_version(db, "my-sdk", "1.0.0", "/pkg/v1", "marker");
+    xlings::xvm::add_version(db, "tool-a", "1.0.0", "/pkg/v1/bin",
+                             "program", "tool-a", "", "", "my-sdk@1.0.0");
+
+    // Serialize
+    auto j = xlings::xvm::versions_to_json(db);
+
+    // Deserialize
+    auto db2 = xlings::xvm::versions_from_json(j);
+
+    // Verify marker type preserved
+    auto* vinfo = xlings::xvm::get_vinfo(db2, "my-sdk");
+    ASSERT_NE(vinfo, nullptr);
+    EXPECT_EQ(vinfo->type, "marker");
+
+    // Verify bindings preserved
+    EXPECT_TRUE(vinfo->bindings.contains("tool-a"));
+    auto* tool_info = xlings::xvm::get_vinfo(db2, "tool-a");
+    ASSERT_NE(tool_info, nullptr);
+    EXPECT_TRUE(tool_info->bindings.contains("my-sdk"));
+}
+
+TEST(XvmDbTest, MarkerNamespaced) {
+    xlings::xvm::VersionDB db;
+
+    // Non-primary repo: namespace "myrepo"
+    xlings::xvm::add_version(db, "my-sdk", "1.0.0", "/pkg/v1", "marker",
+                             "", "", "myrepo");
+    xlings::xvm::add_version(db, "tool-a", "1.0.0", "/pkg/v1/bin",
+                             "program", "tool-a", "", "myrepo",
+                             "my-sdk@1.0.0");
+
+    // Version key should be namespaced
+    EXPECT_TRUE(xlings::xvm::has_version(db, "my-sdk", "myrepo:1.0.0"));
+    EXPECT_TRUE(xlings::xvm::has_version(db, "tool-a", "myrepo:1.0.0"));
+
+    // Bindings should use namespaced keys
+    auto* sdk_info = xlings::xvm::get_vinfo(db, "my-sdk");
+    ASSERT_NE(sdk_info, nullptr);
+    auto bit = sdk_info->bindings.find("tool-a");
+    ASSERT_NE(bit, sdk_info->bindings.end());
+    // The binding maps namespaced version of tool-a to namespaced version of my-sdk
+    EXPECT_TRUE(bit->second.contains("myrepo:1.0.0"));
+}
+
+// ============================================================
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -1854,7 +1854,7 @@ TEST_F(ShimCreateTest, EnsureSubosShimsCreatesAll) {
     }
 }
 
-// COMPAT(0.4.8 → drop in 0.6.0): tests for xself::compat::cleanup_legacy_alias_shims.
+// COMPAT(0.4.8 → drop in 0.6.0): tests for compat::xself::cleanup_legacy_alias_shims.
 // Delete this whole TEST_F block when the compat module is removed.
 TEST_F(ShimCreateTest, CleanupLegacyAliasShimsRemovesOnlyMatchingSymlinks) {
 #if defined(_WIN32)
@@ -1875,7 +1875,7 @@ TEST_F(ShimCreateTest, CleanupLegacyAliasShimsRemovesOnlyMatchingSymlinks) {
     auto userFile = binDir / "xim";
     std::ofstream(userFile) << "user data\n";
 
-    xlings::xself::compat::v0_4_8::cleanup_legacy_alias_shims(binDir, src);
+    xlings::compat::xself::v0_4_8::cleanup_legacy_alias_shims(binDir, src);
 
     // Regular user file with a colliding name must survive.
     EXPECT_TRUE(fs::exists(userFile));


### PR DESCRIPTION
## Summary

- Add compat shim (`COMPAT 0.4.37 → drop in 0.6.0`) that auto-registers a `type="marker"` XVM entry for packages whose config hook doesn't call `xvm:add()` for `package.name`
- Extract `compute_version_ns_()` helper to eliminate duplicated namespace logic between `process_xvm_operations_` and the new compat function
- Add lint warning D1: warns xpkg authors when config hook registers tools but not `package.name` itself

**Problem**: Library/toolkit xpkgs (where `package.name` isn't an executable) that don't explicitly register themselves via `xvm:add()` break `xlings list` (subos mode), `xlings uninstall`, and binding-root version switching — because `workspace_installed` has no entry for the package.

**Solution**: After config hook completes, check if `node.name` was registered. If not, inject a marker entry that:
- Acts as binding root for `xlings use pkg@ver` cascade switching
- Doesn't create PATH shims (`type != "program"`)
- Enables subos-scoped list/uninstall/tracking

## Test plan

- [x] 5 new unit tests: `XvmDbTest.AddMarkerType`, `MarkerAsBindingRoot`, `MarkerMultipleVersionsBinding`, `MarkerJsonRoundTrip`, `MarkerNamespaced`
- [x] All 249 existing unit tests pass locally
- [ ] CI linux pipeline passes
- [ ] CI macOS/Windows pipelines pass