### PR TITLE
feat(0.4.48): owner-anchored shim dispatch (owner -> env -> default)

### DIFF
--- a/.agents/docs/2026-06-04-shim-owner-anchoring-design.md
+++ b/.agents/docs/2026-06-04-shim-owner-anchoring-design.md
@@ -1,7 +1,7 @@
 # Shim Owner-Anchoring Design (shims bind to their owning home)
 
 > Date: 2026-06-04
-> Status: design proposal for review
+> Status: implemented (0.4.48, Phase 1 — owner → env → default); Phase 2 (strict) pending soak
 > Related: `2026-05-29-compact-git-bootstrap-plan.md`, `2026-05-22-selfcontained-detection-windows-bug.md`
 > Evidence: mcpp-community/mcpp PR #114 (temp Windows CI repro, branch `test/windows-no-git-user-flow`)
 
@@ -178,11 +178,13 @@ Platform notes:
 - **Windows**: shims are hardlinks/copies; `GetModuleFileNameW` returns the
   invoked shim path (e.g. `<home>/subos/current/bin/git.exe`) → walk-up
   finds `<home>`. The `subos/current` dir itself can never false-match: it
-  has no `subos/` subdirectory. This **replaces and deletes** the fragile
-  JSON-content disambiguation hack in the `Config` ctor (the
-  `version`+`activeSubos` key check documented in
-  `2026-05-22-selfcontained-detection-windows-bug.md`) with a structural
-  test.
+  has no `subos/` subdirectory. The fragile JSON-content disambiguation
+  hack in the `Config` ctor (the `version`+`activeSubos` key check
+  documented in `2026-05-22-selfcontained-detection-windows-bug.md`) is
+  superseded by this structural test for shim dispatch; its removal from
+  the CLI self-contained path is deferred to a follow-up cleanup once
+  anchoring has soaked (the ctor path still serves the CLI, which this
+  change deliberately leaves untouched).
 - **Linux/macOS**: shims are (relative) symlinks to `<home>/bin/xlings`;
   prefer absolutized `argv[0]` (the shim's own path), fall back to
   `/proc/self/exe` / `_NSGetExecutablePath` — both land inside the owning
@@ -282,29 +284,29 @@ everything downstream is reused verbatim:
 Net: every currently-working scenario keeps its result; the only behavior
 change is #5, which replaces an accident with a contract.
 
-## 5. Implementation plan
+## 5. Implementation (as landed in 0.4.48)
 
-1. `xvm::resolve_owner_home(exe_path) -> optional<fs::path>` — pure
-   function + structural signature (new, ~30 lines; unit-testable with a
-   tmpdir home layout).
-2. `Config::override_home(const fs::path&)` — static pre-init hook on the
-   lazy singleton; assert it is called before first `instance_()` use.
-3. `main.cpp` multicall: when `program_name` is not `xlings`, run the §3
-   lookup chain and inject the chosen home before `shim_dispatch`. Factor
-   `has_program(home, name)` so each hop is a cheap DB probe (reuse the
-   tri-state diagnostic); `Config` must support constructing the probe
-   against a non-final home (lightweight read-only workspace load, or
-   defer singleton finalization until the home is chosen).
-4. `shim_dispatch` miss-path error text: name the owner home and list the
-   other consulted homes (see §3); warn on hop-2 use and 5b ambiguity.
-5. Delete the Windows JSON-content disambiguation in the `Config` ctor;
-   replace the self-contained check with `is_home_root` (shared helper).
-6. `xlings doctor`: new check — every shim under `<home>/subos/*/bin`
-   anchors back to `<home>`; orphans flagged (extends the existing
-   orphan-shim check in `xself/doctor.cppm`).
-7. Docs + CHANGELOG: state the contract explicitly
-   ("shims are bound to their owning home; `XLINGS_HOME` only selects the
-   management target of the xlings CLI").
+| Change | Where |
+| --- | --- |
+| `is_home_root` / `resolve_owner_home` / `home_knows_program` / `resolve_dispatch_home` (the §3 chain, incl. legacy mode + warnings) | `src/core/xvm/shim.cppm` |
+| `Config::override_home()` pre-init hook + ctor honors it ahead of env/self-contained | `src/core/config.cppm` |
+| Multicall runs the chain for shim invocations BEFORE the first Config use; CLI path untouched | `src/main.cpp` |
+| Doctor check 2.6 "shim anchor": every program shim under this home's binDir anchors back to this home (warning-only; scoped to binDirs physically inside the home so project-subos binDirs don't false-positive) | `src/core/xself/doctor.cppm` |
+| Unit tests: home-root signature (real home / subos dir / project state dir), owner walk (subos bin, nested innermost, orphan), DB probe (key / filename-stem / empty / missing), chain ordering (owner-wins, env-fallback, total-miss owner-bound, legacy) | `tests/unit/test_shim_anchor.cpp` |
+| E2E: owner-wins + ambiguity warning; deprecated borrowing + warning; legacy mode env-first; redirected-env regression (the mcpp case) | `tests/e2e/shim_owner_anchoring_test.sh` (registered in linux + macos CI) |
+| Version bump | `src/core/config.cppm` `VERSION = "0.4.48"`, `mcpp.toml` |
+
+Deliberately NOT in this change (follow-ups):
+
+1. Removing the Windows JSON-content disambiguation from the `Config`
+   ctor's self-contained detection — the ctor path still serves the CLI;
+   clean up once anchoring has soaked (§3.1).
+2. `home_knows_program` reads the home-global versions DB only (project
+   overlays apply after the home is chosen, as before) — by design, not a
+   simplification to revisit.
+3. CHANGELOG/release-notes wording: "shims are bound to their owning
+   home; `XLINGS_HOME` only selects the management target of the xlings
+   CLI" — goes in the 0.4.48 release notes.
 
 ### Testing
 

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -250,6 +250,10 @@ jobs:
         run: |
           bash tests/e2e/install_silent_failure_test.sh
 
+      - name: "E2E-28: shim owner anchoring (owner -> env -> default)"
+        run: |
+          bash tests/e2e/shim_owner_anchoring_test.sh
+
       - name: Attach artifact
         uses: actions/upload-artifact@v4
         if: success()

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -170,6 +170,10 @@ jobs:
         run: |
           bash tests/e2e/build_deps_split_test.sh
 
+      - name: "E2E-12: shim owner anchoring (owner -> env -> default)"
+        run: |
+          bash tests/e2e/shim_owner_anchoring_test.sh
+
       - name: Attach artifact
         uses: actions/upload-artifact@v4
         if: success()

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "0.4.47"
+version = "0.4.48"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.47";
+    static constexpr std::string_view VERSION = "0.4.48";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 
@@ -42,7 +42,21 @@ public:
         bool                  selfContained = false;
     };
 
