### PR TITLE
fix(xim): handle UTF-8 zip entry paths

### DIFF
--- a/src/core/xim/extract.cppm
+++ b/src/core/xim/extract.cppm
@@ -2,6 +2,7 @@ module;
 
 #include <archive.h>
 #include <archive_entry.h>
+#include <clocale>
 
 export module xlings.core.xim.extract;
 
@@ -75,6 +76,20 @@ check_safe_pathname_(const char* raw) {
     return std::string{sv};
 }
 
+const char* entry_pathname_(archive_entry* entry) {
+    if (auto* path = ::archive_entry_pathname_utf8(entry); path && *path) {
+        return path;
+    }
+    return ::archive_entry_pathname(entry);
+}
+
+const char* entry_hardlink_(archive_entry* entry) {
+    if (auto* path = ::archive_entry_hardlink_utf8(entry); path && *path) {
+        return path;
+    }
+    return ::archive_entry_hardlink(entry);
+}
+
 std::string libarchive_error_(struct archive* a) {
     if (auto* msg = ::archive_error_string(a); msg && *msg) {
         return msg;
@@ -112,12 +127,26 @@ copy_entry_data_(struct archive* src, struct archive* dst) {
     }
 }
 
+void ensure_archive_locale_() {
+    static std::once_flag once;
+    std::call_once(once, [] {
+#ifdef _WIN32
+        if (!std::setlocale(LC_CTYPE, ".UTF-8")) {
+            std::setlocale(LC_CTYPE, "");
+        }
+#else
+        std::setlocale(LC_CTYPE, "");
+#endif
+    });
+}
+
 } // namespace detail_
 
 std::expected<std::filesystem::path, std::string>
 extract_archive(const std::filesystem::path& archive,
                 const std::filesystem::path& destDir) {
     namespace fs = std::filesystem;
+    detail_::ensure_archive_locale_();
 
     std::error_code ec;
     fs::create_directories(destDir, ec);
@@ -163,6 +192,7 @@ extract_archive(const std::filesystem::path& archive,
 
     ::archive_read_support_filter_all(src);
     ::archive_read_support_format_all(src);
+    ::archive_read_set_format_option(src, "zip", "hdrcharset", "UTF-8");
     ::archive_write_disk_set_options(dst, detail_::kWriteFlags);
 
     // Custom user/group lookup that always returns 0 (root). xim-pkgindex
@@ -206,7 +236,7 @@ extract_archive(const std::filesystem::path& archive,
 
         // Reroot the entry under destDir. archive_entry_pathname is a
         // relative path inside the archive; we vet it and prepend destDir.
-        const char* original = ::archive_entry_pathname(entry);
+        const char* original = detail_::entry_pathname_(entry);
         auto safeRel = detail_::check_safe_pathname_(original);
         if (!safeRel) {
             cleanup();
@@ -219,7 +249,7 @@ extract_archive(const std::filesystem::path& archive,
         // entries — same vetting + rebase rule. Symlink *targets* stay
         // relative to the symlink (not vetted here); SECURE_SYMLINKS
         // prevents following them during extraction.
-        if (auto* hl = ::archive_entry_hardlink(entry); hl && *hl) {
+        if (auto* hl = detail_::entry_hardlink_(entry); hl && *hl) {
             auto safeHl = detail_::check_safe_pathname_(hl);
             if (!safeHl) {
                 cleanup();

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -2886,6 +2886,29 @@ struct ExtractFixture {
         return out;
     }
 
+    std::filesystem::path make_utf8_zip() const {
+        namespace fs = std::filesystem;
+        std::ofstream(tmp / "make_utf8_zip.py") << R"PY(
+import zipfile
+
+with zipfile.ZipFile("fixture_utf8.zip", "w", zipfile.ZIP_DEFLATED) as z:
+    z.writestr(
+        "utf8/.github/ISSUE_TEMPLATE/bug-report---\u95ee\u9898.md",
+        "unicode-path-fixture\n",
+    )
+)PY";
+        auto out = tmp / "fixture_utf8.zip";
+        int rc = run_in_(tmp, [] {
+#ifdef _WIN32
+            return std::system("python make_utf8_zip.py");
+#else
+            return std::system("python3 make_utf8_zip.py || python make_utf8_zip.py");
+#endif
+        });
+        if (rc != 0) throw std::runtime_error("failed to create utf8 zip fixture");
+        return out;
+    }
+
     std::filesystem::path make_tar_xz() const {
         auto out = tmp / "fixture.tar.xz";
         int rc = run_in_(tmp, [] {
@@ -2937,6 +2960,29 @@ TEST(Extract, ZipRoundTrip) {
     auto root = *r;
     EXPECT_TRUE(std::filesystem::exists(root / "src/hello.txt"));
     EXPECT_TRUE(file_has_(root / "src/hello.txt", "hello-from-fixture"));
+}
+
+TEST(Extract, ZipUtf8PathRoundTrip) {
+#ifdef _WIN32
+    if (std::system("python --version >NUL 2>NUL") != 0) {
+        GTEST_SKIP() << "python not available on this host";
+    }
+#else
+    if (std::system("command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1") != 0) {
+        GTEST_SKIP() << "python not available on this host";
+    }
+#endif
+    ExtractFixture fx;
+    auto archive = fx.make_utf8_zip();
+    auto out = fx.tmp / "out_zip_utf8";
+
+    auto r = xlings::xim::extract_archive(archive, out);
+    ASSERT_TRUE(r.has_value()) << "extract failed: " << (r ? "" : r.error());
+
+    auto root = *r;
+    auto expected = root / "utf8/.github/ISSUE_TEMPLATE/bug-report---问题.md";
+    EXPECT_TRUE(std::filesystem::exists(expected));
+    EXPECT_TRUE(file_has_(expected, "unicode-path-fixture"));
 }
 
 TEST(Extract, TarXzRoundTrip) {


### PR DESCRIPTION
## Summary
- initialize archive extraction locale before libarchive reads entry paths
- prefer libarchive UTF-8 pathname/hardlink accessors before falling back to legacy narrow paths
- add a regression test for ZIP archives containing UTF-8 entry names like the bundled xim-pkgindex issue template paths

## Root cause
`xlings install local:xlings@0.4.42` fails on the full Windows release ZIP with `extract failed for xlings: empty pathname`. The release self-install path uses PowerShell `Expand-Archive`, so it did not cover the libarchive-backed package install path.

A UTF-8 ZIP entry can produce null pathnames from libarchive while the process is still in the default C locale. Initializing `LC_CTYPE` before extraction allows libarchive to convert those entry names instead of surfacing an empty pathname.

## Test plan
- `xmake build -y xlings_tests && xmake run xlings_tests --gtest_filter=Extract.ZipUtf8PathRoundTrip`
- `xmake run xlings_tests --gtest_filter=Extract.*`
- `xmake run xlings_tests`
