### PR TITLE
feat(0.4.50): macOS releases run on 14.0+ (static libc++ via mcpp 0.0.50)

### DIFF
--- a/.agents/docs/2026-05-30-mcpp-build-xlings-plan.md
+++ b/.agents/docs/2026-05-30-mcpp-build-xlings-plan.md
@@ -1,0 +1,129 @@
+# xlings 使用 mcpp 构建实测记录
+
+> 日期: 2026-05-30 | 状态: Linux musl 静态二进制已跑通 | xlings 分支: `feat/mcpp-build-plan`
+
+## 结论
+
+已经在 xlings 仓库内新增 mcpp 构建入口，并用隔离的 `MCPP_HOME` /
+`XLINGS_HOME` 验证 mcpp 可以完整构建出可运行的 xlings Linux musl 静态
+二进制。
+
+本次验证通过的产物:
+
+```text
+target/x86_64-linux-musl/416f32eb2054cfae/bin/xlings
+```
+
+验证命令:
+
+```bash
+KEEP_MCPP_RUNTIME=1 \
+MCPP_BIN=/home/speak/workspace/github/mcpp-community/mcpp/target/x86_64-linux-gnu/afb76caa74c38c77/bin/mcpp \
+bash tests/e2e/mcpp_build_xlings_test.sh
+```
+
+结果:
+
+```text
+Finished release [optimized] in 34.83s
+[project-e2e] PASS: mcpp builds a runnable xlings binary
+```
+
+## xlings 侧改动
+
+新增:
+
+- `mcpp.toml`: xlings 的 mcpp manifest，默认工具链为 `gcc@16.1.0`，
+  `x86_64-linux-musl` 目标使用 `gcc@15.1.0-musl` 和 static linkage。
+- `mcpp/pkgs/*`: 仓库内本地 mcpp index，先承载 xlings 需要的 C 库包:
+  `zlib`、`bzip2`、`lz4`、`zstd`、`xz`、`libarchive`。
+- `mcpp/include/xlings_libarchive_config.h`: libarchive 的 xlings/musl
+  专用配置头，避免依赖外部 configure 生成物。
+- `tests/e2e/mcpp_build_xlings_test.sh`: 隔离验证脚本，运行时使用独立
+  `tests/e2e/runtime/mcpp_build_xlings/{mcpp-home,xlings-home}`。
+
+调整:
+
+- `.gitignore`: 忽略 `.mcpp/`、`compile_commands.json` 等本地生成物。
+- `src/platform/{linux,macos,unix,windows}.cppm`: 将 `import std` 等模块
+  import 移到平台 `#if` 外层，满足 mcpp 当前的 module scanner 约束。
+
+## 依赖构建策略
+
+`libarchive` 继续保持 in-process 解压能力，不退回系统 `xz` / `tar` 工具。
+本地 index 中的压缩库按源码包静态编译:
+
+- `zlib`: 编译库源码，启用 `Z_HAVE_UNISTD_H`。
+- `bzip2`: 编译库源码，排除 CLI。
+- `lz4`: 编译 `lib/*.c`。
+- `zstd`: 编译 common/compress/decompress/dictBuilder，启用
+  `ZSTD_DISABLE_ASM=1`，避免未编译 `.S` 时出现 HUF asm 符号缺失。
+- `xz`: 直接编译 `liblzma` 所需源码，并提供最小 config 宏。
+- `libarchive`: 直接列出需要的 `libarchive/*.c`，包含 rar5 所需
+  `archive_blake2s_ref.c` / `archive_blake2sp_ref.c`。
+
+## mcpp 侧发现的问题
+
+为了让 xlings 构建成立，mcpp 仓库需要配套修复。当前修复在:
+
+```text
+/home/speak/workspace/github/mcpp-community/mcpp
+branch: feat/xlings-build-support
+binary: target/x86_64-linux-gnu/afb76caa74c38c77/bin/mcpp
+```
+
+已验证的 mcpp 命令:
+
+```bash
+MCPP_HOME=/home/speak/.xlings/data/xpkgs/xim-x-mcpp/0.0.20 \
+/home/speak/.xlings/data/xpkgs/xim-x-mcpp/0.0.30/bin/mcpp \
+test -- --gtest_filter=Scanner.*:PmCompat.*:Toml.*
+
+MCPP_HOME=/home/speak/.xlings/data/xpkgs/xim-x-mcpp/0.0.20 \
+/home/speak/.xlings/data/xpkgs/xim-x-mcpp/0.0.30/bin/mcpp \
+build --print-fingerprint
+```
+
+这些修复属于构建工具层:
+
+- TOML parser 支持数组尾逗号。
+- 项目 `.mcpp/.xlings.json` 初始化时保留本地 path index，并按项目目录解析相对路径。
+- mcpp 通过 xlings project env 安装 custom/local index 包后，能从
+  `.mcpp/.xlings/data/xpkgs` 读取 `xpkg.lua` 和安装路径。
+- 兼容 nested namespace，例如 `mcpplibs.capi.lua` 与
+  `mcpplibs.capi:lua` 的安装目录和去重。
+- module scanner/plan/backend 增加 per-package local include dirs，并在
+  编译/扫描规则中把本包 include 放在全局 include 前面。这个修复解决了
+  `xz` 的 `"common.h"` 被错误解析到 `mbedtls/library/common.h` 的问题。
+
+在这些 mcpp 修复合入并发布前，不应把 xlings CI 或 release 默认构建路径
+切到已发布的 mcpp 包，否则 CI 会使用缺少上述修复的 mcpp 版本。
+
+## 验证边界
+
+已完成:
+
+- Linux `x86_64-linux-musl` mcpp build。
+- mcpp 构建产物为静态 ELF。
+- 产物在隔离 `XLINGS_HOME` 下执行 `-h`，输出包含 `USAGE` 和
+  `xlings [OPTIONS]`。
+
+暂不声明完成:
+
+- macOS / Windows mcpp 构建。
+- release 脚本默认切换到 mcpp driver。
+- 常规 CI job 默认启用 mcpp build。
+
+原因是当前 xlings 成功依赖 mcpp 分支修复。下一步应先合入并发布 mcpp，
+再在 xlings CI 中增加 non-blocking mcpp job，最后考虑
+`XLINGS_BUILD_DRIVER=mcpp` 接入 release 脚本。
+
+## 后续建议
+
+1. 在 mcpp 仓库提交并合入 `feat/xlings-build-support`。
+2. 发布包含上述修复的新 mcpp 版本。
+3. 在 xlings Linux CI 中增加 `continue-on-error: true` 的 mcpp build e2e:
+   `bash tests/e2e/mcpp_build_xlings_test.sh`。
+4. Linux mcpp job 稳定后，再扩展 macOS / Windows。
+5. 三平台稳定后，再让 `tools/*_release.*` 支持
+   `XLINGS_BUILD_DRIVER=mcpp`。

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b10b506e-a946-4adb-b396-4f6728d59e51","pid":126910,"procStart":"24502474","acquiredAt":1779437108469}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,12 @@ jobs:
           rm -rf "$GITHUB_WORKSPACE/.mcpp/registry/data/mcpplibs"
 
       - name: Build (macos_release)
