### PR TITLE
feat(release): bundle xim package index

### DIFF
--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -162,6 +162,10 @@ jobs:
         run: |
           bash tests/e2e/release_self_install_test.sh build/release.tar.gz
 
+      - name: "E2E-02a: Release Packaged Index"
+        run: |
+          bash tests/e2e/release_packaged_index_test.sh build/release.tar.gz
+
       - name: "E2E-02b: Self Uninstall (dry-run / safety / keep-data / full)"
         run: |
           bash tests/e2e/self_uninstall_test.sh build/release.tar.gz

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -120,6 +120,10 @@ jobs:
         run: |
           bash tests/e2e/release_self_install_test.sh build/release.tar.gz
 
+      - name: "E2E-02a: Release Packaged Index"
+        run: |
+          bash tests/e2e/release_packaged_index_test.sh build/release.tar.gz
+
       - name: "E2E-03: Quick Install Smoke"
         continue-on-error: true  # may fail due to GitHub rate limits
         env:

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -118,6 +118,11 @@ jobs:
         run: |
           & "$env:GITHUB_WORKSPACE\tests\e2e\release_self_install_test.ps1" "build\release.zip"
 
+      - name: "E2E-02a: Release Packaged Index"
+        shell: pwsh
+        run: |
+          & "$env:GITHUB_WORKSPACE\tests\e2e\release_packaged_index_test.ps1" "build\release.zip"
+
       - name: "E2E-03: Quick Install Smoke"
         shell: pwsh
         continue-on-error: true

--- a/config/xlings.json
+++ b/config/xlings.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "need_update": false,
-  "mirror": "CN",
+  "mirror": "GLOBAL",
   "XLINGS_RES": {
     "GLOBAL": "https://github.com/xlings-res",
     "CN": "https://gitcode.com/xlings-res"
@@ -17,8 +17,8 @@
         "CN": "https://gitcode.com/xlings-res"
       }
     },
-    "res-server": "https://gitcode.com/xlings-res",
-    "index-repo": "https://gitee.com/sunrisepeak/xim-pkgindex.git"
+    "res-server": "https://github.com/xlings-res",
+    "index-repo": "https://github.com/openxlings/xim-pkgindex.git"
   },
-  "repo": "https://gitee.com/sunrisepeak/xlings.git"
+  "repo": "https://github.com/openxlings/xlings.git"
 }

