### PR TITLE
ci(macos): salt mcpp sandbox cache (std.pcm deployment-target mismatch)

### DIFF
--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -52,9 +52,9 @@ jobs:
           path: |
             ~/.mcpp
             .mcpp
-          key: mcpp-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          key: mcpp-${{ runner.os }}-dt110-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
-            mcpp-${{ runner.os }}-
+            mcpp-${{ runner.os }}-dt110-
 
       - name: Prepare bootstrap package index
         run: |


### PR DESCRIPTION
macos CI on main is red since mcpp 0.0.49 became the index latest: the workflow pins `MACOSX_DEPLOYMENT_TARGET=11.0`, but the restored `~/.mcpp` BMI cache holds a `std.pcm` built for `arm64-apple-macosx15` under the same fingerprint — mcpp ≤ 0.0.49 doesn't include the deployment target in the BMI fingerprint, so the stale module is reused and every TU dies with:

```
error: AST file '...std.pcm' was compiled for the target 'arm64-apple-macosx15.0.0'
       but the current translation unit is being compiled for target 'arm64-apple-macosx11.0.0'
```

Salting the cache key (+ restore-keys) rebuilds a coherent all-11.0 store. Permanent fix ships in mcpp 0.0.50 (mcpp-community/mcpp#116: deployment target folded into the fingerprint + `[build] macos_deployment_target` manifest field), after which xlings switches to the manifest field with CI assertions.