### PR TITLE
fix(installer): add Windows release source probing

### DIFF
--- a/tests/e2e/windows_quick_install_resource_probe_test.sh
+++ b/tests/e2e/windows_quick_install_resource_probe_test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/tools/other/quick_install.ps1"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+require_pattern() {
+    local pattern="$1"
+    local message="$2"
+    grep -Eq "$pattern" "$SCRIPT" || fail "$message"
+}
+
+reject_pattern() {
+    local pattern="$1"
+    local message="$2"
+    if grep -Eq "$pattern" "$SCRIPT"; then
+        fail "$message"
+    fi
+}
+
+require_pattern 'RESOURCE_REPO = "xlings-res/xlings"' 'Windows quick installer must probe xlings-res release resources'
+require_pattern 'GITHUB_API = "https://api\.github\.com"' 'Windows quick installer must support GitHub release metadata'
+require_pattern 'GITCODE_API = "https://api\.gitcode\.com/api/v5"' 'Windows quick installer must support GitCode xlings-res release metadata'
+require_pattern 'GITEE_API = "https://gitee\.com/api/v5"' 'Windows quick installer must support Gitee xlings-res release metadata when available'
+require_pattern 'Resolve-ReleaseCandidates' 'Windows quick installer must resolve release candidates lazily'
+require_pattern 'Get-ReleaseAsset' 'Windows quick installer must select assets from release metadata'
+reject_pattern '^[[:space:]]*exit[[:space:]]+[0-9]+' 'Windows quick installer must not call exit from irm|iex execution path'
+
+echo "PASS: Windows quick install resource probing checks"