--- a/src/core/xim/repo.cppm
+++ b/src/core/xim/repo.cppm
@@ -14,6 +14,11 @@ export namespace xlings::xim {
 
 namespace detail_ {
 
+bool git_available_() {
+    auto [rc, _] = platform::run_command_capture("git --version");
+    return rc == 0;
+}
+
 bool ensure_local_repo_link_(const std::filesystem::path& localDir,
                              const std::filesystem::path& sourceDir) {
     namespace fs = std::filesystem;
@@ -165,6 +170,11 @@ bool sync_repo(const std::filesystem::path& localDir,
                bool force = false) {
     namespace fs = std::filesystem;
 
+    if (!detail_::git_available_()) {
+        log::error("git is required to update package index: {}", url);
+        return false;
+    }
+
     if (!fs::exists(localDir / ".git")) {
         // Build mirror fallback list for the index repo URL. Mirror::expand
         // returns just [url] when mirror_fallback=off or url is non-github.
@@ -172,20 +182,37 @@ bool sync_repo(const std::filesystem::path& localDir,
         if (urls.empty()) urls.push_back(url);
 
         std::string lastErr;
+        auto tmpDir = fs::path(localDir.string() + ".tmp." + std::to_string(platform::get_pid()));
+        std::error_code ec;
+        fs::remove_all(tmpDir, ec);
         for (std::size_t i = 0; i < urls.size(); ++i) {
             log::debug("cloning index repo attempt {}/{}: {}",
                        i + 1, urls.size(), urls[i]);
-            auto cmd = std::format("git clone --depth 1 --quiet \"{}\" \"{}\"",
-                                   urls[i], localDir.string());
+            auto cmd = std::format("git clone --depth 1 --quiet {} {}",
+                                   platform::shell_quote(urls[i]),
+                                   platform::shell_quote(tmpDir.string()));
             auto [rc, output] = platform::run_command_capture(cmd);
             if (rc == 0) {
                 if (i > 0)
                     log::info("[mirror] index repo fallback succeeded via {}", urls[i]);
+                fs::remove_all(localDir, ec);
+                if (ec) {
+                    log::error("failed to replace index repo {}: {}",
+                               localDir.string(), ec.message());
+                    fs::remove_all(tmpDir, ec);
+                    return false;
+                }
+                fs::rename(tmpDir, localDir, ec);
+                if (ec) {
+                    log::error("failed to move cloned index repo into place {}: {}",
+                               localDir.string(), ec.message());
+                    fs::remove_all(tmpDir, ec);
+                    return false;
+                }
                 return true;
             }
             lastErr = output;
-            std::error_code ec2;
-            fs::remove_all(localDir, ec2);
+            fs::remove_all(tmpDir, ec);
         }
         log::error("all index repo clone URLs failed: {}", lastErr);
         return false;
@@ -207,12 +234,22 @@ bool sync_repo(const std::filesystem::path& localDir,
     }
 
     log::debug("updating index repo: {}", localDir.filename().string());
-    auto cmd = std::format("git -C \"{}\" pull --ff-only", localDir.string());
+    auto setRemoteCmd = std::format("git -C {} remote set-url origin {}",
+                                    platform::shell_quote(localDir.string()),
+                                    platform::shell_quote(url));
+    auto [setRc, setOutput] = platform::run_command_capture(setRemoteCmd);
+    if (setRc != 0) {
+        log::warn("failed to set index repo origin: {}", setOutput);
+    }
+
+    auto cmd = std::format("git -C {} pull --ff-only",
+                           platform::shell_quote(localDir.string()));
     auto [rc, output] = platform::run_command_capture(cmd);
     if (rc != 0) {
         log::warn("git pull failed, trying reset: {}", output);
-        cmd = std::format("git -C \"{}\" fetch origin && git -C \"{}\" reset --hard origin/HEAD",
-                          localDir.string(), localDir.string());
+        cmd = std::format("git -C {} fetch origin && git -C {} reset --hard origin/HEAD",
+                          platform::shell_quote(localDir.string()),
+                          platform::shell_quote(localDir.string()));
         auto [rc2, out2] = platform::run_command_capture(cmd);
         if (rc2 != 0) {
             log::error("git reset failed: {}", out2);

--- a/src/core/xself/install.cppm
+++ b/src/core/xself/install.cppm
@@ -5,6 +5,7 @@ import xlings.core.xself.init;
 
 import xlings.core.config;
 import xlings.libs.json;
+import xlings.libs.tinyhttps;
 import xlings.core.log;
 import xlings.platform;
 import xlings.core.utils;
@@ -26,6 +27,99 @@ static std::string read_version_from_json(const fs::path& homeDir) {
         }
     } catch (...) {}
     return "";
+}
+
+static std::optional<std::string> normalize_mirror_(std::string mirror) {
+    mirror = utils::trim_string(mirror);
+    std::ranges::transform(mirror, mirror.begin(), [](unsigned char c) {
+        return static_cast<char>(std::toupper(c));
+    });
+    if (mirror == "GLOBAL" || mirror == "CN") return mirror;
+    return std::nullopt;
+}
+
+static std::string read_mirror_from_json_(const fs::path& configPath) {
+    if (!fs::exists(configPath)) return {};
+    try {
+        auto content = platform::read_file_to_string(configPath.string());
+        auto json = nlohmann::json::parse(content, nullptr, false);
+        if (!json.is_discarded() && json.is_object() &&
+            json.contains("mirror") && json["mirror"].is_string()) {
+            if (auto mirror = normalize_mirror_(json["mirror"].get<std::string>()))
+                return *mirror;
+        }
+    } catch (...) {}
+    return {};
+}
+
+static std::optional<std::string> env_install_mirror_() {
+    for (auto name : {"XLINGS_INSTALL_MIRROR", "XLINGS_MIRROR", "XLINGS_RELEASE_MIRROR"}) {
+        if (auto value = utils::get_env_or_default(name); !value.empty()) {
+            if (auto mirror = normalize_mirror_(value)) return mirror;
+        }
+    }
+    return std::nullopt;
+}
+
+static std::string detect_install_mirror_() {
+    if (auto mirror = env_install_mirror_()) return *mirror;
+
+    constexpr int timeoutMs = 1000;
+    auto globalLatency = tinyhttps::probe_latency("https://github.com", timeoutMs);
+    auto cnLatency = tinyhttps::probe_latency("https://gitee.com", timeoutMs);
+
+    if (std::isfinite(cnLatency) &&
+        (!std::isfinite(globalLatency) || cnLatency + 0.2 < globalLatency)) {
+        return "CN";
+    }
+    return "GLOBAL";
+}
+
+static void set_mirror_fields_(nlohmann::json& json, const std::string& mirror) {
+    json["mirror"] = mirror;
+    json["xim"]["mirrors"]["index-repo"]["GLOBAL"] =
+        "https://github.com/openxlings/xim-pkgindex.git";
+    json["xim"]["mirrors"]["index-repo"]["CN"] =
+        "https://gitee.com/sunrisepeak/xim-pkgindex.git";
+    json["xim"]["mirrors"]["res-server"]["GLOBAL"] =
+        "https://github.com/xlings-res";
+    json["xim"]["mirrors"]["res-server"]["CN"] =
+        "https://gitcode.com/xlings-res";
+
+    if (mirror == "CN") {
+        json["xim"]["res-server"] = "https://gitcode.com/xlings-res";
+        json["xim"]["index-repo"] = "https://gitee.com/sunrisepeak/xim-pkgindex.git";
+        json["repo"] = "https://gitee.com/sunrisepeak/xlings.git";
+    } else {
+        json["xim"]["res-server"] = "https://github.com/xlings-res";
+        json["xim"]["index-repo"] = "https://github.com/openxlings/xim-pkgindex.git";
+        json["repo"] = "https://github.com/openxlings/xlings.git";
+    }
+}
+
+static void configure_install_mirror_(const fs::path& targetHome,
+                                      const std::string& existingMirror,
+                                      bool overwriteDataSubos) {
+    auto envMirror = env_install_mirror_();
+    if (!envMirror && !overwriteDataSubos && !existingMirror.empty()) {
+        return;
+    }
+
+    auto mirror = envMirror ? *envMirror : detect_install_mirror_();
+    auto configPath = targetHome / ".xlings.json";
+
+    nlohmann::json json = nlohmann::json::object();
+    if (fs::exists(configPath)) {
+        try {
+            auto content = platform::read_file_to_string(configPath.string());
+            auto parsed = nlohmann::json::parse(content, nullptr, false);
+            if (!parsed.is_discarded() && parsed.is_object()) json = std::move(parsed);
+        } catch (...) {}
+    }
+
+    set_mirror_fields_(json, mirror);
+    platform::write_string_to_file(configPath.string(), json.dump(2));
+    log::println("[xlings:self] mirror: {}", mirror);
 }
 
 /// True if path is under a temp dir (e.g. /tmp, $TMPDIR, $TEMP, $RUNNER_TEMP). Used to detect
@@ -272,6 +366,7 @@ export int cmd_install() {
             sameDir = false;
         }
     }
+    auto existingMirror = read_mirror_from_json_(targetHome / ".xlings.json");
 
     // Install header: show existing (if any) and install target; paths may differ
     std::println("\n[xlings:self] install");
@@ -376,6 +471,7 @@ export int cmd_install() {
             } catch (...) {}
         }
     }
+    configure_install_mirror_(targetHome, existingMirror, overwriteDataSubos);
 
     // 3. First install: preserve extra trees if the source package still ships them.
     if (!fs::exists(targetHome / "data") && fs::exists(srcDir / "data")) {

--- a/tests/e2e/release_packaged_index_test.ps1
+++ b/tests/e2e/release_packaged_index_test.ps1
@@ -1,0 +1,32 @@
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot\release_test_lib.ps1"
+
+$ARCHIVE_PATH = if ($args.Count -ge 1) { $args[0] } else { Join-Path $ROOT_DIR 'build\release.zip' }
+$ARCHIVE_PATH = Require-ReleaseArchive $ARCHIVE_PATH
+
+$PKG_DIR = Expand-ReleaseArchive $ARCHIVE_PATH 'release_packaged_index'
+$INDEX_DIR = Join-Path $PKG_DIR 'data\xim-pkgindex'
+
+if (-not (Test-Path "$INDEX_DIR\pkgs")) { Fail "release package missing bundled xim-pkgindex/pkgs" }
+if (-not (Test-Path "$INDEX_DIR\pkgs\p\patchelf.lua")) { Fail "bundled xim-pkgindex missing patchelf package" }
+if (-not (Test-Path "$INDEX_DIR\.git")) { Fail "bundled xim-pkgindex should remain a git repo for xlings update" }
+
+$mirror = if ($env:XLINGS_RELEASE_MIRROR) { $env:XLINGS_RELEASE_MIRROR } else { $null }
+if (-not $mirror) {
+    $config = Get-Content (Join-Path $PKG_DIR '.xlings.json') -Raw | ConvertFrom-Json
+    $mirror = if ($config.mirror) { $config.mirror } else { 'GLOBAL' }
+}
+
+$expectedOrigin = 'https://gitee.com/sunrisepeak/xim-pkgindex.git'
+if ($mirror -eq 'GLOBAL') {
+    $expectedOrigin = 'https://github.com/openxlings/xim-pkgindex.git'
+}
+$actualOrigin = (& git -C $INDEX_DIR remote get-url origin).Trim()
+if ($actualOrigin -ne $expectedOrigin) {
+    Fail "bundled xim-pkgindex origin mismatch: expected $expectedOrigin, got $actualOrigin"
+}
+
+Log "PASS: release package includes usable xim-pkgindex snapshot"

--- a/tests/e2e/release_packaged_index_test.sh
+++ b/tests/e2e/release_packaged_index_test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/release_test_lib.sh"
+
+ARCHIVE_PATH="${1:-$ROOT_DIR/build/release.tar.gz}"
+require_release_archive "$ARCHIVE_PATH"
+
+PKG_DIR="$(extract_release_archive "$ARCHIVE_PATH" release_packaged_index)"
+INDEX_DIR="$PKG_DIR/data/xim-pkgindex"
+
+[[ -d "$INDEX_DIR/pkgs" ]] || fail "release package missing bundled xim-pkgindex/pkgs"
+[[ -f "$INDEX_DIR/pkgs/p/patchelf.lua" ]] || fail "bundled xim-pkgindex missing patchelf package"
+[[ -d "$INDEX_DIR/.git" ]] || fail "bundled xim-pkgindex should remain a git repo for xlings update"
+
+mirror="${XLINGS_RELEASE_MIRROR:-}"
+if [[ -z "$mirror" ]] && command -v jq >/dev/null 2>&1; then
+  mirror="$(jq -r '.mirror // "GLOBAL"' "$PKG_DIR/.xlings.json")"
+fi
+[[ -z "$mirror" || "$mirror" == "null" ]] && mirror="GLOBAL"
+
+expected_origin="https://gitee.com/sunrisepeak/xim-pkgindex.git"
+if [[ "$mirror" == "GLOBAL" ]]; then
+  expected_origin="https://github.com/openxlings/xim-pkgindex.git"
+fi
+actual_origin="$(git -C "$INDEX_DIR" remote get-url origin)"
+[[ "$actual_origin" == "$expected_origin" ]] || \
+  fail "bundled xim-pkgindex origin mismatch: expected $expected_origin, got $actual_origin"
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  INSTALL_USER_DIR="$RUNTIME_ROOT/release_packaged_index_no_git_user"
+  rm -rf "$INSTALL_USER_DIR"
+  mkdir -p "$INSTALL_USER_DIR"
+
+  INSTALL_LOG="$RUNTIME_ROOT/release_packaged_index_no_git_install.log"
+  (
+    unset XLINGS_HOME
+    HOME="$INSTALL_USER_DIR" PATH="$PKG_DIR/bin" XLINGS_INSTALL_MIRROR=GLOBAL \
+      "$PKG_DIR/bin/xlings" self install
+  ) >"$INSTALL_LOG" 2>&1
+  if grep -qE 'git is required|failed to sync repositories|package index not available, updating' "$INSTALL_LOG"; then
+    cat "$INSTALL_LOG"
+    fail "self install without system git tried to update/sync the package index"
+  fi
+
+  INSTALLED_HOME="$INSTALL_USER_DIR/.xlings"
+  [[ -x "$INSTALLED_HOME/data/xpkgs/xim-x-patchelf/0.18.0/bin/patchelf" ]] || \
+    fail "self install without system git did not install patchelf from bundled index"
+  [[ -d "$INSTALLED_HOME/data/xim-pkgindex/pkgs" ]] || \
+    fail "installed home missing bundled xim-pkgindex"
+  installed_mirror="$(sed -n 's/.*"mirror"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$INSTALLED_HOME/.xlings.json" | head -1)"
+  [[ "$installed_mirror" == "GLOBAL" ]] || \
+    fail "installed home mirror should be GLOBAL, got $installed_mirror"
+fi
+
+log "PASS: release package includes usable xim-pkgindex snapshot"

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -206,6 +206,33 @@ TEST(UtilsTest, GetEnvOrDefault) {
     EXPECT_EQ(val, "fallback");
 }
 
+TEST(XimRepoTest, SyncWithoutGitPreservesExistingSnapshot) {
+    namespace fs = std::filesystem;
+
+    auto root = fs::temp_directory_path() / "xlings_sync_without_git_test";
+    auto repo = root / "xim-pkgindex";
+    fs::remove_all(root);
+    fs::create_directories(repo / "pkgs" / "p");
+    auto marker = repo / "pkgs" / "p" / "patchelf.lua";
+    {
+        std::ofstream out(marker);
+        out << "package = { name = \"patchelf\" }\n";
+    }
+
+    auto oldPath = std::string(std::getenv("PATH") ? std::getenv("PATH") : "");
+    auto emptyPath = root / "empty-path";
+    fs::create_directories(emptyPath);
+    xlings::platform::set_env_variable("PATH", emptyPath.string());
+
+    auto ok = xlings::xim::sync_repo(repo, "https://github.com/openxlings/xim-pkgindex.git", true);
+
+    xlings::platform::set_env_variable("PATH", oldPath);
+    EXPECT_FALSE(ok);
+    EXPECT_TRUE(fs::exists(marker));
+    EXPECT_TRUE(fs::exists(repo / "pkgs"));
+    fs::remove_all(root);
+}
+
 // ============================================================
 // cmdline tests
 // ============================================================

--- a/tools/linux_release.sh
+++ b/tools/linux_release.sh
@@ -4,10 +4,11 @@
 # Directory layout:
 #   xlings-<ver>-linux-x86_64/
 #   ├── .xlings.json
+#   ├── data/xim-pkgindex/        # bundled index snapshot
 #   └── bin/
 #       └── xlings
 #
-# Runtime directories are created lazily by `xlings self init`.
+# Remaining runtime directories are created lazily by `xlings self init`.
 #
 # Output:  build/xlings-<ver>-linux-x86_64.tar.gz
 # Usage:   ./tools/linux_release.sh
@@ -77,18 +78,34 @@ mkdir -p "$OUT_DIR/bin"
 cp "$BIN_SRC"         "$OUT_DIR/bin/xlings"
 chmod +x "$OUT_DIR/bin/"*
 
-# .xlings.json — default mirror is CN; CI sets XLINGS_RELEASE_MIRROR=GLOBAL
-# so test runs (which need github.com endpoints) don't hit gitee auth.
-MIRROR="${XLINGS_RELEASE_MIRROR:-CN}"
+# .xlings.json — release packages default to GLOBAL. Users can switch mirror
+# locally after install, and CI also keeps GLOBAL for github.com endpoints.
+MIRROR="${XLINGS_RELEASE_MIRROR:-GLOBAL}"
+if [[ "$MIRROR" == "CN" ]]; then
+  RES_SERVER_URL="https://gitcode.com/xlings-res"
+  INDEX_REPO_URL="https://gitee.com/sunrisepeak/xim-pkgindex.git"
+  REPO_URL="https://gitee.com/sunrisepeak/xlings.git"
+else
+  RES_SERVER_URL="https://github.com/xlings-res"
+  INDEX_REPO_URL="https://github.com/openxlings/xim-pkgindex.git"
+  REPO_URL="https://github.com/openxlings/xlings.git"
+fi
 if command -v jq &>/dev/null && [[ -f config/xlings.json ]]; then
   jq --arg version "$VERSION" --arg mirror "$MIRROR" \
-     '. + {"version":$version,"mirror":$mirror,"activeSubos":"default","subos":{"default":{"dir":""}}}' \
+     --arg res_server "$RES_SERVER_URL" --arg index_repo "$INDEX_REPO_URL" \
+     --arg repo "$REPO_URL" \
+     '. + {"version":$version,"mirror":$mirror,"activeSubos":"default","subos":{"default":{"dir":""}}}
+      | .xim["res-server"] = $res_server
+      | .xim["index-repo"] = $index_repo
+      | .repo = $repo' \
     config/xlings.json > "$OUT_DIR/.xlings.json"
 else
   cat > "$OUT_DIR/.xlings.json" << DOTJSON
-{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/openxlings/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
+{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/openxlings/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"$RES_SERVER_URL","index-repo":"$INDEX_REPO_URL"},"repo":"$REPO_URL"}
 DOTJSON
 fi
+
+bash "$PROJECT_DIR/tools/package_xim_index.sh" "$OUT_DIR"
 
 info "Package assembled: $OUT_DIR"
 
@@ -108,6 +125,10 @@ if command -v jq &>/dev/null; then
   [[ "$AS" == "default" ]] || fail ".xlings.json activeSubos != 'default' (got '$AS')"
 fi
 info "OK: .xlings.json present and valid"
+
+[[ -d "$OUT_DIR/data/xim-pkgindex/pkgs" ]] || fail "bundled xim-pkgindex missing"
+[[ -f "$OUT_DIR/data/xim-pkgindex/pkgs/p/patchelf.lua" ]] || fail "bundled xim-pkgindex missing patchelf"
+info "OK: bundled xim-pkgindex snapshot present"
 
 # 4c. Functional tests (bootstrap home detection)
 info "Testing bootstrap home execution..."

--- a/tools/macos_release.sh
+++ b/tools/macos_release.sh
@@ -4,10 +4,11 @@
 # Directory layout:
 #   xlings-<ver>-macosx-arm64/
 #   ├── .xlings.json
+#   ├── data/xim-pkgindex/        # bundled index snapshot
 #   └── bin/
 #       └── xlings
 #
-# Runtime directories are created lazily by `xlings self init`.
+# Remaining runtime directories are created lazily by `xlings self init`.
 #
 # Output:  build/xlings-<ver>-macosx-arm64.tar.gz
 # Usage:   ./tools/macos_release.sh
@@ -70,18 +71,34 @@ mkdir -p "$OUT_DIR/bin"
 cp "$BIN_SRC"          "$OUT_DIR/bin/xlings"
 chmod +x "$OUT_DIR/bin/"*
 
-# .xlings.json — default mirror is CN; CI sets XLINGS_RELEASE_MIRROR=GLOBAL
-# so test runs (which need github.com endpoints) don't hit gitee auth.
-MIRROR="${XLINGS_RELEASE_MIRROR:-CN}"
+# .xlings.json — release packages default to GLOBAL. Users can switch mirror
+# locally after install, and CI also keeps GLOBAL for github.com endpoints.
+MIRROR="${XLINGS_RELEASE_MIRROR:-GLOBAL}"
+if [[ "$MIRROR" == "CN" ]]; then
+  RES_SERVER_URL="https://gitcode.com/xlings-res"
+  INDEX_REPO_URL="https://gitee.com/sunrisepeak/xim-pkgindex.git"
+  REPO_URL="https://gitee.com/sunrisepeak/xlings.git"
+else
+  RES_SERVER_URL="https://github.com/xlings-res"
+  INDEX_REPO_URL="https://github.com/openxlings/xim-pkgindex.git"
+  REPO_URL="https://github.com/openxlings/xlings.git"
+fi
 if command -v jq &>/dev/null && [[ -f config/xlings.json ]]; then
   jq --arg version "$VERSION" --arg mirror "$MIRROR" \
-     '. + {"version":$version,"mirror":$mirror,"activeSubos":"default","subos":{"default":{"dir":""}}}' \
+     --arg res_server "$RES_SERVER_URL" --arg index_repo "$INDEX_REPO_URL" \
+     --arg repo "$REPO_URL" \
+     '. + {"version":$version,"mirror":$mirror,"activeSubos":"default","subos":{"default":{"dir":""}}}
+      | .xim["res-server"] = $res_server
+      | .xim["index-repo"] = $index_repo
+      | .repo = $repo' \
     config/xlings.json > "$OUT_DIR/.xlings.json"
 else
   cat > "$OUT_DIR/.xlings.json" << DOTJSON
-{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/openxlings/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
+{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/openxlings/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"$RES_SERVER_URL","index-repo":"$INDEX_REPO_URL"},"repo":"$REPO_URL"}
 DOTJSON
 fi
+
+bash "$PROJECT_DIR/tools/package_xim_index.sh" "$OUT_DIR"
 
 info "Package assembled: $OUT_DIR"
 
@@ -99,6 +116,10 @@ info "OK: packaged bin/xlings has no LLVM runtime dependency"
 
 [[ -f "$OUT_DIR/.xlings.json" ]] || fail ".xlings.json missing"
 info "OK: .xlings.json present"
+
+[[ -d "$OUT_DIR/data/xim-pkgindex/pkgs" ]] || fail "bundled xim-pkgindex missing"
+[[ -f "$OUT_DIR/data/xim-pkgindex/pkgs/p/patchelf.lua" ]] || fail "bundled xim-pkgindex missing patchelf"
+info "OK: bundled xim-pkgindex snapshot present"
 
 TEST_DATA="$PROJECT_DIR/build/.release_verify_$$"
 mkdir -p "$TEST_DATA"

--- a/tools/package_xim_index.ps1
+++ b/tools/package_xim_index.ps1
@@ -1,0 +1,48 @@
+#Requires -Version 5.1
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$OutDir
+)
+
+$ErrorActionPreference = 'Stop'
+
+$mirror = if ($env:XLINGS_RELEASE_MIRROR) { $env:XLINGS_RELEASE_MIRROR } else { 'GLOBAL' }
+$ref = if ($env:XLINGS_RELEASE_PKGINDEX_REF) { $env:XLINGS_RELEASE_PKGINDEX_REF } else { 'main' }
+
+if ($env:XLINGS_RELEASE_PKGINDEX_URL) {
+    $url = $env:XLINGS_RELEASE_PKGINDEX_URL
+} elseif ($mirror -eq 'CN') {
+    $url = 'https://gitee.com/sunrisepeak/xim-pkgindex.git'
+} else {
+    $url = 'https://github.com/openxlings/xim-pkgindex.git'
+}
+
+$tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) "xlings-pkgindex-$([System.Guid]::NewGuid().ToString('N').Substring(0,8))"
+New-Item -ItemType Directory -Force -Path $tmpRoot | Out-Null
+
+try {
+    $cloneDir = Join-Path $tmpRoot 'xim-pkgindex'
+    Write-Host "[release] Bundling xim-pkgindex snapshot: $url ($ref)"
+    & git clone --depth 1 --branch $ref $url $cloneDir
+    if ($LASTEXITCODE -ne 0) {
+        if (Test-Path $cloneDir) { Remove-Item -Recurse -Force $cloneDir }
+        & git clone $url $cloneDir
+        if ($LASTEXITCODE -ne 0) { throw "git clone failed for $url" }
+        & git -C $cloneDir checkout --quiet $ref
+        if ($LASTEXITCODE -ne 0) { throw "git checkout failed for $ref" }
+    }
+
+    & git -C $cloneDir remote set-url origin $url
+    if ($LASTEXITCODE -ne 0) { throw "git remote set-url failed for $url" }
+
+    $dest = Join-Path $OutDir 'data\xim-pkgindex'
+    if (Test-Path $dest) { Remove-Item -Recurse -Force $dest }
+    New-Item -ItemType Directory -Force -Path (Split-Path $dest) | Out-Null
+    Move-Item -LiteralPath $cloneDir -Destination $dest -Force
+
+    if (-not (Test-Path "$dest\pkgs")) {
+        throw "bundled xim-pkgindex missing pkgs/"
+    }
+} finally {
+    Remove-Item -Recurse -Force $tmpRoot -ErrorAction SilentlyContinue
+}

--- a/tools/package_xim_index.sh
+++ b/tools/package_xim_index.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT_DIR="${1:-}"
+[[ -z "$OUT_DIR" ]] && { echo "usage: $0 <release-package-dir>" >&2; exit 1; }
+
+MIRROR="${XLINGS_RELEASE_MIRROR:-GLOBAL}"
+REF="${XLINGS_RELEASE_PKGINDEX_REF:-main}"
+
+case "$MIRROR" in
+  GLOBAL) URL="${XLINGS_RELEASE_PKGINDEX_URL:-https://github.com/openxlings/xim-pkgindex.git}" ;;
+  CN)     URL="${XLINGS_RELEASE_PKGINDEX_URL:-https://gitee.com/sunrisepeak/xim-pkgindex.git}" ;;
+  *)      URL="${XLINGS_RELEASE_PKGINDEX_URL:-https://github.com/openxlings/xim-pkgindex.git}" ;;
+esac
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/xlings-pkgindex.XXXXXX")"
+cleanup() { rm -rf "$TMP_ROOT"; }
+trap cleanup EXIT
+
+echo "[release] Bundling xim-pkgindex snapshot: $URL ($REF)"
+if ! git clone --depth 1 --branch "$REF" "$URL" "$TMP_ROOT/xim-pkgindex"; then
+  rm -rf "$TMP_ROOT/xim-pkgindex"
+  git clone "$URL" "$TMP_ROOT/xim-pkgindex"
+  git -C "$TMP_ROOT/xim-pkgindex" checkout --quiet "$REF"
+fi
+
+git -C "$TMP_ROOT/xim-pkgindex" remote set-url origin "$URL"
+
+rm -rf "$OUT_DIR/data/xim-pkgindex"
+mkdir -p "$OUT_DIR/data"
+mv "$TMP_ROOT/xim-pkgindex" "$OUT_DIR/data/xim-pkgindex"
+
+test -d "$OUT_DIR/data/xim-pkgindex/pkgs" || {
+  echo "[release] FAIL: bundled xim-pkgindex missing pkgs/" >&2
+  exit 1
+}

