### PR TITLE
[codex] fix config install state and Windows installer probing

### DIFF
--- a/.agents/docs/2026-05-27-config-package-repeatable-design.md
+++ b/.agents/docs/2026-05-27-config-package-repeatable-design.md
@@ -1,0 +1,164 @@
+# Config Package Repeatable Design
+
+> Date: 2026-05-27
+> Status: design note for PR #306 and follow-up libxpkg/spec work
+
+## Summary
+
+`type = "config"` should mean a repeatable configuration procedure, not an installed package.
+
+A config package may depend on normal packages and may execute configuration logic after those dependencies are available. It should not own install artifacts, should not create an implicit installed state, and should generally avoid registering itself through xvm. Its core value is to provide a reentrant configuration code path that can be run more than once safely.
+
+This definition intentionally narrows `config` so package authors do not need to reason about install markers, versioned payload directories, uninstall snapshots, or xvm deregistration for a package that is only meant to configure an environment.
+
+## Definition
+
+A `config` package is:
+
+- a repeatable configuration procedure;
+- dependency-aware;
+- reentrant and expected to tolerate repeated execution;
+- usually implemented with `config()`;
+- normally not uninstallable, because it has no owned install payload.
+
+A `config` package is not:
+
+- a package with its own installed payload;
+- a package that owns package payload files under `pkginfo.install_dir()`;
+- a package that should become installed because xlings created metadata;
+- an xvm registration unit;
+- a good place for irreversible or non-idempotent system mutation.
+
+## Lifecycle Contract
+
+Recommended shape:
+
+```lua
+package = {
+    spec = "1",
+    name = "example-config",
+    type = "config",
+    xpm = {
+        linux = {
+            deps = { "some-tool" },
+            ["latest"] = { ref = "1.0.0" },
+            ["1.0.0"] = {},
+        },
+    },
+}
+
+function config()
+    -- Reentrant configuration logic only.
+    return true
+end
+```
+
+Lifecycle constraints:
+
+- `install()` is discouraged for `type = "config"`.
+- `config()` is the primary entrypoint.
+- `installed()` is discouraged because config packages should not rely on a persistent installed state.
+- `uninstall()` is optional and should only exist when the config procedure creates a deliberate, reversible external side effect.
+- Hooks must be idempotent. Running `xlings install <config>` multiple times should not corrupt user or system state.
+- Hooks should use explicit paths such as user config paths, dependency paths, or `system.rundir()` when needed. They should not rely on `pkginfo.install_dir()` as durable package-owned storage.
+
+## Dependency Semantics
+
+Config packages may have dependencies.
+
+Those dependencies are normal packages and keep their own install state, xvm state, payloads, and uninstall semantics. The config package itself does not inherit or proxy those states.
+
+This allows patterns such as:
+
+- install normal toolchain packages as dependencies;
+- run a config procedure that wires editor settings or project state;
+- rerun the config procedure after user changes without reinstalling the toolchain.
+
+## XVM Semantics
+
+Config packages should avoid `xvm.add()` as part of their own definition.
+
+Reason: `xvm.add()` creates durable registration state. Durable registration implies a corresponding `xvm.remove()` and therefore an uninstall contract. That contradicts the narrow config definition: a repeatable configuration procedure without its own install/uninstall lifecycle.
+
+If a package needs xvm registration, it should usually be one of these instead:
+
+- a normal `package` that owns an installed payload and registers its programs;
+- a future explicit registration-oriented package type or policy;
+- a dependency whose own `config()` registers itself.
+
+Short-term compatibility note: existing packages may still use `xvm.add()` from config hooks. The stricter rule should first be documented and linted in libxpkg/index tooling before being made a hard runtime error.
+
+## Install State Semantics
+
+For `type = "config"` in the current soft-constraint PR:
+
+- xlings should not create `.xim-installed`;
+- xlings should not copy `.xpkg.lua` into the package install directory;
+- xlings should not treat xlings-owned metadata as evidence that the config package is installed.
+- an empty install directory is allowed by the existing hook flow and must not count as installed.
+
+If a config hook deliberately writes files somewhere, those files are external configuration state, not package payload. The hook author is responsible for making that write idempotent.
+
+If the package truly needs owned files, backups, snapshots, or versioned removal, it should not be modeled as a pure config package.
+
+## Current PR #306 Evaluation
+
+PR #306 already moves in the right direction:
+
+- it skips the `.xim-installed` auto-stamp for config packages;
+- it skips the `.xpkg.lua` install-dir snapshot for config packages;
+- it tests that a no-payload config package runs repeatedly instead of being mistaken for installed.
+
+Current PR #306 soft policy:
+
+- keep existing hook and cwd semantics unchanged;
+- allow the generic flow to leave an empty install directory;
+- treat only non-empty author-created content as installed state;
+- avoid xlings-owned stamp/snapshot files for config packages;
+- keep xvm compatibility for now, but document that new config packages should avoid `xvm.add()`.
+
+This keeps the code change small while leaving room to refine the config contract in libxpkg/spec.
+
+## Discussion Options
+
+Option A: soft runtime policy, current PR scope.
+
+- Keep hook semantics unchanged.
+- Allow an empty install directory.
+- Skip only xlings-owned install markers and snapshots for `type = "config"`.
+- Add TODO comments and tests.
+
+Option B: stricter no-install-dir runtime policy.
+
+- Do not precreate `install_dir` for config packages.
+- Do not run config hooks from `install_dir`.
+- This is cleaner theoretically, but it changes hook runtime behavior and may break existing recipes.
+
+Option C: spec/lint first.
+
+- Keep runtime compatibility.
+- Update libxpkg/spec and index checks to discourage `install()`, `installed()`, `pkginfo.install_dir()`, and `xvm.add()` in config packages.
+- Migrate existing packages gradually before any hard runtime behavior change.
+
+Recommended now: Option A in PR #306, then Option C as follow-up. Option B should wait until existing package usage has been audited.
+
+## Follow-Up Work
+
+Spec and libxpkg should later make the contract explicit:
+
+- update `docs/spec/xpkg-manifest-v1.md` with the narrow config definition;
+- add libxpkg/index lint checks:
+  - warn when `type = "config"` defines `install()`;
+  - warn when it calls `xvm.add()`;
+  - warn when it uses `pkginfo.install_dir()`;
+  - warn when it defines `installed()` as persistent install-state logic;
+- add migration guidance for existing config packages that are actually xvm registration or managed-state packages;
+- consider a future explicit package type or policy for registration/managed external state.
+
+## Recommended Author Rule
+
+Use `type = "config"` only when this sentence is true:
+
+> This package is just a repeatable configuration procedure over its dependencies and environment; it has no owned install payload and no durable registration state of its own.
+
+If that sentence is not true, use a normal package or introduce a more specific type/policy.

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.41";
+    static constexpr std::string_view VERSION = "0.4.42";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -1407,7 +1407,10 @@ public:
             // and skip the extracted-payload fallback (which exists for
             // packages whose hook silently no-ops, e.g. patchelf where
             // the tarball has no top-level dir).
