### PR TITLE
chore: bump version to 0.4.43

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.42";
+    static constexpr std::string_view VERSION = "0.4.43";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 


### PR DESCRIPTION
## Summary
- bump xlings source version to 0.4.43 after the UTF-8 zip extraction fix landed
- keep release artifact names and `xlings --version` aligned for the blocker fix release

## Test plan
- `xmake build -y xlings`
- `xmake run xlings --version` -> `xlings 0.4.43`
- CI: Linux/macOS/Windows build-and-test