+        env:
+          # macOS min-version support: floor 11.0 (first arm64 macOS).
+          # The mcpp from the bootstrap index (0.0.50+) links static LLVM
+          # libc++ via lld natively; macos_release.sh asserts minos +
+          # no system libc++ dylib when this env is set.
+          MACOSX_DEPLOYMENT_TARGET: '11.0'
         run: |
           chmod +x ./tools/macos_release.sh
           SKIP_NETWORK_VERIFY=1 ./tools/macos_release.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,11 +144,13 @@ jobs:
 
       - name: Build (macos_release)
         env:
-          # macOS min-version support: floor 11.0 (first arm64 macOS).
-          # The mcpp from the bootstrap index (0.0.50+) links static LLVM
-          # libc++ via lld natively; macos_release.sh asserts minos +
-          # no system libc++ dylib when this env is set.
-          MACOSX_DEPLOYMENT_TARGET: '11.0'
+          # macOS min-version support: floor 14.0 (the official LLVM
+          # static libc++ archives are built for macOS 14; lower needs a
+          # custom libc++ build). The mcpp from the bootstrap index
+          # (0.0.50+) links static LLVM libc++ via lld natively;
+          # macos_release.sh asserts minos + no system libc++ dylib when
+          # this env is set.
+          MACOSX_DEPLOYMENT_TARGET: '14.0'
         run: |
           chmod +x ./tools/macos_release.sh
           SKIP_NETWORK_VERIFY=1 ./tools/macos_release.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ env:
   XLINGS_RELEASE_MIRROR: GLOBAL
   # Pinned bootstrap xlings used to install mcpp. Bump together with
   # XIM_PKGINDEX_REF so release uses a known-good xlings + package index pair.
