### PR TITLE
feat(0.4.49): adaptive mirroring for github asset downloads (stall watchdog + latency-ordered candidates)

### DIFF
--- a/.agents/docs/2026-06-04-github-asset-adaptive-mirror.md
+++ b/.agents/docs/2026-06-04-github-asset-adaptive-mirror.md
@@ -1,0 +1,177 @@
+# Adaptive Mirroring for GitHub Asset URLs (no explicit mirror config)
+
+> Date: 2026-06-04
+> Status: implemented (0.4.49 — stall watchdog + latency-ordered candidates)
+> Related: `2026-05-01-mirror-fallback-step1.md` (mirror registry),
+>          `2026-06-04-shim-owner-anchoring-design.md` (0.4.48)
+
+## TL;DR
+
+When a package only carries a plain GitHub URL and the user never set a
+mirror (`mirror=GLOBAL` default, `mirror_fallback=auto`), a degraded
+network ("connects, then trickles") can pin a download to the original
+URL for up to `maxTimeSec` (600 s) × retries before any mirror is tried —
+the user experiences a hang.
+
+Two changes fix this **without any explicit configuration**:
+
+1. **Stall watchdog** (tinyhttps): abort a transfer whose windowed average
+   speed stays under a floor (default 10 KB/s over 15 s) and move to the
+   next candidate. This is the root-cause fix — latency probes cannot see
+   "handshake fast, transfer throttled".
+2. **Latency-ordered candidates** (mirror::adaptive): probe each candidate
+   host's TCP connect latency once per process (1.5 s cap, cached),
+   order candidates by measured latency, and demote hosts that stalled
+   earlier in the session. Guarded by a sha256 integrity gate.
+
+## 1. Current state (what exists, what's missing)
+
+The mirror machinery has three tiers today:
+
+| Tier | Mechanism | Quality |
+| --- | --- | --- |
+| index repos / `.git` sources | `mirror::expand(type=Git)` + CN swaps the index URL to the official gitee mirror (`config.cppm`) | official mirror, deterministic |
+| `XLINGS_RES` assets | resource-server map (GLOBAL→github / CN→gitcode) + **latency-probed selection** (`config.cppm selected_resource_server_for_`, `tinyhttps::probe_latency`) | official mirror, adaptive |
+| plain GitHub asset URLs | `mirror::expand()` in `downloader.cppm` appends third-party proxies (ghfast / ghproxy / kkgithub) **after** the original URL | proxy-grade, **static order** |
+
+Gaps for tier 3:
+
+- **Order is static**: original URL is always tried first (`Mode::Auto`),
+  regardless of how the local network reaches github.com.
+- **No stall detection**: `DownloadOptions` has `connectTimeoutSec=30`
+  (handshake only) and `maxTimeSec=600` (total). A connection that
+  *establishes* but transfers at KB/s-level — the typical degraded-network
+  shape for github.com — triggers neither. Worst case before the first
+  mirror attempt: 600 s × (1 + retryCount).
+- The latency probing that already powers `XLINGS_RES` server selection
+  and `xlings self install`'s GLOBAL/CN auto-pick is **not applied** to
+  tier-3 candidates.
+
+## 2. Design
+
+### 2.1 Stall watchdog (tinyhttps)
+
+New fields on `DownloadOptions` (defaults ON; `0` disables):
+
+```cpp
+int lowSpeedLimitBytes { 10 * 1024 }; // windowed average floor
+int lowSpeedTimeSec    { 15 };        // window length
+```
+
+Semantics (curl `--speed-limit/--speed-time` style, windowed):
+
+- Track `(windowStartTime, windowStartBytes)`. Once a window of
+  `lowSpeedTimeSec` has elapsed, compute the windowed average; if it is
+  below `lowSpeedLimitBytes`, abort the attempt with a `stalled: ...`
+  error; otherwise slide the window forward.
+- Implemented as a small pure class `StallDetector` (unit-testable) fed
+  from the progress callback; the abort is delivered by wrapping the
+  existing `isCancelled` hook — no changes to the underlying
+  `mcpplibs.tinyhttps` client.
+- Total-silence connections never fire the progress callback, so the
+  per-read socket timeout is lowered from `maxTimeSec` to
+  `max(30, 2 × lowSpeedTimeSec)` when the watchdog is enabled — a server
+  that sends nothing for that long is treated as failed and the next
+  candidate is tried.
+- A stalled attempt is an *attempt failure*, not a cancellation: the
+  driver loop proceeds to the next retry/candidate as for any error.
+
+Escape hatch: `XLINGS_DOWNLOAD_LOW_SPEED=off` (or `0`) disables the
+watchdog process-wide; `XLINGS_DOWNLOAD_LOW_SPEED=<bytes>:<secs>` tunes
+it. Users on genuinely-slow-but-working links (< 10 KB/s sustained) are
+the only regression surface, and they get a copy-pasteable knob in the
+error message.
+
+### 2.2 Latency-ordered candidates (`mirror::adaptive`)
+
+New partition `src/core/mirror/adaptive.cppm`:
+
+```cpp
+// per-host latency, probed once per process (TCP connect, 1.5 s cap)
+double host_latency(const std::string& url, const ProbeFn& probe = {});
+
+// session-scoped demotion: a stalled host is as bad as an unreachable one
+void penalize_host(const std::string& url);
+
+// order candidates for download. has_sha256 gates how aggressive we get.
+std::vector<std::string> reorder(std::vector<std::string> urls, bool has_sha256,
+                                 const ProbeFn& probe = {});
+```
+
+Rules:
+
+- `urls.size() < 2` → returned unchanged (nothing to decide; also keeps
+  `Mode::Off` behavior intact since `expand()` returns one URL there).
+- Probe the **unique hosts** of the candidates concurrently-cheap
+  (sequential 1.5 s-capped TCP connects; results memoized per process in
+  a mutex-guarded map, so one `xlings install` with 40 packages probes
+  each host exactly once).
+- **sha256 integrity gate**:
+  - `has_sha256 == true`: full stable sort ascending by latency. Mirrors
+    may be tried before the original URL — the declared sha256 pins the
+    exact bytes, so a malicious/corrupt proxy cannot inject content.
+  - `has_sha256 == false`: the original (author-declared) URL keeps first
+    position **unless its host is unreachable/penalized** (latency = ∞);
+    only the relative order of the remaining candidates is
+    latency-sorted. Third-party proxies must not silently become the
+    authoritative source for unpinned content.
+- `penalize_host()` writes ∞ into the same cache. The downloader calls it
+  when an attempt for that URL died with a `stalled:` error, so the next
+  package in the same session skips straight past the degraded host —
+  this folds the "session network profile" idea into the latency cache
+  with no extra state.
+- Escape hatch: `XLINGS_ADAPTIVE_MIRROR=off` returns candidates unchanged
+  (CI determinism / debugging).
+
+### 2.3 Downloader integration
+
+In `downloader.cppm` the HTTP path already builds
+`[primary, fallbackUrls..., expand() mirrors...]`. Two added lines of
+behavior:
+
+- pass the list through `mirror::adaptive::reorder(urls, !task.sha256.empty())`
+  before handing it to `tinyhttps::download_file`;
+- supply tinyhttps's new per-URL failure hook
+  (`onUrlAttemptFailed(url, error)`) and call `penalize_host(url)` when
+  the error is a stall.
+
+This also benefits `XLINGS_RES` tasks: their github/gitcode fallback pair
+now gets latency-ordered with the same machinery that
+`selected_resource_server_for_` uses, instead of a fixed order.
+
+### 2.4 Explicitly out of scope (follow-ups)
+
+- **Racing / happy-eyeballs** (start best mirror in parallel after N
+  silent seconds): best UX, heaviest implementation; revisit if the
+  watchdog+reorder combination proves insufficient.
+- **Hot-updating the proxy registry** via the index repo (the compiled-in
+  list rots — kkgithub is already dead); separate change.
+- **Official mirror form for arbitrary release URLs** (rewrite
+  `github.com/<o>/<r>/releases/download/...` to a gitcode twin when one
+  exists); needs a mirrored-repo existence signal.
+- Index lint: warn on non-GitHub, non-`XLINGS_RES` direct URLs (the
+  lua.org outage class).
+
+## 3. Implementation map (as landed in 0.4.49)
+
+| Change | Where |
+| --- | --- |
+| `StallDetector` (pure, windowed-average) + `lowSpeedLimitBytes/lowSpeedTimeSec` + reduced per-read timeout + `onUrlAttemptFailed` hook + `XLINGS_DOWNLOAD_LOW_SPEED` | `src/libs/tinyhttps.cppm` |
+| `mirror::adaptive` — cached `host_latency`, `penalize_host`, sha256-gated `reorder`, `XLINGS_ADAPTIVE_MIRROR` | `src/core/mirror/adaptive.cppm` (+ export in `src/core/mirror.cppm`) |
+| reorder + stall-penalty wiring in the HTTP download path | `src/core/xim/downloader.cppm` |
+| Unit tests: detector windows (ok/stall/slide/disable), reorder gates (sha-full-sort, no-sha original-first, dead-host demotion, probe memoization, penalty, env off) | `tests/unit/test_adaptive_mirror.cpp` |
+| Version bump 0.4.49 | `src/core/config.cppm`, `mcpp.toml` |
+
+## 4. Risk notes
+
+- **Sustained-slow-but-legit links** (< 10 KB/s for 15 s+): the watchdog
+  will rotate through mirrors and ultimately fail if every source is that
+  slow. The stall error message names the env knob. Judged acceptable:
+  such links cannot realistically install multi-MB packages anyway.
+- **Probe cost**: ≤ 1.5 s × unique hosts, once per process, only on
+  multi-candidate downloads. Single-URL downloads pay nothing.
+- **Mirror-first with sha256**: bytes are pinned by checksum; worst case
+  a poisoned proxy causes a checksum mismatch → next candidate.
+- **No e2e for the stall path** (needs a throttled HTTP server): covered
+  by unit tests on the pure detector + reorder logic; the existing
+  download e2e suite guards against regressions in the happy path.

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "0.4.48"
+version = "0.4.49"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.48";
+    static constexpr std::string_view VERSION = "0.4.49";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/mirror.cppm
+++ b/src/core/mirror.cppm
@@ -13,11 +13,14 @@
 //   mirror/forms.cppm     — three URL-rewriting strategies (internal)
 //   mirror/registry.cppm  — embedded default list + user-override loader
 //   mirror/expand.cppm    — classify() + expand() public API