+    // Owner-anchored shim dispatch (0.4.48; see
+    // .agents/docs/2026-06-04-shim-owner-anchoring-design.md): inject the
+    // dispatch home BEFORE first Config use. main.cpp calls this for shim
+    // invocations only — the xlings CLI keeps the env-first resolution.
+    // Has no effect once the singleton is constructed.
+    static void override_home(const std::filesystem::path& home) {
+        home_override_() = home;
+    }
+
 private:
+    static std::optional<std::filesystem::path>& home_override_() {
+        static std::optional<std::filesystem::path> v;
+        return v;
+    }
+
     PathInfo paths_;
     std::string mirror_;
     std::string lang_;
@@ -398,7 +412,11 @@ private:
         namespace fs = std::filesystem;
 
         auto envHome = utils::get_env_or_default("XLINGS_HOME");
-        if (!envHome.empty()) {
+        if (auto& anchored = home_override_(); anchored && !anchored->empty()) {
+            // Owner-anchored shim dispatch: the dispatch home was chosen
+            // before Config construction (main.cpp → resolve_dispatch_home).
+            paths_.homeDir = *anchored;
+        } else if (!envHome.empty()) {
             paths_.homeDir = envHome;
         } else {
             auto exePath   = platform::get_executable_path();

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -193,6 +193,51 @@ export int cmd_doctor(EventStream& stream, bool fix) {
         }
     }
 
+    // Check 2.6: shim ownership anchoring (0.4.48). Every program-typed
+    // shim under this home's binDir must anchor back to THIS home — a shim
+    // that anchors elsewhere (or nowhere) would dispatch against a foreign
+    // home's versions DB. Warning-only: the usual cause is a hand-copied
+    // shim file or a damaged home layout, and the right fix depends on
+    // which it is. Scoped to bin dirs physically inside the home: a project
+    // subos binDir lives in the project tree, where shims intentionally
+    // anchor to the global home via their symlink target (and on Windows,
+    // where hardlinks don't carry the target path, via the dispatch-time
+    // fallback chain) — not a defect.
+    // See .agents/docs/2026-06-04-shim-owner-anchoring-design.md.
+    std::error_code relEc;
+    auto binRel = fs::relative(p.binDir, p.homeDir, relEc);
+    bool binDirInsideHome = !relEc && !binRel.empty()
+        && binRel.string().rfind("..", 0) != 0;
+    if (binDirInsideHome && fs::exists(p.binDir)) {
+        std::error_code hec;
+        auto home_canon = fs::weakly_canonical(p.homeDir, hec);
+        for (auto& entry : platform::dir_entries(p.binDir)) {
+            std::error_code ec;
+            if (!entry.is_regular_file(ec) && !entry.is_symlink(ec)) continue;
+            auto fname = entry.path().filename().string();
+            std::string base = fname;
+            if (!shim_ext.empty() && base.ends_with(shim_ext)) {
+                base = base.substr(0, base.size() - shim_ext.size());
+            }
+            if (xvm::is_xlings_binary(base)) continue;
+            auto* vi = xvm::get_vinfo(db, base);
+            if (!vi || vi->type != "program") continue;
+
+            auto owner = xvm::resolve_owner_home(entry.path());
+            std::error_code oec;
+            bool anchored = owner
+                && fs::weakly_canonical(*owner, oec) == home_canon;
+            if (anchored) continue;
+
+            ++warnings;
+            add_field("⚠ shim anchor", std::format(
+                "{} anchors to {} (expected this home); it will dispatch "
+                "against that home's versions DB",
+                entry.path().string(),
+                owner ? owner->string() : "no home (orphan)"));
+        }
+    }
+
     // Check 3: payload existence + executability for every (name, version)
     // in the versions DB. Reuses the same `resolve_executable` helper that
     // shim_dispatch uses at runtime so doctor's verdict matches what the

--- a/src/core/xvm/shim.cppm
+++ b/src/core/xvm/shim.cppm
@@ -1,5 +1,7 @@
 module;
 
+#include <cstdlib>
+
 #if defined(__linux__) || defined(__APPLE__)
 #include <unistd.h>
 #endif
@@ -8,6 +10,7 @@ export module xlings.core.xvm.shim;
 
 import std;
 
+import xlings.libs.json;
 import xlings.core.config;
 import xlings.core.log;
 import xlings.platform;
@@ -30,6 +33,197 @@ bool is_xlings_binary(std::string_view name) {
 std::string extract_program_name(const char* argv0) {
     auto p = std::filesystem::path(argv0);
     return p.stem().string();
+}
+
+// ─── Owner-anchored dispatch home (0.4.48) ──────────────────────────
+//
+// Design: .agents/docs/2026-06-04-shim-owner-anchoring-design.md
+//
+// A shim is an artifact of exactly one home; dispatch resolves against
+// that home FIRST ("which shim file PATH hits" is the selector, ambient
+// env is not). env XLINGS_HOME stays as a deprecated lower-priority
+// fallback ("borrowing") for one transition window; ~/.xlings covers
+// orphan shims copied out of a home. `XLINGS_SHIM_ANCHOR=legacy` (or
+// `0`/`off`) restores the pre-0.4.48 env-first behavior as release
+// insurance.
+
+// Structural home-root signature. Deliberately structural (no JSON
+// content sniffing): a real home has all three of `.xlings.json`,
+// `bin/xlings[.exe]`, and a `subos/` directory. A subos dir
+// (`<home>/subos/current`) has no `subos/` inside it, and a project
+// state dir (`<project>/.xlings`) has no `bin/xlings` — so neither can
+// false-match. Project shims must anchor to the GLOBAL home (their
+// payloads live there); the project state dir is excluded by design.
+bool is_home_root(const std::filesystem::path& dir) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    if (!fs::is_regular_file(dir / ".xlings.json", ec)) return false;
+    constexpr std::string_view bin_name =
+        (platform::OS_NAME == "windows") ? "xlings.exe" : "xlings";
+    if (!fs::exists(dir / "bin" / bin_name, ec)) return false;
+    if (!fs::is_directory(dir / "subos", ec)) return false;
+    return true;
+}
+
+// Find the home that owns the invoked shim by walking parents upward.
+// Tries the shim file as invoked first (only when argv[0] carries a
+// path — a bare name came from PATH search and is not a location),
+// then the running executable path (Windows: the hardlinked shim path;
+// Unix: the symlink-resolved real binary inside its home — both land
+// inside the owning home). The walk meets the INNERMOST home root
+// first, so nested homes resolve to the nearest owner.
+std::optional<std::filesystem::path>
+resolve_owner_home(const std::filesystem::path& invoked) {
+    namespace fs = std::filesystem;
+
+    auto walk_up = [](fs::path p) -> std::optional<fs::path> {
+        std::error_code ec;
+        auto canon = fs::weakly_canonical(p, ec);
+        if (!ec && !canon.empty()) p = canon;
+        for (auto dir = p.parent_path(); !dir.empty();) {
+            if (is_home_root(dir)) return dir;
+            auto parent = dir.parent_path();
+            if (parent == dir) break;
+            dir = parent;
+        }
+        return std::nullopt;
+    };
+
+    if (invoked.has_parent_path() && !invoked.parent_path().empty()) {
+        std::error_code ec;
+        auto abs = fs::absolute(invoked, ec);
+        if (!ec) {
+            if (auto h = walk_up(abs)) return h;
+        }
+    }
+
+    auto exe = platform::get_executable_path();
+    if (!exe.empty()) {
+        if (auto h = walk_up(exe)) return h;
+    }
+    return std::nullopt;
+}
+
+// Lightweight probe: does <home>'s version DB register `program` (with
+// at least one version)? Reads <home>/.xlings.json directly — no Config
+// singleton involvement, so candidate homes can be probed before the
+// dispatch home is chosen. A registered-but-broken entry counts as a
+// hit: the error is then reported against that home instead of silently
+// jumping homes (genuine breakage must not be masked).
+bool home_knows_program(const std::filesystem::path& home,
+                        const std::string& program) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    auto cfg = home / ".xlings.json";
+    if (!fs::is_regular_file(cfg, ec)) return false;
+    try {
+        auto content = platform::read_file_to_string(cfg.string());
+        auto j = nlohmann::json::parse(content, nullptr, false);
+        if (j.is_discarded() || !j.is_object()) return false;
+        if (!j.contains("versions") || !j["versions"].is_object()) return false;
+        const auto& versions = j["versions"];
+
+        auto has_versions = [](const nlohmann::json& e) {
+            return e.is_object() && e.contains("versions")
+                && e["versions"].is_object() && !e["versions"].empty();
+        };
+
+        if (versions.contains(program) && has_versions(versions[program]))
+            return true;
+
+        // The shim file name may differ from the DB key (VInfo::filename).
+        for (auto it = versions.begin(); it != versions.end(); ++it) {
+            const auto& e = it.value();
+            if (!e.is_object()) continue;
+            if (!e.contains("filename") || !e["filename"].is_string()) continue;
+            auto fn = e["filename"].get<std::string>();
+            if (!fn.empty() && fs::path(fn).stem().string() == program
+                && has_versions(e)) {
+                return true;
+            }
+        }
+    } catch (...) {
+        return false;
+    }
+    return false;
+}
+
+// Choose the dispatch home for a shim invocation: owner → env →
+// default (§3 of the design doc). Returns the home to inject via
+// Config::override_home(), or nullopt to leave Config's legacy
+// resolution untouched (legacy mode, or no candidate knows better).
+std::optional<std::filesystem::path>
+resolve_dispatch_home(const std::string& program, const char* argv0) {
+    namespace fs = std::filesystem;
+
+    auto env_or_empty = [](const char* key) -> std::string {
+        const char* v = std::getenv(key);
+        return v ? std::string(v) : std::string();
+    };
+
+    auto mode = env_or_empty("XLINGS_SHIM_ANCHOR");
+    if (mode == "0" || mode == "legacy" || mode == "off") {
+        log::debug("shim home: anchoring disabled (XLINGS_SHIM_ANCHOR={})", mode);
+        return std::nullopt;
+    }
+
+    auto owner = resolve_owner_home(fs::path(argv0 ? argv0 : ""));
+    auto envHomeStr = env_or_empty("XLINGS_HOME");
+    fs::path envHome = envHomeStr.empty() ? fs::path{} : fs::path(envHomeStr);
+
+    auto same = [](const fs::path& a, const fs::path& b) {
+        if (a.empty() || b.empty()) return false;
+        std::error_code ec;
+        auto ca = fs::weakly_canonical(a, ec);
+        std::error_code ec2;
+        auto cb = fs::weakly_canonical(b, ec2);
+        return (ec || ec2) ? (a == b) : (ca == cb);
+    };
+
+    // hop 1: owner home (the shim's own home) — the contract.
+    if (owner && home_knows_program(*owner, program)) {
+        if (!envHome.empty() && !same(*owner, envHome)
+            && home_knows_program(envHome, program)) {
+            log::warn("shim '{}' owned by {} is also resolvable in XLINGS_HOME={}; "
+                      "using the owner home (env-based shim switching is deprecated "
+                      "— put that home's subos bin on PATH instead)",
+                      program, owner->string(), envHome.string());
+        }
+        log::debug("shim home: owner={} (hop 1)", owner->string());
+        return owner;
+    }
+
+    // hop 2: env XLINGS_HOME — DEPRECATED compat fallback ("borrowing").
+    if (!envHome.empty() && !same(owner.value_or(fs::path{}), envHome)
+        && home_knows_program(envHome, program)) {
+        log::warn("shim '{}' is not installed in its owning home{}; falling back "
+                  "to XLINGS_HOME={} (deprecated, will be removed in a future "
+                  "release)",
+                  program,
+                  owner ? (" " + owner->string()) : std::string(""),
+                  envHome.string());
+        log::debug("shim home: env={} (hop 2)", envHome.string());
+        return envHome;
+    }
+
+    // hop 3: default ~/.xlings — covers orphan shims copied out of a home.
+    fs::path defaultHome = fs::path(platform::get_home_dir()) / ".xlings";
+    if (!same(owner.value_or(fs::path{}), defaultHome)
+        && !same(envHome, defaultHome)
+        && home_knows_program(defaultHome, program)) {
+        log::debug("shim home: default={} (hop 3)", defaultHome.string());
+        return defaultHome;
+    }
+
+    // No candidate knows the program: bind to the owner so the error is
+    // reported against the home this shim belongs to; otherwise leave
+    // Config's legacy resolution (env/default) in place.
+    if (owner) {
+        log::debug("shim home: owner={} (no candidate knows '{}')",
+                   owner->string(), program);
+        return owner;
+    }
+    return std::nullopt;
 }
 
 // Resolve the real executable path for a shim target

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,9 +32,6 @@ int main(int argc, char* argv[]) {
 
     xlings::platform::init_console_output();
 
-    auto& p = xlings::Config::paths();
-    xlings::platform::set_env_variable("XLINGS_HOME", p.homeDir.string());
-
     // Multicall: check argv[0] to determine mode.
     auto program_name = xlings::xvm::extract_program_name(argv[0]);
 
@@ -48,6 +45,21 @@ int main(int argc, char* argv[]) {
         return 2;
     }
 
+    // Owner-anchored shim dispatch (0.4.48): a shim resolves against the
+    // home that owns the shim file (owner → env → default), not against
+    // ambient XLINGS_HOME. Must run BEFORE the first Config use below.
+    // The xlings CLI itself keeps the env-first home resolution.
+    // See .agents/docs/2026-06-04-shim-owner-anchoring-design.md.
+    const bool is_cli = xlings::xvm::is_xlings_binary(program_name);
+    if (!is_cli) {
+        if (auto home = xlings::xvm::resolve_dispatch_home(program_name, argv[0])) {
+            xlings::Config::override_home(*home);
+        }
+    }
+
+    auto& p = xlings::Config::paths();
+    xlings::platform::set_env_variable("XLINGS_HOME", p.homeDir.string());
+
     // COMPAT(0.4.17 → permanent self-heal): if the user updated xlings via
     // `xlings update xlings` (which only flips the xvm pointer; it doesn't
     // call ensure_home_layout), the on-disk shell profiles will be stale.
@@ -56,7 +68,7 @@ int main(int argc, char* argv[]) {
     xlings::xself::compat::v0_4_17::auto_upgrade_profiles_if_stale(p.homeDir);
 
     int rc;
-    if (xlings::xvm::is_xlings_binary(program_name)) {
+    if (is_cli) {
         rc = xlings::cli::run(argc, argv);
     } else {
         rc = xlings::xvm::shim_dispatch(program_name, argc, argv);

--- a/tests/e2e/shim_owner_anchoring_test.sh
+++ b/tests/e2e/shim_owner_anchoring_test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# shim_owner_anchoring_test.sh — owner-anchored shim dispatch (0.4.48).
+#
+# Design: .agents/docs/2026-06-04-shim-owner-anchoring-design.md
+#
+# A shim is an artifact of exactly one home: invoking it must resolve
+# against that home (owner), regardless of ambient XLINGS_HOME. The env
+# var stays as a deprecated lower-priority fallback ("borrowing") for one
+# transition window, and XLINGS_SHIM_ANCHOR=legacy restores the pre-0.4.48
+# env-first behavior.
+#
+# Scenarios:
+#   1. owner wins: tool installed in home A (shim's owner) AND in env home
+#      B with a different payload → A's payload runs + ambiguity warning.
+#   2. borrowing fallback: shim's owner does not know the tool, env home
+#      does → env home's payload runs + deprecation warning.
+#   3. legacy mode: XLINGS_SHIM_ANCHOR=legacy restores env-first → B wins.
+#   4. redirected-env regression (the mcpp case): tool ONLY in owner home,
+#      XLINGS_HOME points at a fresh foreign home → tool still runs.
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/shim_owner_anchoring"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+HOME_A="$RUNTIME_DIR/home-a"
+HOME_B="$RUNTIME_DIR/home-b"
+HOME_FRESH="$RUNTIME_DIR/home-fresh"   # fresh foreign home (mcpp registry shape)
+WORK_DIR="$RUNTIME_DIR/work"
+
+# make_home <dir> — fabricate a structural home: .xlings.json + bin/xlings
+# + subos/default/bin (the owner-anchoring signature).
+make_home() {
+  local home="$1"
+  mkdir -p "$home/subos/default/bin" "$home/bin"
+  cp "$XLINGS_BIN" "$home/bin/xlings"
+  cat > "$home/.xlings.json" <<JSON
+{ "activeSubos": "default", "mirror": "GLOBAL", "versions": {} }
+JSON
+  cat > "$home/subos/default/.xlings.json" <<JSON
+{ "workspace": {} }
+JSON
+}
+
+# install_tool <home> <tool> <marker> — register <tool>@1.0.0 in <home>'s
+# versions DB + workspace, with a payload script that prints <marker>.
+install_tool() {
+  local home="$1" tool="$2" marker="$3"
+  local payload="$home/data/xpkgs/$tool/1.0.0"
+  mkdir -p "$payload/bin"
+  cat > "$payload/bin/$tool" <<SCRIPT
+#!/usr/bin/env bash
+echo "$marker"
+SCRIPT
+  chmod +x "$payload/bin/$tool"
+
+  python3 - "$home/.xlings.json" "$tool" "$payload" <<'PY'
+import json, sys
+path, tool, payload = sys.argv[1:4]
+with open(path) as f:
+    cfg = json.load(f)
+cfg.setdefault("versions", {})[tool] = {
+    "type": "program",
+    "versions": {"1.0.0": {"path": payload}},
+}
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+PY
+
+  python3 - "$home/subos/default/.xlings.json" "$tool" <<'PY'
+import json, sys
+path, tool = sys.argv[1:3]
+with open(path) as f:
+    cfg = json.load(f)
+cfg.setdefault("workspace", {})[tool] = "1.0.0"
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+PY
+
+  # The shim: the home's own xlings binary, named after the tool
+  # (matches xself::create_shim's symlink form on Unix).
+  ln -sf "$home/bin/xlings" "$home/subos/default/bin/$tool"
+}
+
+run_shim() {
+  # run_shim <shim-path> [env overrides as VAR=val ...]
+  local shim="$1"; shift
+  (cd "$WORK_DIR" && env -u XLINGS_PROJECT_DIR -u XLINGS_ACTIVE_SUBOS \
+      XLINGS_SHIM_DEPTH=0 "$@" "$shim" 2>"$WORK_DIR/stderr.txt")
+}
+
+mkdir -p "$WORK_DIR"
+make_home "$HOME_A"
+make_home "$HOME_B"
+make_home "$HOME_FRESH"
+
+install_tool "$HOME_A" "anchortool" "payload-from-A"
+install_tool "$HOME_B" "anchortool" "payload-from-B"
+install_tool "$HOME_B" "borrowtool" "borrow-from-B"
+
+SHIM_A="$HOME_A/subos/default/bin/anchortool"
+
+# ── 1. owner wins over env (both homes know the tool) ────────────────
+out="$(run_shim "$SHIM_A" XLINGS_HOME="$HOME_B")"
+[[ "$out" == "payload-from-A" ]] \
+  || fail "owner anchoring: expected payload-from-A, got '$out'"
+grep -q "deprecated" "$WORK_DIR/stderr.txt" \
+  || fail "owner anchoring: expected ambiguity warning on stderr"
+log "1. owner wins over env XLINGS_HOME — ok"
+
+# ── 2. borrowing fallback (owner doesn't know, env does) ─────────────
+ln -sf "$HOME_A/bin/xlings" "$HOME_A/subos/default/bin/borrowtool"
+out="$(run_shim "$HOME_A/subos/default/bin/borrowtool" XLINGS_HOME="$HOME_B")"
+[[ "$out" == "borrow-from-B" ]] \
+  || fail "borrowing fallback: expected borrow-from-B, got '$out'"
+grep -q "deprecated" "$WORK_DIR/stderr.txt" \
+  || fail "borrowing fallback: expected deprecation warning on stderr"
+log "2. env borrowing fallback (deprecated) — ok"
+
+# ── 3. legacy mode restores env-first dispatch ───────────────────────
+out="$(run_shim "$SHIM_A" XLINGS_HOME="$HOME_B" XLINGS_SHIM_ANCHOR=legacy)"
+[[ "$out" == "payload-from-B" ]] \
+  || fail "legacy mode: expected payload-from-B, got '$out'"
+log "3. XLINGS_SHIM_ANCHOR=legacy restores env-first — ok"
+
+# ── 4. redirected-env regression (the mcpp case) ─────────────────────
+# A fresh foreign home (like mcpp's registry) knows nothing; pre-0.4.48
+# this failed with "'anchortool' is not installed".
+out="$(run_shim "$SHIM_A" XLINGS_HOME="$HOME_FRESH")"
+[[ "$out" == "payload-from-A" ]] \
+  || fail "redirected env: expected payload-from-A, got '$out'"
+log "4. shim works under redirected XLINGS_HOME (mcpp regression) — ok"
+
+log "PASS: shim owner anchoring"

--- a/tests/unit/test_shim_anchor.cpp
+++ b/tests/unit/test_shim_anchor.cpp
@@ -1,0 +1,247 @@
+// Unit tests for owner-anchored shim dispatch (0.4.48).
+// Design: .agents/docs/2026-06-04-shim-owner-anchoring-design.md
+#include <gtest/gtest.h>
+
+import std;
+import xlings.core.xvm.shim;
+import xlings.platform;
+
+namespace fs = std::filesystem;
+
+namespace {
+
+#if defined(_WIN32)
+constexpr const char* kXlingsBin = "xlings.exe";
+#else
+constexpr const char* kXlingsBin = "xlings";
+#endif
+
+struct TempDir {
+    fs::path path;
+    TempDir() {
+        path = fs::temp_directory_path()
+             / ("xlings-anchor-test-" + std::to_string(
+                   std::chrono::steady_clock::now().time_since_epoch().count()));
+        fs::create_directories(path);
+    }
+    ~TempDir() {
+        std::error_code ec;
+        fs::remove_all(path, ec);
+    }
+};
+
+void touch(const fs::path& p, std::string_view content = "x") {
+    fs::create_directories(p.parent_path());
+    std::ofstream os(p);
+    os << content;
+}
+
+// Build a minimal structural home at `root`: .xlings.json + bin/xlings +
+// subos/default/bin. Returns the subos bin dir.
+fs::path make_home(const fs::path& root, std::string_view versionsJson = "{}") {
+    touch(root / ".xlings.json",
+          std::string("{ \"activeSubos\": \"default\", \"versions\": ")
+              + std::string(versionsJson) + " }");
+    touch(root / "bin" / kXlingsBin);
+    auto bin = root / "subos" / "default" / "bin";
+    fs::create_directories(bin);
+    return bin;
+}
+
+} // namespace
+
+// ── is_home_root ─────────────────────────────────────────────────────
+
+TEST(ShimAnchorHomeRoot, RealHomeMatches) {
+    TempDir tmp;
+    auto home = tmp.path / "home";
+    make_home(home);
+    EXPECT_TRUE(xlings::xvm::is_home_root(home));
+}
+
+TEST(ShimAnchorHomeRoot, SubosDirDoesNotMatch) {
+    TempDir tmp;
+    auto home = tmp.path / "home";
+    make_home(home);
+    // subos/current carries a workspace .xlings.json and (as a shim) a
+    // bin/xlings — but it has no subos/ inside it.
+    auto current = home / "subos" / "current";
+    touch(current / ".xlings.json", "{ \"workspace\": {} }");
+    touch(current / "bin" / kXlingsBin);
+    EXPECT_FALSE(xlings::xvm::is_home_root(current));
+}
+
+TEST(ShimAnchorHomeRoot, ProjectStateDirDoesNotMatch) {
+    TempDir tmp;
+    // <project>/.xlings has subos/ but no bin/xlings — a project state
+    // dir owns no payloads and must never anchor a shim.
+    auto state = tmp.path / "project" / ".xlings";
+    touch(state / ".xlings.json", "{}");
+    fs::create_directories(state / "subos" / "_" / "bin");
+    EXPECT_FALSE(xlings::xvm::is_home_root(state));
+}
+
+// ── resolve_owner_home ───────────────────────────────────────────────
+
+TEST(ShimAnchorOwner, ShimInSubosBinAnchorsToHome) {
+    TempDir tmp;
+    auto home = tmp.path / "home";
+    auto bin = make_home(home);
+    auto shim = bin / "tool";
+    touch(shim);
+
+    auto owner = xlings::xvm::resolve_owner_home(shim);
+    ASSERT_TRUE(owner.has_value());
+    EXPECT_EQ(fs::weakly_canonical(*owner), fs::weakly_canonical(home));
+}
+
+TEST(ShimAnchorOwner, NestedHomeAnchorsToInnermost) {
+    TempDir tmp;
+    auto outer = tmp.path / "outer";
+    make_home(outer);
+    auto inner = outer / "data" / "xpkgs" / "xim-x-embed" / "0.0.1" / "registry";
+    auto innerBin = make_home(inner);
+    auto shim = innerBin / "tool";
+    touch(shim);
+
+    auto owner = xlings::xvm::resolve_owner_home(shim);
+    ASSERT_TRUE(owner.has_value());
+    EXPECT_EQ(fs::weakly_canonical(*owner), fs::weakly_canonical(inner));
+}
+
+TEST(ShimAnchorOwner, OrphanShimHasNoOwner) {
+    TempDir tmp;
+    auto shim = tmp.path / "loose" / "tool";
+    touch(shim);
+    // Walks up into the temp dir and beyond — no home signature anywhere
+    // on the way (the walk stops at filesystem root).
+    auto owner = xlings::xvm::resolve_owner_home(shim);
+    EXPECT_FALSE(owner.has_value());
+}
+
+// ── home_knows_program ───────────────────────────────────────────────
+
+TEST(ShimAnchorKnows, DirectKeyMatch) {
+    TempDir tmp;
+    auto home = tmp.path / "home";
+    make_home(home, R"({
+        "git": { "type": "program",
+                 "versions": { "2.51.1": { "path": "data/xpkgs/g" } } }
+    })");
+    EXPECT_TRUE(xlings::xvm::home_knows_program(home, "git"));
+    EXPECT_FALSE(xlings::xvm::home_knows_program(home, "python"));
+}
+
+TEST(ShimAnchorKnows, FilenameStemMatch) {
+    TempDir tmp;
+    auto home = tmp.path / "home";
+    make_home(home, R"({
+        "python3": { "type": "program", "filename": "python.exe",
+                     "versions": { "3.12.0": { "path": "data/xpkgs/p" } } }
+    })");
+    EXPECT_TRUE(xlings::xvm::home_knows_program(home, "python"));
+}
+
+TEST(ShimAnchorKnows, EmptyVersionsIsNotAHit) {
+    TempDir tmp;
+    auto home = tmp.path / "home";
+    make_home(home, R"({ "git": { "type": "program", "versions": {} } })");
+    EXPECT_FALSE(xlings::xvm::home_knows_program(home, "git"));
+}
+
+TEST(ShimAnchorKnows, MissingConfigIsNotAHit) {
+    TempDir tmp;
+    EXPECT_FALSE(xlings::xvm::home_knows_program(tmp.path / "nope", "git"));
+}
+
+// ── resolve_dispatch_home (chain ordering) ───────────────────────────
+
+namespace {
+
+struct EnvGuard {
+    std::string key;
+    std::string old;
+    EnvGuard(const std::string& k, const std::string& v) : key(k) {
+        if (const char* o = std::getenv(k.c_str())) old = o;
+        xlings::platform::set_env_variable(k, v);
+    }
+    ~EnvGuard() { xlings::platform::set_env_variable(key, old); }
+};
+
+} // namespace
+
+TEST(ShimAnchorChain, OwnerWinsOverEnv) {
+    TempDir tmp;
+    auto ownerHome = tmp.path / "owner";
+    auto ownerBin = make_home(ownerHome, R"({
+        "tool": { "type": "program",
+                  "versions": { "1.0.0": { "path": "data/xpkgs/t" } } }
+    })");
+    auto envHome = tmp.path / "env";
+    make_home(envHome, R"({
+        "tool": { "type": "program",
+                  "versions": { "9.9.9": { "path": "data/xpkgs/t" } } }
+    })");
+    auto shim = ownerBin / "tool";
+    touch(shim);
+
+    EnvGuard g1("XLINGS_HOME", envHome.string());
+    EnvGuard g2("XLINGS_SHIM_ANCHOR", "");
+    auto chosen = xlings::xvm::resolve_dispatch_home(
+        "tool", shim.string().c_str());
+    ASSERT_TRUE(chosen.has_value());
+    EXPECT_EQ(fs::weakly_canonical(*chosen), fs::weakly_canonical(ownerHome));
+}
+
+TEST(ShimAnchorChain, EnvFallbackWhenOwnerDoesNotKnow) {
+    TempDir tmp;
+    auto ownerHome = tmp.path / "owner";
+    auto ownerBin = make_home(ownerHome, "{}");
+    auto envHome = tmp.path / "env";
+    make_home(envHome, R"({
+        "tool": { "type": "program",
+                  "versions": { "1.0.0": { "path": "data/xpkgs/t" } } }
+    })");
+    auto shim = ownerBin / "tool";
+    touch(shim);
+
+    EnvGuard g1("XLINGS_HOME", envHome.string());
+    EnvGuard g2("XLINGS_SHIM_ANCHOR", "");
+    auto chosen = xlings::xvm::resolve_dispatch_home(
+        "tool", shim.string().c_str());
+    ASSERT_TRUE(chosen.has_value());
+    EXPECT_EQ(fs::weakly_canonical(*chosen), fs::weakly_canonical(envHome));
+}
+
+TEST(ShimAnchorChain, OwnerBoundOnTotalMiss) {
+    TempDir tmp;
+    auto ownerHome = tmp.path / "owner";
+    auto ownerBin = make_home(ownerHome, "{}");
+    auto shim = ownerBin / "tool";
+    touch(shim);
+
+    EnvGuard g1("XLINGS_HOME", "");
+    EnvGuard g2("XLINGS_SHIM_ANCHOR", "");
+    auto chosen = xlings::xvm::resolve_dispatch_home(
+        "tool", shim.string().c_str());
+    // Nothing knows the tool → bind to the owner so the error names the
+    // home this shim belongs to.
+    ASSERT_TRUE(chosen.has_value());
+    EXPECT_EQ(fs::weakly_canonical(*chosen), fs::weakly_canonical(ownerHome));
+}
+
+TEST(ShimAnchorChain, LegacyModeDisablesAnchoring) {
+    TempDir tmp;
+    auto ownerHome = tmp.path / "owner";
+    auto ownerBin = make_home(ownerHome, R"({
+        "tool": { "type": "program",
+                  "versions": { "1.0.0": { "path": "data/xpkgs/t" } } }
+    })");
+    auto shim = ownerBin / "tool";
+    touch(shim);
+
+    EnvGuard g("XLINGS_SHIM_ANCHOR", "legacy");
+    auto chosen = xlings::xvm::resolve_dispatch_home(
+        "tool", shim.string().c_str());
+    EXPECT_FALSE(chosen.has_value());
+}