-  BOOTSTRAP_XLINGS_VERSION: v0.4.44
+  BOOTSTRAP_XLINGS_VERSION: v0.4.49
   # Includes mcpp 0.0.36 for all release builds.
-  XIM_PKGINDEX_REF: fba1ce953589df609c862d0a895fc9d6ff5eb6de
+  XIM_PKGINDEX_REF: 34e32a0fe234d0677b6200e824bad7dcd24dd78c
 
 jobs:
   build-linux:

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -13,9 +13,9 @@ env:
   XLINGS_RELEASE_MIRROR: GLOBAL
   # Pinned bootstrap xlings used to install mcpp. Bump together with
   # XIM_PKGINDEX_REF so CI uses a known-good xlings + package index pair.
-  BOOTSTRAP_XLINGS_VERSION: v0.4.44
+  BOOTSTRAP_XLINGS_VERSION: v0.4.49
   # Includes mcpp 0.0.36 for all CI/release mcpp builds.
-  XIM_PKGINDEX_REF: fba1ce953589df609c862d0a895fc9d6ff5eb6de
+  XIM_PKGINDEX_REF: 34e32a0fe234d0677b6200e824bad7dcd24dd78c
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -112,14 +112,12 @@ jobs:
             || { echo "FAIL: expected minos ${MACOSX_DEPLOYMENT_TARGET}"; exit 1; }
           echo "=== dylib deps ==="
           otool -L "$BIN"
-          # Static libc++ requires mcpp >= 0.0.50 as the build tool; warn
-          # (not fail) until the bootstrap index ships it, then flip to a
-          # hard assertion.
+          # mcpp 0.0.50 (static libc++ via -Wl,-load_hidden) is the index
+          # latest — hard assertion.
           if otool -L "$BIN" | grep -q "libc++"; then
-            echo "WARN: still linked against system libc++ (build tool < mcpp 0.0.50?)"
-          else
-            echo "OK: static libc++"
+            echo "FAIL: still linked against system libc++"; exit 1
           fi
+          echo "OK: static libc++
 
       - name: Prepare fixture index repo
         run: |

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GIT_TERMINAL_PROMPT: 0
-  MACOSX_DEPLOYMENT_TARGET: "11.0"
+  MACOSX_DEPLOYMENT_TARGET: "14.0"
   # CI runs on github.com; force GLOBAL mirror so xim doesn't try gitee
   # endpoints (which need auth and aren't reachable in CI).
   XLINGS_RELEASE_MIRROR: GLOBAL

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -102,6 +102,25 @@ jobs:
             exit "$status"
           }
 
