### PR TITLE
fix(installer): normalize GitCode release asset URLs

### DIFF
--- a/tests/e2e/windows_quick_install_resource_probe_test.sh
+++ b/tests/e2e/windows_quick_install_resource_probe_test.sh
@@ -29,8 +29,12 @@ require_pattern 'GITCODE_API = "https://api\.gitcode\.com/api/v5"' 'Windows quic
 require_pattern 'Measure-ReleaseLatency' 'Windows quick installer must probe release source latency'
 require_pattern 'Sort-ReleaseCandidates' 'Windows quick installer must prefer lower-latency release candidates'
 require_pattern 'Get-ReleaseAsset' 'Windows quick installer must select assets from release metadata'
+require_pattern 'Convert-GitCodeAssetUrl' 'Windows quick installer must normalize GitCode release asset URLs'
+require_pattern 'api\.gitcode\.com.*/releases/download' 'Windows quick installer must guard GitCode API-hosted asset URLs'
+require_pattern 'https://gitcode\.com/' 'Windows quick installer must download GitCode release assets from gitcode.com'
 reject_pattern 'GITEE|gitee\.com|Gitee' 'Windows quick installer should only use GitHub and GitCode sources'
 reject_pattern 'GitHub xlings-res/xlings' 'Windows quick installer should not add a second GitHub resource source'
+reject_pattern 'return \[string\]\$asset\.browser_download_url' 'Windows quick installer must not return raw GitCode asset URLs without normalization'
 reject_pattern '^[[:space:]]*exit[[:space:]]+[0-9]+' 'Windows quick installer must not call exit from irm|iex execution path'
 
 echo "PASS: Windows quick install resource probing checks"

--- a/tools/other/quick_install.ps1
+++ b/tools/other/quick_install.ps1
@@ -91,6 +91,19 @@ function Get-TagCandidates {
     return $uniqueCandidates
 }
 
+function Convert-GitCodeAssetUrl {
+    param([string]$Url)
+
+    # GitCode release metadata currently reports attach browser_download_url on
+    # api.gitcode.com, but direct downloads from that host return 404. The same
+    # /releases/download/... path on gitcode.com redirects to file-cdn.gitcode.com.
+    if ($Url -like "https://api.gitcode.com/*/releases/download/*") {
+        return $Url.Replace("https://api.gitcode.com/", "https://gitcode.com/")
+    }
+
+    return $Url
+}
+
 function Get-ReleaseAsset {
     param(
         [object]$Release,
@@ -99,7 +112,7 @@ function Get-ReleaseAsset {
 
     foreach ($asset in @($Release.assets)) {
         if ($asset.name -eq $AssetName -and $asset.browser_download_url) {
-            return [string]$asset.browser_download_url
+            return Convert-GitCodeAssetUrl ([string]$asset.browser_download_url)
         }
     }
 


### PR DESCRIPTION
## Summary

- normalize GitCode release asset URLs returned by release metadata before download
- document the GitCode attach URL behavior: metadata reports `api.gitcode.com`, while direct downloads work through `gitcode.com`
- tighten the Windows quick-install resource probe regression check so raw GitCode asset URLs are not returned directly

## Root Cause

GitCode release metadata returns attach asset `browser_download_url` values like `https://api.gitcode.com/xlings-res/xlings/releases/download/...`, but direct downloads from that host return 404. The equivalent `https://gitcode.com/xlings-res/xlings/releases/download/...` route redirects to `file-cdn.gitcode.com` and returns the ZIP content.

## Test Plan

- `bash tests/e2e/windows_quick_install_resource_probe_test.sh`
- `git diff --check`
- live smoke: `curl -LfsS --max-time 20 -H 'User-Agent: xlings-quick-install' --range 0-3 https://gitcode.com/xlings-res/xlings/releases/download/0.4.43/xlings-0.4.43-windows-x86_64.zip | xxd -p -l 16` -> `504b0304`
