### PR TITLE
chore: bump version to 0.4.40

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.39";
+    static constexpr std::string_view VERSION = "0.4.40";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 


### PR DESCRIPTION
Bump VERSION constant in `src/core/config.cppm` from 0.4.39 → 0.4.40 to prepare the next release.

## What's in 0.4.40

Two changes shipped since v0.4.39 tag (cf647de):

- **feat(subos): `--gpu` opt-in NVIDIA/DRM passthrough for bwrap sandbox** (PR #302, already in 0.4.39 — yes 0.4.39 was tagged on the previous fix, so this carries forward)
- **fix(xim): propagate per-package install failures to exit code** (PR #303, the cmd_install silent-failure fix that motivates this release — mcpp and other interface consumers will now get correct exitCodes when packages fail)

## Follow-up

After this merges, dispatch `Release` workflow (workflow_dispatch) to build + publish v0.4.40 artifacts.