+      - name: "Assert macOS min-version support (minos + static libc++)"
+        run: |
+          BIN=$(find target -type f -path '*/bin/xlings' | head -1)
+          test -n "$BIN" || { echo "xlings binary not found"; exit 1; }
+          echo "=== LC_BUILD_VERSION ==="
+          otool -l "$BIN" | grep -A4 LC_BUILD_VERSION | head -6
+          otool -l "$BIN" | grep -A4 LC_BUILD_VERSION | grep -q "minos ${MACOSX_DEPLOYMENT_TARGET}" \
+            || { echo "FAIL: expected minos ${MACOSX_DEPLOYMENT_TARGET}"; exit 1; }
+          echo "=== dylib deps ==="
+          otool -L "$BIN"
+          # Static libc++ requires mcpp >= 0.0.50 as the build tool; warn
+          # (not fail) until the bootstrap index ships it, then flip to a
+          # hard assertion.
+          if otool -L "$BIN" | grep -q "libc++"; then
+            echo "WARN: still linked against system libc++ (build tool < mcpp 0.0.50?)"
+          else
+            echo "OK: static libc++"
+          fi
+
       - name: Prepare fixture index repo
         run: |
           bash tests/e2e/prepare_fixture_index.sh

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -121,7 +121,7 @@ jobs:
           if otool -L "$BIN" | grep -q "libc++"; then
             echo "FAIL: still linked against system libc++"; exit 1
           fi
-          echo "OK: static libc++
+          echo "OK: static libc++"
 
       - name: Prepare fixture index repo
         run: |

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -14,9 +14,9 @@ env:
   XLINGS_RELEASE_MIRROR: GLOBAL
   # Pinned bootstrap xlings used to install mcpp. Bump together with
   # XIM_PKGINDEX_REF so CI uses a known-good xlings + package index pair.
-  BOOTSTRAP_XLINGS_VERSION: v0.4.44
+  BOOTSTRAP_XLINGS_VERSION: v0.4.49
   # Includes mcpp 0.0.36 for all CI/release mcpp builds.
-  XIM_PKGINDEX_REF: fba1ce953589df609c862d0a895fc9d6ff5eb6de
+  XIM_PKGINDEX_REF: 34e32a0fe234d0677b6200e824bad7dcd24dd78c
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -104,8 +104,12 @@ jobs:
 
       - name: "Assert macOS min-version support (minos + static libc++)"
         run: |
-          BIN=$(find target -type f -path '*/bin/xlings' | head -1)
+          # Multiple fingerprint dirs can exist (build + test fingerprints
+          # differ); pick the newest binary, same as the release stage-2 fix.
+          BIN=$(ls -t $(find target -type f -path '*/bin/xlings') 2>/dev/null | head -1)
           test -n "$BIN" || { echo "xlings binary not found"; exit 1; }
+          echo "all candidates:"; find target -type f -path '*/bin/xlings' | head -5
+          echo "selected: $BIN"
           echo "=== LC_BUILD_VERSION ==="
           otool -l "$BIN" | grep -A4 LC_BUILD_VERSION | head -6
           otool -l "$BIN" | grep -A4 LC_BUILD_VERSION | grep -q "minos ${MACOSX_DEPLOYMENT_TARGET}" \

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -13,9 +13,9 @@ env:
   XLINGS_RELEASE_MIRROR: GLOBAL
   # Pinned bootstrap xlings used to install mcpp. Bump together with
   # XIM_PKGINDEX_REF so CI uses a known-good xlings + package index pair.
-  BOOTSTRAP_XLINGS_VERSION: v0.4.44
+  BOOTSTRAP_XLINGS_VERSION: v0.4.49
   # Includes mcpp 0.0.36 for all CI/release mcpp builds.
-  XIM_PKGINDEX_REF: fba1ce953589df609c862d0a895fc9d6ff5eb6de
+  XIM_PKGINDEX_REF: 34e32a0fe234d0677b6200e824bad7dcd24dd78c
 
 jobs:
   build-and-test:

--- a/.xlings.json
+++ b/.xlings.json
@@ -3,6 +3,6 @@
   "projectScope": false,
   "mirror": "GLOBAL",
   "workspace": {
-    "mcpp": "0.0.36"
+    "mcpp": "0.0.50"
   }
 }

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -7,6 +7,10 @@ repo = "https://github.com/openxlings/xlings"
 
 [build]
 include_dirs = ["src/libs/json"]