### PR DESCRIPTION
## What

A shim is an artifact of exactly one home. Dispatch now resolves against the home that **owns the shim file** first, instead of trusting ambient `XLINGS_HOME`:

```
shim dispatch home: owner home (exe-anchored) -> env XLINGS_HOME (deprecated, warns) -> ~/.xlings
```

- `XLINGS_HOME` keeps exactly one meaning: the management target of the **xlings CLI** (install/update). CLI home resolution is untouched.
- `XLINGS_SHIM_ANCHOR=legacy` restores pre-0.4.48 env-first dispatch (release insurance, one soak cycle).
- Design + impact analysis: `.agents/docs/2026-06-04-shim-owner-anchoring-design.md` (updated to as-landed state in this PR).

## Why

Any process tree that redirects `XLINGS_HOME` (e.g. mcpp's vendored registry sandbox) silently broke **every shim-resolved tool on PATH** — git, python, node… The git shim failing inside mcpp's environment deadlocked package-index sync (index needs git, git bootstrap needs index) and left Windows users with `mcpp build` / `mcpp self init --force` permanently failing while their terminal `git --version` worked fine. Reproduced end-to-end in mcpp-community/mcpp#114; probe:

```
XLINGS_HOME=~/.xlings        git --version -> git version 2.51.0.windows.2
XLINGS_HOME=~/.mcpp/registry git --version -> [error] xlings: 'git' is not installed
```

## Changes

- `src/core/xvm/shim.cppm` — `is_home_root` (structural signature: `.xlings.json` + `bin/xlings` + `subos/`), `resolve_owner_home` (innermost-home upward walk), `home_knows_program` (lightweight versions-DB probe, no Config involvement), `resolve_dispatch_home` (the chain, legacy mode, deprecation/ambiguity warnings)
- `src/core/config.cppm` — `Config::override_home()` pre-init hook; ctor honors it ahead of env/self-contained; version 0.4.48
- `src/main.cpp` — run the chain for shim invocations before first Config use
- `src/core/xself/doctor.cppm` — check 2.6 `shim anchor` (warning-only; scoped to binDirs physically inside the home so project-subos binDirs don't false-positive)
- `tests/unit/test_shim_anchor.cpp` — 14 tests: home-root signature, owner walk (incl. nested innermost + orphan), DB probe, chain ordering
- `tests/e2e/shim_owner_anchoring_test.sh` — owner-wins + warning / deprecated borrowing + warning / legacy mode / redirected-env (mcpp) regression; registered in linux + macos CI

## Behavior changes

Only one: when **both** the owner home and the env home have the tool, the owner now wins (previously env won) — with a visible ambiguity warning. Borrowing (tool only in env home) still works, with a deprecation warning. Everything else is unchanged or was previously a hard error.

## Verification

- `mcpp build` clean; `tests/unit` pass (pre-existing local-env `Extract.*` failures reproduce identically on clean main, unrelated)
- e2e script passes all 4 scenarios locally
- Follow-up after release: re-run mcpp-community/mcpp#114 CI against the new release to confirm the Windows user-flow repro is fixed