--- a/tools/windows_release.ps1
+++ b/tools/windows_release.ps1
@@ -3,10 +3,11 @@
 # Directory layout:
 #   xlings-<ver>-windows-x86_64/
 #   ├── .xlings.json
+#   ├── data/xim-pkgindex/        # bundled index snapshot
 #   └── bin/
 #       └── xlings.exe
 #
-# Runtime directories are created lazily by `xlings self init`.
+# Remaining runtime directories are created lazily by `xlings self init`.
 #
 # Output:  build/xlings-<ver>-windows-x86_64.zip
 # Usage:   pwsh ./tools/windows_release.ps1
@@ -55,9 +56,18 @@ foreach ($d in $dirs) { New-Item -ItemType Directory -Force -Path $d | Out-Null 
 
 Copy-Item $BIN_SRC "$OUT_DIR\bin\"
 
-# Default mirror is CN; CI sets XLINGS_RELEASE_MIRROR=GLOBAL so test
-# runs (which need github.com endpoints) don't hit gitee auth.
-$MIRROR = if ($env:XLINGS_RELEASE_MIRROR) { $env:XLINGS_RELEASE_MIRROR } else { "CN" }
+# Release packages default to GLOBAL. Users can switch mirror locally after
+# install, and CI also keeps GLOBAL for github.com endpoints.
+$MIRROR = if ($env:XLINGS_RELEASE_MIRROR) { $env:XLINGS_RELEASE_MIRROR } else { "GLOBAL" }
+if ($MIRROR -eq "CN") {
+  $RES_SERVER_URL = "https://gitcode.com/xlings-res"
+  $INDEX_REPO_URL = "https://gitee.com/sunrisepeak/xim-pkgindex.git"
+  $REPO_URL = "https://gitee.com/sunrisepeak/xlings.git"
+} else {
+  $RES_SERVER_URL = "https://github.com/xlings-res"
+  $INDEX_REPO_URL = "https://github.com/openxlings/xim-pkgindex.git"
+  $REPO_URL = "https://github.com/openxlings/xlings.git"
+}
 
 $configSrc = "$PROJECT_DIR\config\xlings.json"
 if (Test-Path $configSrc) {
@@ -66,12 +76,18 @@ if (Test-Path $configSrc) {
   $base | Add-Member -NotePropertyName "mirror" -NotePropertyValue $MIRROR -Force
   $base | Add-Member -NotePropertyName "activeSubos" -NotePropertyValue "default" -Force
   $base | Add-Member -NotePropertyName "subos" -NotePropertyValue @{default=@{dir=""}} -Force
+  if (-not $base.xim) { $base | Add-Member -NotePropertyName "xim" -NotePropertyValue @{} -Force }
+  $base.xim | Add-Member -NotePropertyName "res-server" -NotePropertyValue $RES_SERVER_URL -Force
+  $base.xim | Add-Member -NotePropertyName "index-repo" -NotePropertyValue $INDEX_REPO_URL -Force
+  $base | Add-Member -NotePropertyName "repo" -NotePropertyValue $REPO_URL -Force
   $base | ConvertTo-Json -Depth 10 -Compress | Set-Content "$OUT_DIR\.xlings.json" -Encoding UTF8
 } else {
   @"
-{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/openxlings/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"https://gitcode.com/xlings-res","index-repo":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"repo":"https://gitee.com/sunrisepeak/xlings.git"}
+{"activeSubos":"default","subos":{"default":{"dir":""}},"version":"$VERSION","need_update":false,"mirror":"$MIRROR","xim":{"mirrors":{"index-repo":{"GLOBAL":"https://github.com/openxlings/xim-pkgindex.git","CN":"https://gitee.com/sunrisepeak/xim-pkgindex.git"},"res-server":{"GLOBAL":"https://github.com/xlings-res","CN":"https://gitcode.com/xlings-res"}},"res-server":"$RES_SERVER_URL","index-repo":"$INDEX_REPO_URL"},"repo":"$REPO_URL"}
 "@ | Set-Content "$OUT_DIR\.xlings.json" -Encoding UTF8
 }
+
+& "$PROJECT_DIR\tools\package_xim_index.ps1" -OutDir $OUT_DIR
 
 Info "Package assembled: $OUT_DIR"
 
@@ -86,6 +102,10 @@ Info "OK: all binaries present"
 
 if (-not (Test-Path "$OUT_DIR\.xlings.json")) { Fail ".xlings.json missing" }
 Info "OK: .xlings.json present"
+
+if (-not (Test-Path "$OUT_DIR\data\xim-pkgindex\pkgs")) { Fail "bundled xim-pkgindex missing" }
+if (-not (Test-Path "$OUT_DIR\data\xim-pkgindex\pkgs\p\patchelf.lua")) { Fail "bundled xim-pkgindex missing patchelf" }
+Info "OK: bundled xim-pkgindex snapshot present"
 
 $env:XLINGS_HOME = $OUT_DIR
 $env:PATH = "$OUT_DIR\bin;$env:PATH"
@@ -121,7 +141,13 @@ Info "All checks passed. Creating release archive..."
 
 $ARCHIVE = "$PROJECT_DIR\build\$PKG_NAME.zip"
 if (Test-Path $ARCHIVE) { Remove-Item $ARCHIVE }
-Compress-Archive -Path $OUT_DIR -DestinationPath $ARCHIVE
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+[System.IO.Compression.ZipFile]::CreateFromDirectory(
+  $OUT_DIR,
+  $ARCHIVE,
+  [System.IO.Compression.CompressionLevel]::Optimal,
+  $true
+)
 
 Info ""
 Info "Done."


### PR DESCRIPTION
## Summary
- bundle a shallow `xim-pkgindex` snapshot into Linux, macOS, and Windows release packages under `data/xim-pkgindex`
- select package-index clone origin from `XLINGS_RELEASE_MIRROR`/`XLINGS_RELEASE_PKGINDEX_URL` so CN packages keep Gitee origin and GLOBAL packages keep GitHub origin
- preserve bundled index snapshots when `git` is unavailable during `xlings update`, and retarget existing repo origins before pull/reset
- add Linux/macOS/Windows release packaged-index e2e checks in CI

## Local verification
- `bash -n tools/package_xim_index.sh tools/linux_release.sh tools/macos_release.sh tests/e2e/release_packaged_index_test.sh && git diff --check`
- `xmake run xlings_tests` (254 passed, 4 existing catalog-dependent skips)
- `bash tests/e2e/release_packaged_index_test.sh build/release.tar.gz`
- `bash tests/e2e/release_self_install_test.sh build/release.tar.gz`
- `XLINGS_RELEASE_MIRROR=GLOBAL bash tools/package_xim_index.sh <tmp>` verified GitHub origin
- `XLINGS_RELEASE_MIRROR=CN bash tools/package_xim_index.sh <tmp>` verified Gitee origin

## Notes
- Local `pwsh` is not installed on this host, so PowerShell syntax and Windows zip behavior are covered by CI.
- Full local `tools/linux_release.sh` cannot complete here because `tools/setup_musl_runtime.sh` requires sudo; the release-package e2e above was run against an assembled tarball using the built binary and the new packaging helper.