--- a/tools/other/quick_install.ps1
+++ b/tools/other/quick_install.ps1
@@ -14,8 +14,12 @@ function Log-Info  { param([string]$Msg) Write-Host "[xlings]: $Msg" -Foreground
 function Log-Warn  { param([string]$Msg) Write-Host "[xlings]: $Msg" -ForegroundColor Yellow }
 function Log-Error { param([string]$Msg) Write-Host "[xlings]: $Msg" -ForegroundColor Red }
 
-$GITHUB_REPO = "openxlings/xlings"
+$OFFICIAL_REPO = "openxlings/xlings"
+$RESOURCE_REPO = "xlings-res/xlings"
 $GITHUB_MIRROR = $env:XLINGS_GITHUB_MIRROR
+$GITHUB_API = "https://api.github.com"
+$GITCODE_API = "https://api.gitcode.com/api/v5"
+$GITEE_API = "https://gitee.com/api/v5"
 
 # --------------- banner ---------------
 
@@ -45,62 +49,229 @@ if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64" -or $env:PROCESSOR_ARCHITEW6432 -eq 
 
 # --------------- resolve download URL ---------------
 
-function Resolve-LatestVersion {
-    $baseUrl = if ($GITHUB_MIRROR) { $GITHUB_MIRROR } else { "https://github.com" }
-    $url = "$baseUrl/$GITHUB_REPO/releases/latest"
-    $response = Invoke-WebRequest -Uri $url -MaximumRedirection 10 -UseBasicParsing -ErrorAction Stop
-    $finalUrl = $response.BaseResponse.ResponseUri
-    if (-not $finalUrl) {
-        $finalUrl = $response.BaseResponse.RequestMessage.RequestUri  # PS 7+
-    }
-    return ($finalUrl.ToString() -split '/')[-1]
+function Invoke-JsonGet {
+    param([string]$Url)
+
+    $response = Invoke-WebRequest -Uri $Url -UseBasicParsing -UserAgent "xlings-quick-install" -ErrorAction Stop
+    return $response.Content | ConvertFrom-Json
 }
 
-if ($Version) {
-    $latestVersion = $Version
-    Log-Info "Using specified version: $latestVersion"
-} else {
-    Log-Info "Querying latest release..."
+function Get-VersionNumber {
+    param([string]$Tag)
+
+    if (-not $Tag) { return $null }
+    return (($Tag -replace '^refs/tags/', '') -replace '^v', '')
+}
+
+function Get-TagCandidates {
+    param(
+        [string]$RequestedVersion,
+        [bool]$PreferVTag
+    )
+
+    $versionNum = Get-VersionNumber $RequestedVersion
+    if (-not $versionNum) { return @() }
+
+    if ($PreferVTag) {
+        $candidates = @("v$versionNum", $versionNum)
+    } else {
+        $candidates = @($versionNum, "v$versionNum")
+    }
+
+    $uniqueCandidates = $candidates | Select-Object -Unique
+    return $uniqueCandidates
+}
+
+function Get-ReleaseAsset {
+    param(
+        [object]$Release,
+        [string]$AssetName
+    )
+
+    foreach ($asset in @($Release.assets)) {
+        if ($asset.name -eq $AssetName -and $asset.browser_download_url) {
+            return [string]$asset.browser_download_url
+        }
+    }
+
+    return $null
+}
+
+function Resolve-ReleaseCandidates {
+    $githubWebBase = if ($GITHUB_MIRROR) { $GITHUB_MIRROR.TrimEnd([char[]]"/") } else { "https://github.com" }
+
+    # Keep mirrors lazy: the next source is probed only after the current source
+    # cannot provide or download a Windows package.
+    @(
+        [pscustomobject]@{
+            Name       = "GitHub openxlings/xlings"
+            Repo       = $OFFICIAL_REPO
+            ApiBase    = $GITHUB_API
+            WebBase    = $githubWebBase
+            PreferVTag = $true
+        },
+        [pscustomobject]@{
+            Name       = "GitHub xlings-res/xlings"
+            Repo       = $RESOURCE_REPO
+            ApiBase    = $GITHUB_API
+            WebBase    = "https://github.com"
+            PreferVTag = $false
+        },
+        [pscustomobject]@{
+            Name       = "GitCode xlings-res/xlings"
+            Repo       = $RESOURCE_REPO
+            ApiBase    = $GITCODE_API
+            WebBase    = $null
+            PreferVTag = $false
+        },
+        [pscustomobject]@{
+            Name       = "Gitee xlings-res/xlings"
+            Repo       = $RESOURCE_REPO
+            ApiBase    = $GITEE_API
+            WebBase    = $null
+            PreferVTag = $false
+        }
+    )
+}
+
+function Get-ReleaseMetadata {
+    param(
+        [object]$Source,
+        [string]$RequestedVersion
+    )
+
+    if ($RequestedVersion) {
+        $lastError = $null
+        foreach ($tag in (Get-TagCandidates -RequestedVersion $RequestedVersion -PreferVTag $Source.PreferVTag)) {
+            try {
+                return Invoke-JsonGet "$($Source.ApiBase)/repos/$($Source.Repo)/releases/tags/$tag"
+            } catch {
+                $lastError = $_.Exception.Message
+            }
+        }
+        throw "release '$RequestedVersion' not found on $($Source.Name): $lastError"
+    }
+
+    return Invoke-JsonGet "$($Source.ApiBase)/repos/$($Source.Repo)/releases/latest"
+}
+
+function Resolve-SourceCandidate {
+    param(
+        [object]$Source,
+        [string]$RequestedVersion,
+        [string]$PackageArch
+    )
+
+    $release = Get-ReleaseMetadata -Source $Source -RequestedVersion $RequestedVersion
+    $tag = [string]$release.tag_name
+    if (-not $tag) {
+        throw "release metadata from $($Source.Name) does not include tag_name"
+    }
+
+    $versionNum = Get-VersionNumber $tag
+    $zipName = "xlings-$versionNum-windows-$PackageArch.zip"
+    $assetUrl = Get-ReleaseAsset -Release $release -AssetName $zipName
+    if (-not $assetUrl) {
+        throw "asset '$zipName' not found in $($Source.Name) release '$tag'"
+    }
+
+    if ($Source.Repo -eq $OFFICIAL_REPO -and $GITHUB_MIRROR) {
+        $assetUrl = "$($Source.WebBase)/$($Source.Repo)/releases/download/$tag/$zipName"
+    }
+
+    [pscustomobject]@{
+        Source  = $Source.Name
+        Tag     = $tag
+        Version = $versionNum
+        ZipName = $zipName
+        Url     = $assetUrl
+    }
+}
+
+function Test-ZipPackage {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) { return $false }
+    $file = Get-Item $Path
+    if ($file.Length -lt 4) { return $false }
+
+    $stream = [System.IO.File]::OpenRead($Path)
     try {
-        $latestVersion = Resolve-LatestVersion
-    } catch {
-        Log-Error "Failed to query the latest release: $_"
-        exit 1
+        $first = $stream.ReadByte()
+        $second = $stream.ReadByte()
+        return ($first -eq 0x50 -and $second -eq 0x4b)
+    } finally {
+        $stream.Dispose()
     }
 }
 
-if (-not $latestVersion) {
-    Log-Error "Failed to resolve release version."
-    exit 1
+function Download-ReleasePackage {
+    param(
+        [object[]]$Sources,
+        [string]$RequestedVersion,
+        [string]$PackageArch,
+        [string]$TempDir
+    )
+
+    $lastError = $null
+
+    foreach ($source in $Sources) {
+        $zipPath = $null
+
+        try {
+            Log-Info "Probing $($source.Name)..."
+            $candidate = Resolve-SourceCandidate -Source $source -RequestedVersion $RequestedVersion -PackageArch $PackageArch
+            $zipPath = Join-Path $TempDir $candidate.ZipName
+
+            Log-Info "Version:      $($candidate.Tag)"
+            Log-Info "Package:      $($candidate.ZipName)"
+            Log-Info "Download URL: $($candidate.Url)"
+            Log-Info "Downloading..."
+
+            $progressPref = $ProgressPreference
+            $ProgressPreference = 'SilentlyContinue'
+            try {
+                Invoke-WebRequest -Uri $candidate.Url -OutFile $zipPath -UseBasicParsing -UserAgent "xlings-quick-install" -ErrorAction Stop
+            } finally {
+                $ProgressPreference = $progressPref
+            }
+
+            if (-not (Test-ZipPackage $zipPath)) {
+                throw "downloaded file is not a zip package"
+            }
+
+            return [pscustomobject]@{
+                Candidate = $candidate
+                ZipPath   = $zipPath
+            }
+        } catch {
+            $lastError = $_.Exception.Message
+            Log-Warn "$($source.Name) unavailable: $lastError"
+            if ($zipPath -and (Test-Path $zipPath)) {
+                Remove-Item -Force $zipPath -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    throw "all Windows release sources failed. Last error: $lastError"
 }
-
-if ($latestVersion -notmatch '^v') { $latestVersion = "v$latestVersion" }
-$versionNum = $latestVersion -replace '^v', ''
-$zipName = "xlings-$versionNum-windows-$arch.zip"
-
-if ($GITHUB_MIRROR) {
-    $downloadUrl = "$GITHUB_MIRROR/$GITHUB_REPO/releases/download/$latestVersion/$zipName"
-} else {
-    $downloadUrl = "https://github.com/$GITHUB_REPO/releases/download/$latestVersion/$zipName"
-}
-
-Log-Info "Latest version: $latestVersion"
-Log-Info "Package:        $zipName"
-Log-Info "Download URL:   $downloadUrl"
 
 # --------------- download & extract ---------------
 
 $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "xlings-install-$([System.Guid]::NewGuid().ToString('N').Substring(0,8))"
 New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
 
-$zipPath = Join-Path $tempDir $zipName
-
 try {
-    Log-Info "Downloading..."
-    $progressPref = $ProgressPreference
-    $ProgressPreference = 'SilentlyContinue'
-    Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath -UseBasicParsing
-    $ProgressPreference = $progressPref
+    if ($Version) {
+        Log-Info "Using specified version: $Version"
+    } else {
+        Log-Info "No version specified; probing release sources lazily..."
+    }
+
+    $download = Download-ReleasePackage -Sources (Resolve-ReleaseCandidates) -RequestedVersion $Version -PackageArch $arch -TempDir $tempDir
+    $zipPath = $download.ZipPath
+    $selected = $download.Candidate
+    Log-Info "Selected source: $($selected.Source)"
 
     Log-Info "Extracting..."
     Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
@@ -108,17 +279,22 @@ try {
     $extractDir = Get-ChildItem -Path $tempDir -Directory -Filter "xlings-*" | Select-Object -First 1
     $xlingsBin = if ($extractDir) { Join-Path $extractDir.FullName "bin\xlings.exe" } else { $null }
     if (-not $extractDir -or -not (Test-Path $xlingsBin)) {
-        Log-Error "Extracted package is invalid (missing bin\xlings.exe)."
-        exit 1
+        throw "extracted package is invalid (missing bin\xlings.exe)"
     }
 
     Log-Info "Running installer..."
     Push-Location $extractDir.FullName
-    & $xlingsBin self install
-    Pop-Location
+    try {
+        & $xlingsBin self install
+        if ($LASTEXITCODE -ne 0) {
+            throw "xlings self install failed with exit code $LASTEXITCODE"
+        }
+    } finally {
+        Pop-Location
+    }
 } catch {
-    Log-Error "Installation failed: $_"
-    exit 1
+    Log-Error "Installation failed: $($_.Exception.Message)"
+    throw
 } finally {
     Log-Info "Cleaning up temporary files..."
     Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- replace the Windows quick installer single GitHub download path with lazy release-source probing
- add official GitHub, GitHub xlings-res, GitCode xlings-res, and Gitee xlings-res metadata sources for Windows packages
- avoid calling `exit` from the `irm | iex` execution path; failures now throw after logging, so an interactive PowerShell host is not forcibly terminated
- validate downloaded content starts as a zip before extraction and check `xlings self install` exit code
- add a static regression test for the Windows installer source-probing contract

## Root cause
The old `quick_install.ps1` resolved `/releases/latest` from a single GitHub path, built one URL, and used `exit 1` in the query/download/extract failure paths. In the common one-line install form (`irm ... | iex`), those `exit` calls can terminate the caller PowerShell session/window. There was also no fallback to xlings-res release resources, so GitHub latency/blocking/missing asset cases became immediate installer failure.

## Resource probe notes
- `openxlings/xlings` latest is currently `v0.4.41` and has `xlings-0.4.41-windows-x86_64.zip`.
- GitHub `xlings-res/xlings` latest is currently `0.4.41`, but only has Linux/macOS assets.
- GitCode `xlings-res/xlings` latest currently reports `0.4.13` and includes a Windows asset in metadata.
- Gitee `xlings-res/xlings` currently returns 404 for release metadata, but the source is included so it starts working once the resource project/release is available.

## Verification
- `bash tests/e2e/windows_quick_install_resource_probe_test.sh`
- `git diff --check`
- `xmake build xlings`
- release-resource checks with `gh release view` and GitCode/Gitee API probes