-            if (!payloadInstalled) {
+            if (!payloadInstalled && node.pkgType != 3 /* Config */) {
+                // Config xpkgs are repeatable actions. Their installed state
+                // should come only from files the package author creates, not
+                // from xlings's empty-dir stamp.
                 executor.apply_install_stamp_if_empty(ctx);
             }
 
@@ -1472,15 +1475,20 @@ public:
                 continue;
             }
 
-            if (auto snapshot = detail_::save_xpkg_snapshot_(node.pkgFile, ctx.install_dir);
-                !snapshot) {
-                log::error("failed to save xpkg snapshot for {}: {}",
-                           node.name, snapshot.error());
-                if (onStatus) {
-                    onStatus({ node.name, InstallPhase::Failed, 0.0f,
-                               snapshot.error() });
+            if (node.pkgType != 3 /* Config */) {
+                // Same policy as the install stamp: a config package with no
+                // author-created payload must not become installed solely
+                // because xlings copied its own metadata into install_dir.
+                if (auto snapshot = detail_::save_xpkg_snapshot_(node.pkgFile, ctx.install_dir);
+                    !snapshot) {
+                    log::error("failed to save xpkg snapshot for {}: {}",
+                               node.name, snapshot.error());
+                    if (onStatus) {
+                        onStatus({ node.name, InstallPhase::Failed, 0.0f,
+                                   snapshot.error() });
+                    }
+                    continue;
                 }
-                continue;
             }
 
             if (catalog_) {

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -1408,9 +1408,11 @@ public:
             // packages whose hook silently no-ops, e.g. patchelf where
             // the tarball has no top-level dir).
             if (!payloadInstalled && node.pkgType != 3 /* Config */) {
-                // Config xpkgs are repeatable actions. Their installed state
-                // should come only from files the package author creates, not
-                // from xlings's empty-dir stamp.
+                // TODO(config): formalize config packages as repeatable,
+                // no-install procedures in libxpkg/spec. Keep current hook
+                // semantics for now; just avoid xlings-owned markers that
+                // would make an otherwise empty config directory look
+                // installed.
                 executor.apply_install_stamp_if_empty(ctx);
             }
 
@@ -1476,9 +1478,11 @@ public:
             }
 
             if (node.pkgType != 3 /* Config */) {
-                // Same policy as the install stamp: a config package with no
-                // author-created payload must not become installed solely
-                // because xlings copied its own metadata into install_dir.
+                // TODO(config): same soft policy as the install stamp. A
+                // config package with no author-created payload must not
+                // become installed solely because xlings copied metadata into
+                // install_dir. Future libxpkg/spec work should define the
+                // stricter config contract.
                 if (auto snapshot = detail_::save_xpkg_snapshot_(node.pkgFile, ctx.install_dir);
                     !snapshot) {
                     log::error("failed to save xpkg snapshot for {}: {}",

--- a/tests/e2e/config_install_no_implicit_dir_test.sh
+++ b/tests/e2e/config_install_no_implicit_dir_test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# E2E test: type=config packages that do not create install_dir themselves
+# must not be materialized by xlings.
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/config_install_no_implicit_dir"
+HOME_DIR="$RUNTIME_DIR/home"
+WORK_DIR="$RUNTIME_DIR/work"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+mkdir -p "$HOME_DIR/subos/default/bin" \
+         "$WORK_DIR" \
+         "$LOCAL_INDEX_DIR/pkgs/c"
+
+cat > "$LOCAL_INDEX_DIR/pkgs/c/config-no-payload.lua" <<'LUA'
+package = {
+    spec = "1",
+    name = "config-no-payload",
+    description = "Test fixture: config install hook does not create install_dir",
+    type = "config",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    xpm = {
+        linux   = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+        macosx  = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+        windows = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.system")
+
+function install()
+    local marker = path.join(system.rundir(), "install-count.txt")
+    local count = 0
+    if os.isfile(marker) then
+        count = tonumber(io.readfile(marker)) or 0
+    end
+    io.writefile(marker, tostring(count + 1))
+    return true
+end
+
+function config()
+    local marker = path.join(system.rundir(), "config-count.txt")
+    local count = 0
+    if os.isfile(marker) then
+        count = tonumber(io.readfile(marker)) or 0
+    end
+    io.writefile(marker, tostring(count + 1))
+    return true
+end
+LUA
+
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+
+cat > "$HOME_DIR/.xlings.json" <<JSON
+{
+  "version": "0.4.39",
+  "activeSubos": "default",
+  "mirror": "GLOBAL",
+  "subos": {"default": {"dir": ""}},
+  "index_repos": [
+    {"name": "xim", "url": "$LOCAL_INDEX_DIR"}
+  ]
+}
+JSON
+
+RUN() {
+  ( cd "$WORK_DIR" && env -u XLINGS_PROJECT_DIR XLINGS_HOME="$HOME_DIR" \
+      "$(find_xlings_bin)" --verbose "$@" )
+}
+
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+log "Installing config-no-payload twice..."
+RUN install config-no-payload -y >/dev/null 2>&1 \
+  || fail "first install failed"
+RUN install config-no-payload -y >/dev/null 2>&1 \
+  || fail "second install failed"
+
+COUNT_FILE="$WORK_DIR/install-count.txt"
+[[ -f "$COUNT_FILE" ]] \
+  || fail "install hook did not write $COUNT_FILE"
+
+COUNT="$(cat "$COUNT_FILE")"
+[[ "$COUNT" == "2" ]] \
+  || fail "install hook should run twice when it does not create install_dir; count=$COUNT"
+
+CONFIG_COUNT_FILE="$WORK_DIR/config-count.txt"
+[[ -f "$CONFIG_COUNT_FILE" ]] \
+  || fail "config hook did not write $CONFIG_COUNT_FILE"
+
+CONFIG_COUNT="$(cat "$CONFIG_COUNT_FILE")"
+[[ "$CONFIG_COUNT" == "2" ]] \
+  || fail "config hook should run twice without materializing install_dir; count=$CONFIG_COUNT"
+
+INSTALL_DIR="$HOME_DIR/data/xpkgs/xim-x-config-no-payload/1.0.0"
+if [[ -e "$INSTALL_DIR" ]]; then
+  [[ -d "$INSTALL_DIR" ]] \
+    || fail "config package install_dir exists but is not a directory: $INSTALL_DIR"
+  [[ -z "$(find "$INSTALL_DIR" -mindepth 1 -print -quit)" ]] \
+    || fail "xlings implicitly materialized config package install_dir:
+$(ls -la "$INSTALL_DIR")"
+fi
+
+log "PASS: config install hook without payload is not materialized by xlings"

--- a/tests/e2e/windows_quick_install_resource_probe_test.sh
+++ b/tests/e2e/windows_quick_install_resource_probe_test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/tools/other/quick_install.ps1"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+require_pattern() {
+    local pattern="$1"
+    local message="$2"
+    grep -Eq "$pattern" "$SCRIPT" || fail "$message"
+}
+
+reject_pattern() {
+    local pattern="$1"
+    local message="$2"
+    if grep -Eq "$pattern" "$SCRIPT"; then
+        fail "$message"
+    fi
+}
+
+require_pattern 'RESOURCE_REPO = "xlings-res/xlings"' 'Windows quick installer must probe xlings-res release resources'
+require_pattern 'GITHUB_API = "https://api\.github\.com"' 'Windows quick installer must support GitHub release metadata'
+require_pattern 'GITCODE_API = "https://api\.gitcode\.com/api/v5"' 'Windows quick installer must support GitCode xlings-res release metadata'
+require_pattern 'Measure-ReleaseLatency' 'Windows quick installer must probe release source latency'
+require_pattern 'Sort-ReleaseCandidates' 'Windows quick installer must prefer lower-latency release candidates'
+require_pattern 'Get-ReleaseAsset' 'Windows quick installer must select assets from release metadata'
+reject_pattern 'GITEE|gitee\.com|Gitee' 'Windows quick installer should only use GitHub and GitCode sources'
+reject_pattern 'GitHub xlings-res/xlings' 'Windows quick installer should not add a second GitHub resource source'
+reject_pattern '^[[:space:]]*exit[[:space:]]+[0-9]+' 'Windows quick installer must not call exit from irm|iex execution path'
+
+echo "PASS: Windows quick install resource probing checks"

--- a/tools/other/quick_install.ps1
+++ b/tools/other/quick_install.ps1
@@ -14,8 +14,11 @@ function Log-Info  { param([string]$Msg) Write-Host "[xlings]: $Msg" -Foreground
 function Log-Warn  { param([string]$Msg) Write-Host "[xlings]: $Msg" -ForegroundColor Yellow }
 function Log-Error { param([string]$Msg) Write-Host "[xlings]: $Msg" -ForegroundColor Red }
 
-$GITHUB_REPO = "openxlings/xlings"
+$OFFICIAL_REPO = "openxlings/xlings"
+$RESOURCE_REPO = "xlings-res/xlings"
 $GITHUB_MIRROR = $env:XLINGS_GITHUB_MIRROR
+$GITHUB_API = "https://api.github.com"
+$GITCODE_API = "https://api.gitcode.com/api/v5"
 
 # --------------- banner ---------------
 
@@ -45,62 +48,286 @@ if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64" -or $env:PROCESSOR_ARCHITEW6432 -eq 
 
 # --------------- resolve download URL ---------------
 
-function Resolve-LatestVersion {
-    $baseUrl = if ($GITHUB_MIRROR) { $GITHUB_MIRROR } else { "https://github.com" }
-    $url = "$baseUrl/$GITHUB_REPO/releases/latest"
-    $response = Invoke-WebRequest -Uri $url -MaximumRedirection 10 -UseBasicParsing -ErrorAction Stop
-    $finalUrl = $response.BaseResponse.ResponseUri
-    if (-not $finalUrl) {
-        $finalUrl = $response.BaseResponse.RequestMessage.RequestUri  # PS 7+
-    }
-    return ($finalUrl.ToString() -split '/')[-1]
+function Invoke-JsonGet {
+    param([string]$Url)
+
+    $response = Invoke-WebRequest -Uri $Url -UseBasicParsing -UserAgent "xlings-quick-install" -ErrorAction Stop
+    return $response.Content | ConvertFrom-Json
 }
 
-if ($Version) {
-    $latestVersion = $Version
-    Log-Info "Using specified version: $latestVersion"
-} else {
-    Log-Info "Querying latest release..."
+function Get-VersionNumber {
+    param([string]$Tag)
+
+    if (-not $Tag) { return $null }
+    return (($Tag -replace '^refs/tags/', '') -replace '^v', '')
+}
+
+function Get-VersionSortKey {
+    param([string]$VersionNum)
+
     try {
-        $latestVersion = Resolve-LatestVersion
+        return [version]$VersionNum
     } catch {
-        Log-Error "Failed to query the latest release: $_"
-        exit 1
+        return [version]"0.0"
     }
 }
 
-if (-not $latestVersion) {
-    Log-Error "Failed to resolve release version."
-    exit 1
+function Get-TagCandidates {
+    param(
+        [string]$RequestedVersion,
+        [bool]$PreferVTag
+    )
+
+    $versionNum = Get-VersionNumber $RequestedVersion
+    if (-not $versionNum) { return @() }
+
+    if ($PreferVTag) {
+        $candidates = @("v$versionNum", $versionNum)
+    } else {
+        $candidates = @($versionNum, "v$versionNum")
+    }
+
+    $uniqueCandidates = $candidates | Select-Object -Unique
+    return $uniqueCandidates
 }
 
-if ($latestVersion -notmatch '^v') { $latestVersion = "v$latestVersion" }
-$versionNum = $latestVersion -replace '^v', ''
-$zipName = "xlings-$versionNum-windows-$arch.zip"
+function Get-ReleaseAsset {
+    param(
+        [object]$Release,
+        [string]$AssetName
+    )
 
-if ($GITHUB_MIRROR) {
-    $downloadUrl = "$GITHUB_MIRROR/$GITHUB_REPO/releases/download/$latestVersion/$zipName"
-} else {
-    $downloadUrl = "https://github.com/$GITHUB_REPO/releases/download/$latestVersion/$zipName"
+    foreach ($asset in @($Release.assets)) {
+        if ($asset.name -eq $AssetName -and $asset.browser_download_url) {
+            return [string]$asset.browser_download_url
+        }
+    }
+
+    return $null
 }
 
-Log-Info "Latest version: $latestVersion"
-Log-Info "Package:        $zipName"
-Log-Info "Download URL:   $downloadUrl"
+function Resolve-ReleaseCandidates {
+    $githubWebBase = if ($GITHUB_MIRROR) { $GITHUB_MIRROR.TrimEnd([char[]]"/") } else { "https://github.com" }
+
+    # Probe only the two supported Windows package sources. GitCode is the
+    # low-latency resource mirror for users who have trouble reaching GitHub.
+    @(
+        [pscustomobject]@{
+            Name       = "GitHub openxlings/xlings"
+            Repo       = $OFFICIAL_REPO
+            ApiBase    = $GITHUB_API
+            WebBase    = $githubWebBase
+            PreferVTag = $true
+        },
+        [pscustomobject]@{
+            Name       = "GitCode xlings-res/xlings"
+            Repo       = $RESOURCE_REPO
+            ApiBase    = $GITCODE_API
+            WebBase    = $null
+            PreferVTag = $false
+        }
+    )
+}
+
+function Get-ReleaseMetadata {
+    param(
+        [object]$Source,
+        [string]$RequestedVersion
+    )
+
+    if ($RequestedVersion) {
+        $lastError = $null
+        foreach ($tag in (Get-TagCandidates -RequestedVersion $RequestedVersion -PreferVTag $Source.PreferVTag)) {
+            try {
+                return Invoke-JsonGet "$($Source.ApiBase)/repos/$($Source.Repo)/releases/tags/$tag"
+            } catch {
+                $lastError = $_.Exception.Message
+            }
+        }
+        throw "release '$RequestedVersion' not found on $($Source.Name): $lastError"
+    }
+
+    return Invoke-JsonGet "$($Source.ApiBase)/repos/$($Source.Repo)/releases/latest"
+}
+
+function Measure-ReleaseLatency {
+    param(
+        [object]$Source,
+        [string]$RequestedVersion
+    )
+
+    $timer = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        $release = Get-ReleaseMetadata -Source $Source -RequestedVersion $RequestedVersion
+        $timer.Stop()
+        return [pscustomobject]@{
+            Release = $release
+            ProbeMs = [int]$timer.ElapsedMilliseconds
+        }
+    } catch {
+        $timer.Stop()
+        throw $_
+    }
+}
+
+function Resolve-SourceCandidate {
+    param(
+        [object]$Source,
+        [string]$RequestedVersion,
+        [string]$PackageArch
+    )
+
+    $probe = Measure-ReleaseLatency -Source $Source -RequestedVersion $RequestedVersion
+    $release = $probe.Release
+    $tag = [string]$release.tag_name
+    if (-not $tag) {
+        throw "release metadata from $($Source.Name) does not include tag_name"
+    }
+
+    $versionNum = Get-VersionNumber $tag
+    $zipName = "xlings-$versionNum-windows-$PackageArch.zip"
+    $assetUrl = Get-ReleaseAsset -Release $release -AssetName $zipName
+    if (-not $assetUrl) {
+        throw "asset '$zipName' not found in $($Source.Name) release '$tag'"
+    }
+
+    if ($Source.Repo -eq $OFFICIAL_REPO -and $GITHUB_MIRROR) {
+        $assetUrl = "$($Source.WebBase)/$($Source.Repo)/releases/download/$tag/$zipName"
+    }
+
+    [pscustomobject]@{
+        Source  = $Source.Name
+        Tag     = $tag
+        Version = $versionNum
+        VersionKey = (Get-VersionSortKey $versionNum)
+        ProbeMs = $probe.ProbeMs
+        ZipName = $zipName
+        Url     = $assetUrl
+    }
+}
+
+function Sort-ReleaseCandidates {
+    param(
+        [object[]]$Candidates,
+        [string]$RequestedVersion
+    )
+
+    if (-not $Candidates -or $Candidates.Count -eq 0) { return @() }
+
+    $eligible = @($Candidates)
+    if (-not $RequestedVersion) {
+        $latest = $eligible | Sort-Object -Property VersionKey -Descending | Select-Object -First 1
+        $eligible = @($eligible | Where-Object { $_.VersionKey -eq $latest.VersionKey })
+    }
+
+    return @($eligible | Sort-Object -Property ProbeMs)
+}
+
+function Test-ZipPackage {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) { return $false }
+    $file = Get-Item $Path
+    if ($file.Length -lt 4) { return $false }
+
+    $stream = [System.IO.File]::OpenRead($Path)
+    try {
+        $first = $stream.ReadByte()
+        $second = $stream.ReadByte()
+        return ($first -eq 0x50 -and $second -eq 0x4b)
+    } finally {
+        $stream.Dispose()
+    }
+}
+
+function Download-ReleasePackage {
+    param(
+        [object[]]$Sources,
+        [string]$RequestedVersion,
+        [string]$PackageArch,
+        [string]$TempDir
+    )
+
+    $lastError = $null
+    $candidates = @()
+
+    foreach ($source in $Sources) {
+        try {
+            Log-Info "Probing $($source.Name) latency..."
+            $candidate = Resolve-SourceCandidate -Source $source -RequestedVersion $RequestedVersion -PackageArch $PackageArch
+            Log-Info "Available: $($candidate.Source) $($candidate.Tag) ($($candidate.ProbeMs)ms)"
+            $candidates += $candidate
+        } catch {
+            $lastError = $_.Exception.Message
+            Log-Warn "$($source.Name) unavailable: $lastError"
+        }
+    }
+
+    $orderedCandidates = Sort-ReleaseCandidates -Candidates $candidates -RequestedVersion $RequestedVersion
+    if (-not $orderedCandidates -or $orderedCandidates.Count -eq 0) {
+        throw "all Windows release sources failed. Last error: $lastError"
+    }
+
+    if (-not $RequestedVersion) {
+        Log-Info "Selected release version: $($orderedCandidates[0].Tag)"
+    }
+
+    foreach ($candidate in $orderedCandidates) {
+        $zipPath = $null
+
+        try {
+            $zipPath = Join-Path $TempDir $candidate.ZipName
+
+            Log-Info "Version:      $($candidate.Tag)"
+            Log-Info "Package:      $($candidate.ZipName)"
+            Log-Info "Source:       $($candidate.Source) ($($candidate.ProbeMs)ms)"
+            Log-Info "Download URL: $($candidate.Url)"
+            Log-Info "Downloading..."
+
+            $progressPref = $ProgressPreference
+            $ProgressPreference = 'SilentlyContinue'
+            try {
+                Invoke-WebRequest -Uri $candidate.Url -OutFile $zipPath -UseBasicParsing -UserAgent "xlings-quick-install" -ErrorAction Stop
+            } finally {
+                $ProgressPreference = $progressPref
+            }
+
+            if (-not (Test-ZipPackage $zipPath)) {
+                throw "downloaded file is not a zip package"
+            }
+
+            return [pscustomobject]@{
+                Candidate = $candidate
+                ZipPath   = $zipPath
+            }
+        } catch {
+            $lastError = $_.Exception.Message
+            Log-Warn "$($candidate.Source) download failed: $lastError"
+            if ($zipPath -and (Test-Path $zipPath)) {
+                Remove-Item -Force $zipPath -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    throw "all Windows release sources failed. Last error: $lastError"
+}
 
 # --------------- download & extract ---------------
 
 $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "xlings-install-$([System.Guid]::NewGuid().ToString('N').Substring(0,8))"
 New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
 
-$zipPath = Join-Path $tempDir $zipName
-
 try {
-    Log-Info "Downloading..."
-    $progressPref = $ProgressPreference
-    $ProgressPreference = 'SilentlyContinue'
-    Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath -UseBasicParsing
-    $ProgressPreference = $progressPref
+    if ($Version) {
+        Log-Info "Using specified version: $Version"
+    } else {
+        Log-Info "No version specified; probing release source latency..."
+    }
+
+    $download = Download-ReleasePackage -Sources (Resolve-ReleaseCandidates) -RequestedVersion $Version -PackageArch $arch -TempDir $tempDir
+    $zipPath = $download.ZipPath
+    $selected = $download.Candidate
+    Log-Info "Selected source: $($selected.Source)"
 
     Log-Info "Extracting..."
     Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
@@ -108,17 +335,22 @@ try {
     $extractDir = Get-ChildItem -Path $tempDir -Directory -Filter "xlings-*" | Select-Object -First 1
     $xlingsBin = if ($extractDir) { Join-Path $extractDir.FullName "bin\xlings.exe" } else { $null }
     if (-not $extractDir -or -not (Test-Path $xlingsBin)) {
-        Log-Error "Extracted package is invalid (missing bin\xlings.exe)."
-        exit 1
+        throw "extracted package is invalid (missing bin\xlings.exe)"
     }
 
     Log-Info "Running installer..."
     Push-Location $extractDir.FullName
-    & $xlingsBin self install
-    Pop-Location
+    try {
+        & $xlingsBin self install
+        if ($LASTEXITCODE -ne 0) {
+            throw "xlings self install failed with exit code $LASTEXITCODE"
+        }
+    } finally {
+        Pop-Location
+    }
 } catch {
-    Log-Error "Installation failed: $_"
-    exit 1
+    Log-Error "Installation failed: $($_.Exception.Message)"
+    throw
 } finally {
     Log-Info "Cleaning up temporary files..."
     Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- keep `type=config` packages repeatable when they do not create their own payload
- stop xlings from making config packages look installed via the automatic `.xim-installed` stamp or `.xpkg.lua` snapshot
- update the Windows quick installer to use only two release source families: official GitHub and GitCode `xlings-res/xlings`
- probe release metadata latency and prefer the lower-latency source among candidates for the selected version
- avoid `exit` in the Windows `irm | iex` installer path; failures now log and throw instead of terminating the caller PowerShell host directly

## Root Cause
Config package installed state is based on `install_dir` being a non-empty directory. The previous behavior wrote xlings-owned content into an otherwise empty config install dir after the install hook, so a repeatable config package could be treated as already installed on the next run. The fix keeps the normal install dir setup, but skips xlings-owned installed markers/snapshots for config packages.

The Windows quick installer previously resolved and downloaded from a single GitHub URL. On query/download/extract failure it called `exit 1`; in the one-line `irm ... | iex` flow that can terminate the caller PowerShell session/window. The installer now probes GitHub and GitCode metadata latency, keeps the highest available version when no version is specified, then downloads from the lower-latency candidate for that version with fallback on download failure.

## Verification
- `git diff --check`
- `xmake build xlings`
- `bash tests/e2e/config_install_no_implicit_dir_test.sh`
- `bash tests/e2e/windows_quick_install_resource_probe_test.sh`
- release-resource probes with `gh release view` and GitCode API checks