+# Minimum supported macOS for produced binaries (mcpp 0.0.50+ honors
+# this; the MACOSX_DEPLOYMENT_TARGET env in CI/release remains as the
+# second line of assurance and covers older bootstrap mcpp versions).
+macos_deployment_target = "11.0"
 cxxflags = ["-DLIBARCHIVE_STATIC", "-DXLINGS_USE_GTEST_MAIN=1", "-DUNICODE", "-D_UNICODE"]
 
 [targets.xlings]

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "0.4.49"
+version = "0.4.50"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -10,7 +10,7 @@ include_dirs = ["src/libs/json"]
 # Minimum supported macOS for produced binaries (mcpp 0.0.50+ honors
 # this; the MACOSX_DEPLOYMENT_TARGET env in CI/release remains as the
 # second line of assurance and covers older bootstrap mcpp versions).
-macos_deployment_target = "11.0"
+macos_deployment_target = "14.0"
 cxxflags = ["-DLIBARCHIVE_STATIC", "-DXLINGS_USE_GTEST_MAIN=1", "-DUNICODE", "-D_UNICODE"]
 
 [targets.xlings]

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.49";
+    static constexpr std::string_view VERSION = "0.4.50";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -2918,6 +2918,22 @@ struct ExtractFixture {
     // All archive tools below are invoked with relative inputs from inside
     // tmp/, producing the output as a relative filename, then we resolve
     // back to the absolute path.
+    //
+    // host_sys_: run a HOST tool (tar/zip/python) via std::system with the
+    // build tool's injected runtime library path scrubbed. mcpp 0.0.47+
+    // exports the target toolchain's runtime dirs (sandbox glibc) into
+    // LD_LIBRARY_PATH for test processes; host tools crash when loaded
+    // against that glibc. Scope: POSIX only (the var is harmless on
+    // Windows, and `env` isn't available there).
+    static int host_sys_(const char* cmd) {
+#if defined(_WIN32)
+        return std::system(cmd);
+#else
+        std::string wrapped = std::string("env -u LD_LIBRARY_PATH ") + cmd;
+        return std::system(wrapped.c_str());
+#endif
+    }
+
     template <class F>
     static int run_in_(const std::filesystem::path& dir, F&& fn) {
         auto saved = std::filesystem::current_path();
@@ -2930,7 +2946,7 @@ struct ExtractFixture {
     std::filesystem::path make_tar_gz() const {
         auto out = tmp / "fixture.tar.gz";
         int rc = run_in_(tmp, [] {
-            return std::system("tar czf fixture.tar.gz src");
+            return host_sys_("tar czf fixture.tar.gz src");
         });
         if (rc != 0) throw std::runtime_error("failed to create tar.gz fixture");
         return out;
@@ -2939,7 +2955,7 @@ struct ExtractFixture {
     std::filesystem::path make_zip() const {
         auto out = tmp / "fixture.zip";
         int rc = run_in_(tmp, [] {
-            return std::system("zip -qr fixture.zip src");
+            return host_sys_("zip -qr fixture.zip src");
         });
         if (rc != 0) throw std::runtime_error("failed to create zip fixture");
         return out;
@@ -2959,9 +2975,9 @@ with zipfile.ZipFile("fixture_utf8.zip", "w", zipfile.ZIP_DEFLATED) as z:
         auto out = tmp / "fixture_utf8.zip";
         int rc = run_in_(tmp, [] {
 #ifdef _WIN32
-            return std::system("python make_utf8_zip.py");
+            return host_sys_("python make_utf8_zip.py");
 #else
-            return std::system("python3 make_utf8_zip.py || python make_utf8_zip.py");
+            return host_sys_("python3 make_utf8_zip.py || python make_utf8_zip.py");
 #endif
         });
         if (rc != 0) throw std::runtime_error("failed to create utf8 zip fixture");
@@ -2971,7 +2987,7 @@ with zipfile.ZipFile("fixture_utf8.zip", "w", zipfile.ZIP_DEFLATED) as z:
     std::filesystem::path make_tar_xz() const {
         auto out = tmp / "fixture.tar.xz";
         int rc = run_in_(tmp, [] {
-            return std::system("tar cJf fixture.tar.xz src");
+            return host_sys_("tar cJf fixture.tar.xz src");
         });
         if (rc != 0) throw std::runtime_error("failed to create tar.xz fixture");
         return out;
@@ -3086,6 +3102,9 @@ TEST(Extract, RejectsPathTraversal) {
     auto archive = fx.tmp / "ptraversal.tar.gz";
     std::string cmd = std::format("cd {} && tar czf {} -C {} .",
         fx.tmp.string(), archive.string(), stage.string());
+#if !defined(_WIN32)
+    cmd = "env -u LD_LIBRARY_PATH sh -c " + std::string("'") + cmd + "'";
+#endif
     ASSERT_EQ(std::system(cmd.c_str()), 0);
 
     auto out = fx.tmp / "out_ptrav";

--- a/tools/macos_release.sh
+++ b/tools/macos_release.sh
@@ -61,6 +61,25 @@ else
     info "OK: binary has no LLVM runtime dependency"
 fi
 
+# macOS min-version support (0.4.50+): when MACOSX_DEPLOYMENT_TARGET is
+# set (release CI pins 11.0), assert the binary actually carries that
+# floor and is statically linked against LLVM libc++ (no system libc++
+# dylib dependency — older macOS lacks LLVM-20-era C++23 symbols).
+# See .agents/docs/2026-06-05-macos-min-version-support.md.
+if [[ -n "${MACOSX_DEPLOYMENT_TARGET:-}" ]]; then
+    info "Verifying LC_BUILD_VERSION minos ${MACOSX_DEPLOYMENT_TARGET} ..."
+    if ! otool -l "$BIN_SRC" | grep -A4 LC_BUILD_VERSION | grep -q "minos ${MACOSX_DEPLOYMENT_TARGET}"; then
+        otool -l "$BIN_SRC" | grep -A4 LC_BUILD_VERSION
+        fail "binary minos does not match MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}"
+    fi
+    info "Verifying no system libc++ dylib dependency ..."
+    if otool -L "$BIN_SRC" | grep -q "libc++"; then
+        otool -L "$BIN_SRC"
+        fail "binary still links the system libc++ dylib (static libc++ expected)"
+    fi
+    info "OK: minos ${MACOSX_DEPLOYMENT_TARGET}, static libc++"
+fi
+
 # ── 2. Assemble package ─────────────────────────────────────────
 info "Assembling $OUT_DIR ..."
 rm -rf "$OUT_DIR"


### PR DESCRIPTION
## What

macosx-arm64 xlings releases carried `minos=15.0` + dynamic system libc++ — macOS 14 users couldn't even bootstrap (and mcpp, which copies the xlings binary, inherited the wall). With mcpp 0.0.50 as the build tool:

- `mcpp.toml`: `[build] macos_deployment_target = "14.0"` — the project-level floor declaration; mcpp 0.0.50 honors it natively (declared-floor-implies-static: links LLVM's libc++/libc++abi via `-Wl,-load_hidden`, deps shrink to libSystem)
- release workflow (macos job): `MACOSX_DEPLOYMENT_TARGET=14.0` env as the second line of assurance; `macos_release.sh` asserts `minos` + no-system-libc++ when set
- ci-macos: minos assertion + hard static-libc++ assertion (mcpp 0.0.50 is the index latest)
- bootstrap pins: `BOOTSTRAP_XLINGS_VERSION` → v0.4.49, `XIM_PKGINDEX_REF` → index containing mcpp 0.0.50
- version 0.4.50

## Verification chain

mcpp PR #115 (runs A–B5, macos-14 e2e), #116 (product changes + assertions), #117 (split-brain libc++ forensics → `-Wl,-load_hidden` fix, shipped in mcpp 0.0.50), #118 (custom libc++ floor-11 feasibility, deferred). mcpp v0.0.50 macosx asset verified: `minos=14.0`, only `libSystem` in `LC_LOAD_DYLIB`.

Design doc: `.agents/docs/2026-06-05-macos-min-version-support.md`