+//   mirror/adaptive.cppm  — latency-ordered candidate selection (0.4.49)
 //
-// See docs/plans/2026-05-01-mirror-fallback-step1.md for the full design.
+// See docs/plans/2026-05-01-mirror-fallback-step1.md and
+// .agents/docs/2026-06-04-github-asset-adaptive-mirror.md for the design.
 
 export module xlings.core.mirror;
 
 export import xlings.core.mirror.types;
 export import xlings.core.mirror.expand;
+export import xlings.core.mirror.adaptive;
 // registry and forms are implementation details, not re-exported.

--- a/src/core/mirror/adaptive.cppm
+++ b/src/core/mirror/adaptive.cppm
@@ -1,0 +1,160 @@
+// xlings.core.mirror.adaptive — latency-ordered candidate selection for
+// multi-URL downloads (0.4.49).
+//
+// Design: .agents/docs/2026-06-04-github-asset-adaptive-mirror.md
+//
+// Problem: with no explicit mirror config, plain GitHub asset URLs are
+// always tried original-first; on a degraded network ("connects, then
+// trickles") the user waits out the full timeout budget before any mirror
+// is attempted. This partition probes each candidate host's TCP connect
+// latency once per process (memoized) and orders candidates accordingly,
+// gated by a sha256 integrity rule: third-party mirrors may only be tried
+// BEFORE the author-declared URL when the payload's bytes are pinned by a
+// declared sha256.
+//
+// The same cache doubles as the session network profile: a host whose
+// transfer stalled (watchdog abort in tinyhttps) is penalized to ∞ so the
+// next download in this process skips straight past it.
+
+module;
+
+#include <cstdlib>
+
+export module xlings.core.mirror.adaptive;
+
+import std;
+
+import xlings.core.log;
+import xlings.libs.tinyhttps;
+
+namespace xlings::mirror::adaptive {
+
+namespace {
+
+constexpr int kProbeTimeoutMs = 1500;
+
+// "https://github.com/x/y/releases/..." → "https://github.com"
+std::string host_root_(std::string_view url) {
+    auto scheme_end = url.find("://");
+    if (scheme_end == std::string_view::npos) return {};
+    auto host_start = scheme_end + 3;
+    auto path_start = url.find('/', host_start);
+    return std::string(path_start == std::string_view::npos
+        ? url : url.substr(0, path_start));
+}
+
+struct Cache {
+    std::mutex mtx;
+    std::unordered_map<std::string, double> latency;  // host root → seconds (∞ = bad)
+};
+
+Cache& cache_() {
+    static Cache c;
+    return c;
+}
+
+bool adaptive_disabled_() {
+    const char* env = std::getenv("XLINGS_ADAPTIVE_MIRROR");
+    if (!env || !*env) return false;
+    std::string v = env;
+    return v == "off" || v == "0";
+}
+
+} // anonymous namespace
+
+// Injectable prober for tests. Empty = real TCP connect probe.
+export using ProbeFn = std::function<double(const std::string& hostRootUrl)>;
+
+// Connect latency for the host of `url`, probed once per process and
+// memoized. Unknown/unparseable URLs return 0 (neutral — keeps declared
+// order under stable sort).
+export double host_latency(const std::string& url, const ProbeFn& probe = {}) {
+    auto host = host_root_(url);
+    if (host.empty()) return 0.0;
+
+    auto& c = cache_();
+    {
+        std::scoped_lock lock(c.mtx);
+        if (auto it = c.latency.find(host); it != c.latency.end())
+            return it->second;
+    }
+    double lat = probe
+        ? probe(host)
+        : tinyhttps::probe_latency(host, kProbeTimeoutMs);
+    {
+        std::scoped_lock lock(c.mtx);
+        c.latency.emplace(host, lat);
+    }
+    log::debug("[mirror:adaptive] {} latency {:.0f} ms", host,
+               std::isinf(lat) ? -1.0 : lat * 1000.0);
+    return lat;
+}
+
+// Session-scoped demotion: a host whose transfer stalled is as bad as an
+// unreachable one for the rest of this process.
+export void penalize_host(const std::string& url) {
+    auto host = host_root_(url);
+    if (host.empty()) return;
+    auto& c = cache_();
+    std::scoped_lock lock(c.mtx);
+    c.latency[host] = std::numeric_limits<double>::infinity();
+    log::debug("[mirror:adaptive] penalized {}", host);
+}
+
+// Test hook: drop all cached latencies.
+export void reset_for_tests() {
+    auto& c = cache_();
+    std::scoped_lock lock(c.mtx);
+    c.latency.clear();
+}
+
+// Order download candidates by measured host latency.
+//
+//   has_sha256 == true   full stable sort ascending by latency — mirrors
+//                        may be tried before the original URL; the
+//                        declared sha256 pins the exact bytes.
+//   has_sha256 == false  the author-declared first URL keeps its position
+//                        unless its host is unreachable/penalized (∞);
+//                        only the remaining candidates are latency-sorted.
+//
+// Single-candidate lists and XLINGS_ADAPTIVE_MIRROR=off return unchanged.
+export std::vector<std::string> reorder(std::vector<std::string> urls,
+                                        bool has_sha256,
+                                        const ProbeFn& probe = {}) {
+    if (urls.size() < 2 || adaptive_disabled_()) return urls;
+
+    struct Entry {
+        std::string url;
+        double      lat;
+        std::size_t idx;   // declared position, for stable ties
+    };
+    std::vector<Entry> entries;
+    entries.reserve(urls.size());
+    for (std::size_t i = 0; i < urls.size(); ++i) {
+        double lat = host_latency(urls[i], probe);
+        entries.push_back({std::move(urls[i]), lat, i});
+    }
+
+    auto by_latency = [](const Entry& a, const Entry& b) {
+        if (a.lat != b.lat) return a.lat < b.lat;
+        return a.idx < b.idx;   // stable: keep declared order on ties
+    };
+
+    bool primary_pinned = !has_sha256
+        && !std::isinf(entries.front().lat);
+
+    if (primary_pinned) {
+        // Unpinned content: the author-declared URL stays authoritative;
+        // only the fallbacks compete on latency.
+        std::sort(entries.begin() + 1, entries.end(), by_latency);
+    } else {
+        std::sort(entries.begin(), entries.end(), by_latency);
+    }
+
+    std::vector<std::string> out;
+    out.reserve(entries.size());
+    for (auto& e : entries) out.push_back(std::move(e.url));
+    return out;
+}
+
+} // namespace xlings::mirror::adaptive

--- a/src/core/xim/downloader.cppm
+++ b/src/core/xim/downloader.cppm
@@ -353,6 +353,14 @@ DownloadResult download_one(const DownloadTask& task,
             urls.push_back(std::move(u));
     }
 
+    // Adaptive ordering (0.4.49): probe candidate hosts' connect latency
+    // (memoized per process) and order accordingly. With a declared sha256
+    // the bytes are pinned, so faster mirrors may be tried before the
+    // original URL; without one the author-declared URL stays first unless
+    // its host is unreachable/penalized. See
+    // .agents/docs/2026-06-04-github-asset-adaptive-mirror.md.
+    urls = mirror::adaptive::reorder(std::move(urls), !task.sha256.empty());
+
     // Use in-process tinyhttps for all downloads (streaming progress).
     // When a CancellationToken is available, wire isCancelled so ESC aborts.
     {
@@ -366,6 +374,11 @@ DownloadResult download_one(const DownloadTask& task,
         if (cancel) {
             opts.isCancelled = [cancel] { return cancel->is_paused() || cancel->is_cancelled(); };
         }
+        // A stalled host is throttled for us right now — demote it for the
+        // rest of the session so later downloads skip straight past it.
+        opts.onUrlAttemptFailed = [](const std::string& u, const std::string& err) {
+            if (err.rfind("stalled:", 0) == 0) mirror::adaptive::penalize_host(u);
+        };
 
         auto dlResult = tinyhttps::download_file(opts);
         if (!dlResult.success) {

--- a/src/libs/tinyhttps.cppm
+++ b/src/libs/tinyhttps.cppm
@@ -14,8 +14,64 @@ struct DownloadOptions {
     int retryCount        { 3 };
     int connectTimeoutSec { 30 };
     int maxTimeSec        { 600 };
+    // Stall watchdog (0.4.49; see
+    // .agents/docs/2026-06-04-github-asset-adaptive-mirror.md):
+    // abort an attempt whose windowed average speed stays below
+    // lowSpeedLimitBytes for lowSpeedTimeSec, and move to the next
+    // candidate URL. 0 in either field disables. Env override:
+    // XLINGS_DOWNLOAD_LOW_SPEED=off | <bytes>:<secs>.
+    int lowSpeedLimitBytes { 10 * 1024 };
+    int lowSpeedTimeSec    { 15 };
     std::function<void(double total, double now)> onProgress;
     std::function<bool()> isCancelled;      // returns true to abort download
+    // Per-URL attempt failure hook: called once per failed attempt with the
+    // attempted URL and its error string ("stalled: ..." for watchdog
+    // aborts). Used by the downloader to penalize degraded hosts.
+    std::function<void(const std::string& url, const std::string& error)>
+        onUrlAttemptFailed;
+};
+
+// Windowed-average stall detector (curl --speed-limit/--speed-time style).
+// Pure logic, fed cumulative (elapsedSec, downloadedBytes) samples from the
+// progress callback. Exported for unit tests.
+class StallDetector {
+public:
+    StallDetector(int limitBytes, int windowSec)
+        : limit_(limitBytes), window_(windowSec) {}
+
+    bool enabled() const { return limit_ > 0 && window_ > 0; }
+
+    // Feed one sample. Returns true when the windowed average speed over a
+    // full window fell below the limit (= stalled).
+    bool update(double elapsedSec, double downloadedBytes) {
+        if (!enabled()) return false;
+        if (!started_) {
+            started_ = true;
+            winT_ = elapsedSec;
+            winB_ = downloadedBytes;
+            return false;
+        }
+        if (downloadedBytes < winB_) {
+            // Counter went backwards (redirect restart) — restart the window.
+            winT_ = elapsedSec;
+            winB_ = downloadedBytes;
+            return false;
+        }
+        if (elapsedSec - winT_ < static_cast<double>(window_)) return false;
+        double avg = (downloadedBytes - winB_) / (elapsedSec - winT_);
+        if (avg < static_cast<double>(limit_)) return true;
+        // Healthy window — slide forward.
+        winT_ = elapsedSec;
+        winB_ = downloadedBytes;
+        return false;
+    }
+
+private:
+    int    limit_;
+    int    window_;
+    bool   started_ { false };
+    double winT_ { 0 };
+    double winB_ { 0 };
 };
 
 struct DownloadFileResult {
@@ -141,32 +197,89 @@ auto make_client(int connectTimeoutSec, int readTimeoutSec, std::string_view url
     return mcpplibs::tinyhttps::HttpClient(std::move(cfg));
 }
 
+// Resolve the effective stall-watchdog parameters: env override > options.
+//   XLINGS_DOWNLOAD_LOW_SPEED=off|0      → disabled
+//   XLINGS_DOWNLOAD_LOW_SPEED=<b>:<s>    → custom limit bytes / window secs
+std::pair<int, int> effective_low_speed_(int limitBytes, int windowSec) {
+    const char* env = std::getenv("XLINGS_DOWNLOAD_LOW_SPEED");
+    if (!env || !*env) return {limitBytes, windowSec};
+    std::string v = env;
+    if (v == "off" || v == "0") return {0, 0};
+    auto colon = v.find(':');
+    if (colon != std::string::npos) {
+        try {
+            int b = std::stoi(v.substr(0, colon));
+            int s = std::stoi(v.substr(colon + 1));
+            if (b >= 0 && s >= 0) return {b, s};
+        } catch (...) {}
+    }
+    return {limitBytes, windowSec};
+}
+
 // Single download attempt: stream GET url → dest file with progress + cancel
+// + optional stall watchdog.
 DownloadFileResult download_once(
     const std::string& url,
     const std::filesystem::path& dest,
     int connectSec,
     int maxSec,
+    int lowSpeedLimitBytes,
+    int lowSpeedTimeSec,
     std::function<void(double, double)> onProgress,
     std::function<bool()> isCancelled = nullptr
 ) {
-    auto client = make_client(connectSec, maxSec, url);
+    StallDetector detector(lowSpeedLimitBytes, lowSpeedTimeSec);
+
+    // With the watchdog enabled, lower the per-read socket timeout so a
+    // connection that sends NOTHING (progress never fires) also fails
+    // quickly instead of sitting on the full maxTime budget.
+    int readSec = maxSec;
+    if (detector.enabled()) {
+        readSec = std::min(maxSec, std::max(30, 2 * lowSpeedTimeSec));
+    }
+    auto client = make_client(connectSec, readSec, url);
+
+    bool stalled = false;
+    auto t0 = std::chrono::steady_clock::now();
 
     mcpplibs::tinyhttps::DownloadProgressFn progress;
-    if (onProgress) {
+    if (onProgress || detector.enabled()) {
         progress = [&](std::int64_t total, std::int64_t downloaded) {
-            onProgress(static_cast<double>(total), static_cast<double>(downloaded));
+            if (onProgress) {
+                onProgress(static_cast<double>(total),
+                           static_cast<double>(downloaded));
+            }
+            if (!stalled && detector.enabled()) {
+                auto elapsed = std::chrono::duration<double>(
+                    std::chrono::steady_clock::now() - t0).count();
+                if (detector.update(elapsed, static_cast<double>(downloaded))) {
+                    stalled = true;
+                }
+            }
         };
     }
 
-    auto result = client.download_to_file(url, dest, progress, isCancelled);
-
-    if (!result.ok()) {
-        return {false, result.error.empty()
-            ? "HTTP " + std::to_string(result.statusCode) : result.error};
+    std::function<bool()> cancel;
+    if (isCancelled || detector.enabled()) {
+        cancel = [&]() -> bool {
+            if (stalled) return true;
+            return isCancelled && isCancelled();
+        };
     }
 
-    return {true, {}};
+    auto result = client.download_to_file(url, dest, progress, cancel);
+
+    if (result.ok() && !stalled) {
+        return {true, {}};
+    }
+    if (stalled) {
+        return {false, std::format(
+            "stalled: average speed below {} B/s over {} s "
+            "(set XLINGS_DOWNLOAD_LOW_SPEED=off to disable the watchdog)",
+            lowSpeedLimitBytes, lowSpeedTimeSec)};
+    }
+    return {false, result.error.empty()
+        ? "HTTP " + std::to_string(result.statusCode) : result.error};
 }
 
 } // namespace detail_
@@ -190,6 +303,9 @@ DownloadFileResult download_file(const DownloadOptions& opts) {
     std::error_code ec;
     std::filesystem::create_directories(opts.destFile.parent_path(), ec);
 
+    auto [lowSpeedBytes, lowSpeedSecs] = detail_::effective_low_speed_(
+        opts.lowSpeedLimitBytes, opts.lowSpeedTimeSec);
+
     std::string lastErr;
     for (auto& url : opts.urls) {
         if (opts.isCancelled && opts.isCancelled()) return {false, "cancelled"};
@@ -197,10 +313,16 @@ DownloadFileResult download_file(const DownloadOptions& opts) {
             if (opts.isCancelled && opts.isCancelled()) return {false, "cancelled"};
             auto r = detail_::download_once(url, opts.destFile,
                 opts.connectTimeoutSec, opts.maxTimeSec,
+                lowSpeedBytes, lowSpeedSecs,
                 opts.onProgress, opts.isCancelled);
             if (r.success) return r;
             lastErr = r.error;
+            if (opts.onUrlAttemptFailed) opts.onUrlAttemptFailed(url, r.error);
             std::filesystem::remove(opts.destFile, ec);
+            // A stalled attempt means this host is throttled for us right
+            // now — retrying the same URL would burn another full window.
+            // Move straight to the next candidate.
+            if (r.error.rfind("stalled:", 0) == 0) break;
             if (att < opts.retryCount) {
                 std::this_thread::sleep_for(
                     std::chrono::milliseconds(500 * (att + 1)));

--- a/tests/unit/test_adaptive_mirror.cpp
+++ b/tests/unit/test_adaptive_mirror.cpp
@@ -1,0 +1,187 @@
+// Unit tests for the adaptive GitHub-asset mirroring (0.4.49):
+//   - tinyhttps::StallDetector (windowed-average stall watchdog)
+//   - mirror::adaptive::reorder / host_latency / penalize_host
+// Design: .agents/docs/2026-06-04-github-asset-adaptive-mirror.md
+#include <gtest/gtest.h>
+
+import std;
+import xlings.libs.tinyhttps;
+import xlings.core.mirror.adaptive;
+import xlings.platform;
+
+using xlings::tinyhttps::StallDetector;
+namespace adaptive = xlings::mirror::adaptive;
+
+// ── StallDetector ────────────────────────────────────────────────────
+
+TEST(StallDetector, DisabledNeverStalls) {
+    StallDetector d(0, 0);
+    EXPECT_FALSE(d.enabled());
+    EXPECT_FALSE(d.update(0, 0));
+    EXPECT_FALSE(d.update(100, 0));
+}
+
+TEST(StallDetector, HealthySpeedSlidesWindow) {
+    StallDetector d(10 * 1024, 15);
+    EXPECT_FALSE(d.update(0, 0));
+    // 1 MB in 16 s ≈ 64 KB/s — healthy, window slides.
+    EXPECT_FALSE(d.update(16, 1024.0 * 1024));
+    // Another healthy window.
+    EXPECT_FALSE(d.update(32, 2 * 1024.0 * 1024));
+}
+
+TEST(StallDetector, TrickleStallsAfterOneWindow) {
+    StallDetector d(10 * 1024, 15);
+    EXPECT_FALSE(d.update(0, 0));
+    // Inside the window: no verdict yet.
+    EXPECT_FALSE(d.update(10, 5 * 1024));
+    // Window elapsed: 16 KB over 16 s = 1 KB/s < 10 KB/s → stalled.
+    EXPECT_TRUE(d.update(16, 16 * 1024));
+}
+
+TEST(StallDetector, ZeroBytesStalls) {
+    StallDetector d(10 * 1024, 15);
+    EXPECT_FALSE(d.update(0, 0));
+    EXPECT_TRUE(d.update(15.5, 0));
+}
+
+TEST(StallDetector, FastThenThrottledStalls) {
+    StallDetector d(10 * 1024, 15);
+    EXPECT_FALSE(d.update(0, 0));
+    EXPECT_FALSE(d.update(15, 10 * 1024.0 * 1024));  // 10 MB fast start
+    // Then the link gets throttled: +30 KB over the next 16 s.
+    EXPECT_TRUE(d.update(31, 10 * 1024.0 * 1024 + 30 * 1024));
+}
+
+TEST(StallDetector, CounterResetRestartsWindow) {
+    StallDetector d(10 * 1024, 15);
+    EXPECT_FALSE(d.update(0, 0));
+    EXPECT_FALSE(d.update(10, 5 * 1024.0 * 1024));
+    // Redirect restarted the transfer — counter went backwards.
+    EXPECT_FALSE(d.update(12, 0));
+    // New window measured from the reset point: healthy again.
+    EXPECT_FALSE(d.update(28, 2 * 1024.0 * 1024));
+}
+
+// ── mirror::adaptive ─────────────────────────────────────────────────
+
+namespace {
+
+struct ProbeRecorder {
+    std::map<std::string, double> table;     // host root → latency
+    mutable std::map<std::string, int> hits; // host root → probe count
+    adaptive::ProbeFn fn() const {
+        return [this](const std::string& host) {
+            ++hits[host];
+            auto it = table.find(host);
+            return it == table.end()
+                ? std::numeric_limits<double>::infinity() : it->second;
+        };
+    }
+};
+
+struct EnvGuard {
+    std::string key, old;
+    EnvGuard(const std::string& k, const std::string& v) : key(k) {
+        if (const char* o = std::getenv(k.c_str())) old = o;
+        xlings::platform::set_env_variable(k, v);
+    }
+    ~EnvGuard() { xlings::platform::set_env_variable(key, old); }
+};
+
+const std::string kGithub = "https://github.com/o/r/releases/download/v1/a.tar.gz";
+const std::string kFast   = "https://ghfast.top/https://github.com/o/r/releases/download/v1/a.tar.gz";
+const std::string kProxy  = "https://ghproxy.net/https://github.com/o/r/releases/download/v1/a.tar.gz";
+
+} // namespace
+
+TEST(AdaptiveReorder, Sha256FullSortByLatency) {
+    adaptive::reset_for_tests();
+    ProbeRecorder p;
+    p.table = {{"https://github.com", 1.2},
+               {"https://ghfast.top", 0.05},
+               {"https://ghproxy.net", 0.3}};
+    auto out = adaptive::reorder({kGithub, kFast, kProxy},
+                                 /*has_sha256=*/true, p.fn());
+    ASSERT_EQ(out.size(), 3u);
+    EXPECT_EQ(out[0], kFast);
+    EXPECT_EQ(out[1], kProxy);
+    EXPECT_EQ(out[2], kGithub);
+}
+
+TEST(AdaptiveReorder, NoSha256KeepsReachablePrimaryFirst) {
+    adaptive::reset_for_tests();
+    ProbeRecorder p;
+    p.table = {{"https://github.com", 1.2},
+               {"https://ghfast.top", 0.05},
+               {"https://ghproxy.net", 0.3}};
+    auto out = adaptive::reorder({kGithub, kProxy, kFast},
+                                 /*has_sha256=*/false, p.fn());
+    ASSERT_EQ(out.size(), 3u);
+    EXPECT_EQ(out[0], kGithub);   // unpinned content: author URL stays first
+    EXPECT_EQ(out[1], kFast);     // fallbacks latency-sorted
+    EXPECT_EQ(out[2], kProxy);
+}
+
+TEST(AdaptiveReorder, NoSha256DeadPrimaryIsDemoted) {
+    adaptive::reset_for_tests();
+    ProbeRecorder p;
+    p.table = {{"https://ghfast.top", 0.05},
+               {"https://ghproxy.net", 0.3}};   // github absent → ∞
+    auto out = adaptive::reorder({kGithub, kProxy, kFast},
+                                 /*has_sha256=*/false, p.fn());
+    ASSERT_EQ(out.size(), 3u);
+    EXPECT_EQ(out[0], kFast);
+    EXPECT_EQ(out[1], kProxy);
+    EXPECT_EQ(out[2], kGithub);
+}
+
+TEST(AdaptiveReorder, ProbeMemoizedPerHost) {
+    adaptive::reset_for_tests();
+    ProbeRecorder p;
+    p.table = {{"https://github.com", 0.1},
+               {"https://ghfast.top", 0.2},
+               {"https://ghproxy.net", 0.3}};
+    (void)adaptive::reorder({kGithub, kFast, kProxy}, true, p.fn());
+    (void)adaptive::reorder({kGithub, kFast, kProxy}, true, p.fn());
+    EXPECT_EQ(p.hits["https://github.com"], 1);
+    EXPECT_EQ(p.hits["https://ghfast.top"], 1);
+    EXPECT_EQ(p.hits["https://ghproxy.net"], 1);
+}
+
+TEST(AdaptiveReorder, PenalizedHostGoesLast) {
+    adaptive::reset_for_tests();
+    ProbeRecorder p;
+    p.table = {{"https://github.com", 0.1},
+               {"https://ghfast.top", 0.2}};
+    adaptive::penalize_host(kGithub);   // stalled earlier this session
+    auto out = adaptive::reorder({kGithub, kFast},
+                                 /*has_sha256=*/true, p.fn());
+    ASSERT_EQ(out.size(), 2u);
+    EXPECT_EQ(out[0], kFast);
+    EXPECT_EQ(out[1], kGithub);
+    // The penalty must not have been overwritten by a fresh probe.
+    EXPECT_EQ(p.hits["https://github.com"], 0);
+}
+
+TEST(AdaptiveReorder, SingleCandidateUnchangedAndUnprobed) {
+    adaptive::reset_for_tests();
+    ProbeRecorder p;
+    auto out = adaptive::reorder({kGithub}, true, p.fn());
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_EQ(out[0], kGithub);
+    EXPECT_TRUE(p.hits.empty());
+}
+
+TEST(AdaptiveReorder, EnvOffDisablesReordering) {
+    adaptive::reset_for_tests();
+    ProbeRecorder p;
+    p.table = {{"https://github.com", 9.0},
+               {"https://ghfast.top", 0.01}};
+    EnvGuard g("XLINGS_ADAPTIVE_MIRROR", "off");
+    auto out = adaptive::reorder({kGithub, kFast}, true, p.fn());
+    ASSERT_EQ(out.size(), 2u);
+    EXPECT_EQ(out[0], kGithub);
+    EXPECT_EQ(out[1], kFast);
+    EXPECT_TRUE(p.hits.empty());
+}


### PR DESCRIPTION
## Problem

A package that only carries a plain GitHub URL, on a machine with **no explicit mirror config**, can hang for minutes on degraded networks: the original URL is always tried first, and a connection that *establishes but trickles* (the typical degraded shape for github.com) triggers neither `connectTimeoutSec` (30s, handshake only) nor `maxTimeSec` (600s total) — so the first mirror attempt can be 600s × retries away. The latency probing that already powers `XLINGS_RES` server selection and `xlings self install`'s GLOBAL/CN auto-pick was not applied to plain asset URLs.

## Changes

**1. Stall watchdog (`src/libs/tinyhttps.cppm`)** — root-cause fix
- `DownloadOptions.lowSpeedLimitBytes/lowSpeedTimeSec` (default 10 KB/s over 15 s; `0` disables): windowed-average abort, curl `--speed-limit/--speed-time` style, implemented as a pure `StallDetector` fed from the progress callback and delivered via the existing cancel hook — no changes to the underlying client.
- Per-read socket timeout lowered to `max(30, 2×window)` when enabled, so fully-silent connections fail fast too.
- A stalled attempt skips same-URL retries and moves to the next candidate.
- New `onUrlAttemptFailed(url, error)` hook.
- Env escape hatch: `XLINGS_DOWNLOAD_LOW_SPEED=off | <bytes>:<secs>` (named in the error message).

**2. Latency-ordered candidates (`src/core/mirror/adaptive.cppm`)**
- `reorder(urls, has_sha256)`: probe each candidate host's TCP connect latency once per process (1.5 s cap, memoized), order candidates ascending.
- **sha256 integrity gate**: mirrors may be tried *before* the author-declared URL only when a sha256 pins the bytes; unpinned content keeps the author URL first unless its host is unreachable/penalized.
- `penalize_host()`: a host whose transfer stalled is demoted to ∞ for the session — the next download skips straight past it (folds the 'session network profile' idea into the latency cache).
- Env escape hatch: `XLINGS_ADAPTIVE_MIRROR=off`.

**3. Wiring (`src/core/xim/downloader.cppm`)** — candidates pass through `reorder()`; stall errors feed `penalize_host()`. `XLINGS_RES` github/gitcode fallback pairs benefit too.

## Tests

`tests/unit/test_adaptive_mirror.cpp` — 13 tests: detector (disabled / healthy slide / trickle / zero-bytes / fast-then-throttled / counter-reset) + reorder (sha full-sort / unpinned-primary-first / dead-primary demoted / probe memoization / penalty / single-candidate no-op / env off). All pass locally; pre-existing local-env `Extract.*` failures reproduce identically on clean main (unrelated).

## Design doc

`.agents/docs/2026-06-04-github-asset-adaptive-mirror.md` — includes current-state analysis (three mirror tiers), risk notes (sustained-slow-but-legit links → env knob; probe cost; mirror-first-with-sha256 safety), and explicit follow-ups (racing, hot-updating the rotting proxy registry — kkgithub is already dead, official mirror form for arbitrary release URLs, index lint for non-GitHub direct URLs).